### PR TITLE
Pass RNG state to kernel launch params

### DIFF
--- a/csrc/capi/flash_attn.cu
+++ b/csrc/capi/flash_attn.cu
@@ -242,7 +242,7 @@ extern "C" {
 bool flash_attn_fwd(const void * const q,
                     const void * const k,
                     const void * const v,
-                    const void * const rng_state,
+                    void * const rng_state,
                     void * const out,
                     void * const softmax_ptr,
                     void * const softmax_lse_ptr,
@@ -296,7 +296,7 @@ bool flash_attn_fwd(const void * const q,
 		     is_causal,
 		     is_bf16);
 
-    params.rng_state = const_cast<uint64_t*>(static_cast<const uint64_t*>(rng_state));
+    params.rng_state = static_cast<uint64_t*>(rng_state);
 
     if (is_dropout) {
         // number of times random will be generated per thread, to offset philox counter in thc random
@@ -317,7 +317,7 @@ bool flash_attn_varlen_fwd(const void * const q,
                            const void * const v,
                            const int32_t * const cu_seqlens_q,
                            const int32_t * const cu_seqlens_k,
-                           const void * const rng_state,
+                           void * const rng_state,
                            void * const out,
                            void * const softmax_ptr,
                            void * const softmax_lse_ptr,
@@ -371,7 +371,7 @@ bool flash_attn_varlen_fwd(const void * const q,
 		     is_causal,
 		     is_bf16);
     
-    params.rng_state = const_cast<uint64_t*>(static_cast<const uint64_t*>(rng_state));
+    params.rng_state = static_cast<uint64_t*>(rng_state);
 
     if (is_dropout) {
         params.philox_args = at::PhiloxCudaState(seed, offset);
@@ -413,7 +413,7 @@ bool flash_attn_bwd(const void * const dout,
                     const void * const out,
                     const void * const softmax_d,
                     const void * const softmax_lse,
-                    const void * const rng_state,
+                    void * const rng_state,
                     void * const dq,
                     void * const dk,
                     void * const dv,
@@ -487,7 +487,7 @@ bool flash_attn_bwd(const void * const dout,
     if (is_dropout) {
         params.philox_args = at::PhiloxCudaState(seed, offset);
         // seems a wild pointer at fa2: https://github.com/PaddlePaddle/flash-attention/blob/main/csrc/flash_attn/flash_api.cpp#L690-L691
-        params.rng_state = const_cast<uint64_t*>(static_cast<const uint64_t*>(rng_state));
+        params.rng_state = static_cast<uint64_t*>(rng_state);
         uint64_t rng_state_data[2] = {seed, offset};
         cudaMemcpyAsync(params.rng_state, rng_state_data, 2*sizeof(uint64_t), cudaMemcpyHostToDevice, stream);
     }
@@ -509,7 +509,7 @@ bool flash_attn_varlen_bwd(const void * const dout,
                            const void * const softmax_lse,
                            const int32_t * const cu_seqlens_q,
                            const int32_t * const cu_seqlens_k,
-                           const void * const rng_state,
+                           void * const rng_state,
                            void * const dq,
                            void * const dk,
                            void * const dv,
@@ -580,7 +580,7 @@ bool flash_attn_varlen_bwd(const void * const dout,
     if (is_dropout) {
         params.philox_args = at::PhiloxCudaState(seed, offset);
         // seems a wild pointer at fa2: https://github.com/PaddlePaddle/flash-attention/blob/main/csrc/flash_attn/flash_api.cpp#L908-L909
-        params.rng_state = const_cast<uint64_t*>(static_cast<const uint64_t*>(rng_state));
+        params.rng_state = static_cast<uint64_t*>(rng_state);
         uint64_t rng_state_data[2] = {seed, offset};
         cudaMemcpyAsync(params.rng_state, rng_state_data, 2*sizeof(uint64_t), cudaMemcpyHostToDevice, stream);
     }

--- a/csrc/capi/flash_attn.cu
+++ b/csrc/capi/flash_attn.cu
@@ -242,6 +242,7 @@ extern "C" {
 bool flash_attn_fwd(const void * const q,
                     const void * const k,
                     const void * const v,
+                    const void * const rng_state,
                     void * const out,
                     void * const softmax_ptr,
                     void * const softmax_lse_ptr,
@@ -295,6 +296,8 @@ bool flash_attn_fwd(const void * const q,
 		     is_causal,
 		     is_bf16);
 
+    params.rng_state = const_cast<uint64_t*>(static_cast<const uint64_t*>(rng_state));
+
     if (is_dropout) {
         // number of times random will be generated per thread, to offset philox counter in thc random
         // state
@@ -312,9 +315,10 @@ bool flash_attn_fwd(const void * const q,
 bool flash_attn_varlen_fwd(const void * const q,
                            const void * const k,
                            const void * const v,
-                           void * const out,
                            const int32_t * const cu_seqlens_q,
                            const int32_t * const cu_seqlens_k,
+                           const void * const rng_state,
+                           void * const out,
                            void * const softmax_ptr,
                            void * const softmax_lse_ptr,
                            const int batch_size,
@@ -367,6 +371,8 @@ bool flash_attn_varlen_fwd(const void * const q,
 		     is_causal,
 		     is_bf16);
     
+    params.rng_state = const_cast<uint64_t*>(static_cast<const uint64_t*>(rng_state));
+
     if (is_dropout) {
         params.philox_args = at::PhiloxCudaState(seed, offset);
     }
@@ -407,6 +413,7 @@ bool flash_attn_bwd(const void * const dout,
                     const void * const out,
                     const void * const softmax_d,
                     const void * const softmax_lse,
+                    const void * const rng_state,
                     void * const dq,
                     void * const dk,
                     void * const dv,
@@ -479,6 +486,10 @@ bool flash_attn_bwd(const void * const dout,
     
     if (is_dropout) {
         params.philox_args = at::PhiloxCudaState(seed, offset);
+        // seems a wild pointer at fa2: https://github.com/PaddlePaddle/flash-attention/blob/main/csrc/flash_attn/flash_api.cpp#L690-L691
+        params.rng_state = const_cast<uint64_t*>(static_cast<const uint64_t*>(rng_state));
+        uint64_t rng_state_data[2] = {seed, offset};
+        cudaMemcpyAsync(params.rng_state, rng_state_data, 2*sizeof(uint64_t), cudaMemcpyHostToDevice, stream);
     }
 
     launch(params, stream, /*configure=*/false);
@@ -496,12 +507,13 @@ bool flash_attn_varlen_bwd(const void * const dout,
                            const void * const out,
                            const void * const softmax_d,
                            const void * const softmax_lse,
+                           const int32_t * const cu_seqlens_q,
+                           const int32_t * const cu_seqlens_k,
+                           const void * const rng_state,
                            void * const dq,
                            void * const dk,
                            void * const dv,
                            void * const dq_accum,
-                           const int32_t * const cu_seqlens_q,
-                           const int32_t * const cu_seqlens_k,
                            const int batch_size,
                            const int max_seqlen_q,
                            const int max_seqlen_k,
@@ -567,6 +579,10 @@ bool flash_attn_varlen_bwd(const void * const dout,
 
     if (is_dropout) {
         params.philox_args = at::PhiloxCudaState(seed, offset);
+        // seems a wild pointer at fa2: https://github.com/PaddlePaddle/flash-attention/blob/main/csrc/flash_attn/flash_api.cpp#L908-L909
+        params.rng_state = const_cast<uint64_t*>(static_cast<const uint64_t*>(rng_state));
+        uint64_t rng_state_data[2] = {seed, offset};
+        cudaMemcpyAsync(params.rng_state, rng_state_data, 2*sizeof(uint64_t), cudaMemcpyHostToDevice, stream);
     }
 
     launch(params, stream, /*configure=*/false);

--- a/csrc/capi/flash_attn.h
+++ b/csrc/capi/flash_attn.h
@@ -11,6 +11,7 @@ extern "C" {
 bool flash_attn_fwd(const void * const q,         // batch_size x seqlen_q x num_heads x head_size
                     const void * const k,         // batch_size x seqlen_k x num_heads_k x head_size
                     const void * const v,         // batch_size x seqlen_k x num_heads_k x head_size
+                    const void * const rng_state,
                     void * const out,
                     void * const softmax_ptr,
                     void * const softmax_lse_ptr,
@@ -35,9 +36,10 @@ bool flash_attn_fwd(const void * const q,         // batch_size x seqlen_q x num
 bool flash_attn_varlen_fwd(const void * const q,  // total_q x num_heads x head_size, total_q := \sum_{i=0}^{b} s_i
                            const void * const k,  // total_k x num_heads_k x head_size, total_k := \sum_{i=0}^{b} s_i
                            const void * const v,  // total_k x num_heads_k x head_size, total_k := \sum_{i=0}^{b} s_i
-                           void * const out, // total_q x num_heads x head_size, total_k := \sum_{i=0}^{b} s_i
                            const int32_t * const cu_seqlens_q,  // b+1
                            const int32_t * const cu_seqlens_k,  // b+1
+                           const void * const rng_state,
+                           void * const out, // total_q x num_heads x head_size, total_k := \sum_{i=0}^{b} s_i
                            void * const softmax_ptr,
                            void * const softmax_lse_ptr,
                            const int batch_size,
@@ -65,6 +67,7 @@ bool flash_attn_bwd(const void * const dout,  // batch_size x seqlen_q x num_hea
                     const void * const out,   // batch_size x seqlen_q x num_heads x head_size
                     const void * const softmax_d,
                     const void * const softmax_lse,     // b x h x seqlen_q
+                    const void * const rng_state,
                     void * const dq,   // batch_size x seqlen_q x num_heads x head_size
                     void * const dk,   // batch_size x seqlen_k x num_heads_k x head_size
                     void * const dv,   // batch_size x seqlen_k x num_heads_k x head_size
@@ -93,12 +96,13 @@ bool flash_attn_varlen_bwd(const void * const dout,  // total_q x num_heads, x h
                            const void * const out,   // total_q x num_heads x head_size
                            const void * const softmax_d,
                            const void * const softmax_lse,     // b x h x s   softmax logsumexp
+                           const int32_t * const cu_seqlens_q,  // b+1
+                           const int32_t * const cu_seqlens_k,  // b+1
+                           const void * const rng_state,
                            void * const dq,   // total_q x num_heads x head_size, total_q := \sum_{i=0}^{b} s_i
                            void * const dk,   // total_k x num_heads_k x head_size, total_k := \sum_{i=0}^{b} s_i
                            void * const dv,   // total_k x num_heads_k x head_size, total_k := \sum_{i=0}^{b} s_i
                            void * const dq_accum,
-                           const int32_t * const cu_seqlens_q,  // b+1
-                           const int32_t * const cu_seqlens_k,  // b+1
                            const int batch_size,
                            const int max_seqlen_q,
                            const int max_seqlen_k,          // max sequence length to choose the kernel

--- a/csrc/capi/flash_attn.h
+++ b/csrc/capi/flash_attn.h
@@ -11,7 +11,7 @@ extern "C" {
 bool flash_attn_fwd(const void * const q,         // batch_size x seqlen_q x num_heads x head_size
                     const void * const k,         // batch_size x seqlen_k x num_heads_k x head_size
                     const void * const v,         // batch_size x seqlen_k x num_heads_k x head_size
-                    const void * const rng_state,
+                    void * const rng_state,
                     void * const out,
                     void * const softmax_ptr,
                     void * const softmax_lse_ptr,
@@ -38,7 +38,7 @@ bool flash_attn_varlen_fwd(const void * const q,  // total_q x num_heads x head_
                            const void * const v,  // total_k x num_heads_k x head_size, total_k := \sum_{i=0}^{b} s_i
                            const int32_t * const cu_seqlens_q,  // b+1
                            const int32_t * const cu_seqlens_k,  // b+1
-                           const void * const rng_state,
+                           void * const rng_state,
                            void * const out, // total_q x num_heads x head_size, total_k := \sum_{i=0}^{b} s_i
                            void * const softmax_ptr,
                            void * const softmax_lse_ptr,
@@ -67,7 +67,7 @@ bool flash_attn_bwd(const void * const dout,  // batch_size x seqlen_q x num_hea
                     const void * const out,   // batch_size x seqlen_q x num_heads x head_size
                     const void * const softmax_d,
                     const void * const softmax_lse,     // b x h x seqlen_q
-                    const void * const rng_state,
+                    void * const rng_state,
                     void * const dq,   // batch_size x seqlen_q x num_heads x head_size
                     void * const dk,   // batch_size x seqlen_k x num_heads_k x head_size
                     void * const dv,   // batch_size x seqlen_k x num_heads_k x head_size
@@ -98,7 +98,7 @@ bool flash_attn_varlen_bwd(const void * const dout,  // total_q x num_heads, x h
                            const void * const softmax_lse,     // b x h x s   softmax logsumexp
                            const int32_t * const cu_seqlens_q,  // b+1
                            const int32_t * const cu_seqlens_k,  // b+1
-                           const void * const rng_state,
+                           void * const rng_state,
                            void * const dq,   // total_q x num_heads x head_size, total_q := \sum_{i=0}^{b} s_i
                            void * const dk,   // total_k x num_heads_k x head_size, total_k := \sum_{i=0}^{b} s_i
                            void * const dv,   // total_k x num_heads_k x head_size, total_k := \sum_{i=0}^{b} s_i


### PR DESCRIPTION
fa v2.0.4在前向kernel内部将```seed```和```offset```写入```rng_state```，反向直接读取前向记录的```seed```和```offset```。在paddle框架中，已经实现了前向记录```seed```, ```offset```及反向复用的功能。capi需做对应修改以兼容kernel变化。修改如下：
1. 前向反向的capi都传入```rng_state```。
2. ```seed```和```offset```的类型是```uint64_t```，paddle框架中缺乏对```uint64_t```的支持，因此在paddle框架中以```int64_t```类型申请同样大小的```rng_state```。在反向capi中使用```cudaMemcpyAsync```对```rng_state```写入前向记录的```seed```和```offset```。