### PR TITLE
flashattn support stride and padded varlen

### DIFF
--- a/csrc/capi/flash_attn.cu
+++ b/csrc/capi/flash_attn.cu
@@ -88,6 +88,124 @@ const char *flash_attn_error() {
           ASSERT_CHECK(is_sm80 || is_sm90);                                                \
       }
 
+void set_params_fprop_strided(Flash_fwd_params &params,
+                      // sizes
+                      const size_t b,
+                      const size_t seqlen_q,
+                      const size_t seqlen_k,
+                      const size_t seqlen_q_rounded,
+                      const size_t seqlen_k_rounded,
+                      const size_t h,
+                      const size_t h_k,
+                      const size_t d,
+                      const size_t d_rounded,
+                      // device pointers
+                      void * const q,
+                      void * const k,
+                      void * const v,
+                      void * const out,
+                      void * const cu_seqlens_q_d,
+                      void * const cu_seqlens_k_d,
+                      void * const p_d,
+                      void * const softmax_lse_d,
+                      float p_dropout,
+                      float softmax_scale,
+                      float softmax_unscale,
+                      bool is_causal,
+                      bool is_bf16,
+                      const int q_row_stride,
+                      const int k_row_stride,
+                      const int v_row_stride,
+                      const int q_head_stride,
+                      const int k_head_stride,
+                      const int v_head_stride,
+                      const int o_row_stride,
+                      const int o_head_stride,
+                      const int q_batch_stride,
+                      const int k_batch_stride,
+                      const int v_batch_stride,
+                      const int o_batch_stride,
+                      bool varlen_padded_input = false,
+                      void * attn_mask = nullptr,
+                      void * attn_mask_start_row_indices = nullptr,
+                      const int attn_mask_start_row = 0,
+                      int mask_head_mod_size = 0,
+                      int mask_seq_q_mod_size = 0) {
+    // Reset the parameters
+    memset(&params, 0, sizeof(params));
+
+    params.is_bf16 = is_bf16;
+    // Set the pointers and strides.
+    params.q_ptr = q;
+    params.k_ptr = k;
+    params.v_ptr = v;
+    // All stride are in elements, not bytes.
+    params.q_row_stride = q_row_stride;
+    params.k_row_stride = k_row_stride;
+    params.v_row_stride = v_row_stride;
+    params.q_head_stride = q_head_stride;
+    params.k_head_stride = k_head_stride;
+    params.v_head_stride = v_head_stride;
+    params.o_ptr = out;
+    params.o_row_stride = o_row_stride;
+    params.o_head_stride = o_head_stride;
+    params.varlen_padded_input = varlen_padded_input;
+
+    if (cu_seqlens_q_d == nullptr ||  params.varlen_padded_input) {
+        params.q_batch_stride = q_batch_stride;
+        params.k_batch_stride = k_batch_stride;
+        params.v_batch_stride = v_batch_stride;
+        params.o_batch_stride = o_batch_stride;
+    }
+
+    params.cu_seqlens_q = static_cast<int *>(cu_seqlens_q_d);
+    params.cu_seqlens_k = static_cast<int *>(cu_seqlens_k_d);
+
+    // P = softmax(QK^T)
+    params.p_ptr = p_d;
+
+    // Softmax sum
+    params.softmax_lse_ptr = softmax_lse_d;
+
+    // Set the dimensions.
+    params.b = b;
+    params.h = h;
+    params.h_k = h_k;
+    params.h_h_k_ratio = h / h_k;
+    params.seqlen_q = seqlen_q;
+    params.seqlen_k = seqlen_k;
+    params.seqlen_q_rounded = seqlen_q_rounded;
+    params.seqlen_k_rounded = seqlen_k_rounded;
+    params.d = d;
+    params.d_rounded = d_rounded;
+
+    // attn mask
+    params.attn_mask_ptr = attn_mask;
+    params.mask_head_mod_size = mask_head_mod_size;
+    params.mask_seq_q_mod_size = mask_seq_q_mod_size;
+
+    // sparse mask row index
+    params.attn_mask_start_row_indices_ptr = attn_mask_start_row_indices;
+    params.attn_mask_start_row = attn_mask_start_row;
+
+    // Set the different scale values.
+    params.scale_softmax = softmax_scale;
+    params.scale_softmax_log2 = softmax_scale * M_LOG2E;
+    params.unscale_softmax = softmax_unscale;
+
+    // Set this to probability of keeping an element to simplify things.
+    params.p_dropout = 1.f - p_dropout;
+    // Convert p from float to int so we don't have to convert the random uint to float to compare.
+    // [Minor] We want to round down since when we do the comparison we use <= instead of <
+    // params.p_dropout_in_uint = uint32_t(std::floor(params.p_dropout * 4294967295.0));
+    // params.p_dropout_in_uint16_t = uint16_t(std::floor(params.p_dropout * 65535.0));
+    params.p_dropout_in_uint8_t = uint8_t(std::floor(params.p_dropout * 255.0));
+    params.rp_dropout = 1.f / params.p_dropout;
+    params.scale_softmax_rp_dropout = params.rp_dropout * params.scale_softmax;
+    ASSERT_CHECK(p_dropout < 1.f);
+
+    params.is_causal = is_causal;
+}
 void set_params_fprop(Flash_fwd_params &params,
                       // sizes
                       const size_t b,
@@ -281,6 +399,122 @@ void set_params_dgrad(Flash_bwd_params &params,
     params.num_splits = num_splits;
 }
 
+void set_params_dgrad_strided(Flash_bwd_params &params,
+                      // sizes
+                      const size_t b,
+                      const size_t seqlen_q,
+                      const size_t seqlen_k,
+                      const size_t seqlen_q_rounded,
+                      const size_t seqlen_k_rounded,
+                      const size_t h,
+                      const size_t h_k,
+                      const size_t d,
+                      const size_t d_rounded,
+                      // device pointers
+                      void * const q,
+                      void * const k,
+                      void * const v,
+                      void * const out,
+                      void * const dout,
+                      void * const dq,
+                      void * const dk,
+                      void * const dv,
+                      void * const cu_seqlens_q_d,
+                      void * const cu_seqlens_k_d,
+                      void * const dq_accum_d,
+                      void * const dk_accum_d,
+                      void * const dv_accum_d,
+                      void * const softmax_lse_d,
+                      void * const dsoftmax_sum_d,
+                      float p_dropout,
+                      float softmax_scale,
+                      float softmax_unscale,
+                      bool is_causal,
+                      bool is_bf16,
+                      const int q_row_stride,
+                      const int k_row_stride,
+                      const int v_row_stride,
+                      const int q_head_stride,
+                      const int k_head_stride,
+                      const int v_head_stride,
+                      const int o_row_stride,
+                      const int o_head_stride,
+                      const int q_batch_stride,
+                      const int k_batch_stride,
+                      const int v_batch_stride,
+                      const int o_batch_stride,
+                      const int dq_row_stride,
+                      const int dk_row_stride,
+                      const int dv_row_stride,
+                      const int dq_head_stride,
+                      const int dk_head_stride,
+                      const int dv_head_stride,
+                      const int do_row_stride,
+                      const int do_head_stride,
+                      const int dq_batch_stride,
+                      const int dk_batch_stride,
+                      const int dv_batch_stride,
+                      const int do_batch_stride,
+                      const bool varlen_padded_input = false,
+                      const int num_splits = 0,
+                      void * attn_mask = nullptr,
+                      void * attn_mask_start_row_indices = nullptr,
+                      const int attn_mask_start_row = 0,
+                      int mask_head_mod_size = 0,
+                      int mask_seq_q_mod_size = 0) {
+
+    set_params_fprop_strided(params,
+                     b, seqlen_q, seqlen_k, seqlen_q_rounded, seqlen_k_rounded, h, h_k, d, d_rounded,
+                     q, k, v, out,
+                     cu_seqlens_q_d,
+                     cu_seqlens_k_d,
+                     nullptr,
+                     softmax_lse_d,
+                     p_dropout,
+                     softmax_scale,
+                     softmax_unscale,
+                     is_causal,
+                     is_bf16,
+                     q_row_stride,k_row_stride,v_row_stride,
+                     q_head_stride,k_head_stride,v_head_stride,
+                     o_row_stride,o_head_stride,
+                     q_batch_stride,k_batch_stride,v_batch_stride,o_batch_stride,
+                     varlen_padded_input,
+                     attn_mask,
+                     attn_mask_start_row_indices,
+                     attn_mask_start_row,
+                     mask_head_mod_size,
+                     mask_seq_q_mod_size);
+
+    // Set the pointers and strides.
+    params.do_ptr = dout;
+    params.do_row_stride = do_row_stride;
+    params.do_head_stride = do_head_stride;
+    params.dq_ptr = dq;
+    params.dk_ptr = dk;
+    params.dv_ptr = dv;
+    params.dq_row_stride = dq_row_stride;
+    params.dk_row_stride = dk_row_stride;
+    params.dv_row_stride = dv_row_stride;
+    params.dq_head_stride = dq_head_stride;
+    params.dk_head_stride = dk_head_stride;
+    params.dv_head_stride = dv_head_stride;
+
+    if (cu_seqlens_q_d == nullptr || varlen_padded_input) {
+        params.do_batch_stride = do_batch_stride;
+        params.dq_batch_stride = dq_batch_stride;
+        params.dk_batch_stride = dk_batch_stride;
+        params.dv_batch_stride = dv_batch_stride;
+    }
+    params.dq_accum_ptr = dq_accum_d;
+    params.dk_accum_ptr = dk_accum_d;
+    params.dv_accum_ptr = dv_accum_d;
+
+    // Softmax sum
+    params.dsoftmax_sum = dsoftmax_sum_d;
+    params.num_splits = num_splits;
+}
+
 void run_mha_fwd(Flash_fwd_params &params, cudaStream_t stream) {
     FP16_SWITCH(!params.is_bf16, [&] {
         FWD_HEADDIM_SWITCH(params.d, [&] {
@@ -322,7 +556,19 @@ bool flash_attn_fwd(const void * const q,
                     const int64_t * const mask_dims,
                     const void * const attn_mask_start_row_indices,
                     const int64_t * const attn_mask_start_row_indices_dims,
-                    const int attn_mask_start_row) {
+                    const int attn_mask_start_row,
+                    const int q_row_stride,
+                    const int k_row_stride,
+                    const int v_row_stride,
+                    const int q_head_stride,
+                    const int k_head_stride,
+                    const int v_head_stride,
+                    const int o_row_stride,
+                    const int o_head_stride,
+                    const int q_batch_stride,
+                    const int k_batch_stride,
+                    const int v_batch_stride,
+                    const int o_batch_stride) {
     FLASHATTNLIB_BEGIN_FUNC
     const bool is_dropout = p_dropout > 0.0;
     const int mask_head_mod_size = attn_mask ? mask_dims[1] : attn_mask_start_row_indices ? attn_mask_start_row_indices_dims[1] : 0;
@@ -331,7 +577,7 @@ bool flash_attn_fwd(const void * const q,
     CHECK_FWD_EXECTUABLE(seqlen_q, seqlen_k)
 
     Flash_fwd_params params;
-    set_params_fprop(params,
+    set_params_fprop_strided(params,
                      batch_size,
                      seqlen_q, seqlen_k,
                      seqlen_q_rounded, seqlen_k_rounded,
@@ -350,6 +596,19 @@ bool flash_attn_fwd(const void * const q,
                      softmax_unscale,
                      is_causal,
                      is_bf16,
+                     q_row_stride,
+                     k_row_stride,
+                     v_row_stride,
+                     q_head_stride,
+                     k_head_stride,
+                     v_head_stride,
+                     o_row_stride,
+                     o_head_stride,
+                     q_batch_stride,
+                     k_batch_stride,
+                     v_batch_stride,
+                     o_batch_stride,
+                     false/*varlen_padded_input=*/,
                      const_cast<void *>(attn_mask),
                      const_cast<void *>(attn_mask_start_row_indices),
                      attn_mask_start_row,
@@ -400,16 +659,28 @@ bool flash_attn_varlen_fwd(const void * const q,
                            uint64_t seed,
                            uint64_t offset,
                            const void * const attn_mask,
-                           const int64_t * const mask_dims) {
+                           const int64_t * const mask_dims,
+                           const int q_row_stride,
+                           const int k_row_stride,
+                           const int v_row_stride,
+                           const int q_head_stride,
+                           const int k_head_stride,
+                           const int v_head_stride,
+                           const int o_row_stride,
+                           const int o_head_stride,
+                           const int q_batch_stride,
+                           const int k_batch_stride,
+                           const int v_batch_stride,
+                           const int o_batch_stride,
+                           bool varlen_padded_input) {
     FLASHATTNLIB_BEGIN_FUNC
     const bool is_dropout = p_dropout > 0.0;
     const int mask_head_mod_size = attn_mask ? mask_dims[1] : 0;
     const int mask_seq_q_mod_size = attn_mask ? mask_dims[2] : 0;
 
     CHECK_FWD_EXECTUABLE(max_seqlen_q, max_seqlen_k)
-    
     Flash_fwd_params params;
-    set_params_fprop(params,
+    set_params_fprop_strided(params,
                      batch_size,
                      max_seqlen_q, max_seqlen_k,
                      seqlen_q_rounded, seqlen_k_rounded,
@@ -428,11 +699,25 @@ bool flash_attn_varlen_fwd(const void * const q,
                      softmax_unscale,
                      is_causal,
                      is_bf16,
+                     q_row_stride,
+                     k_row_stride,
+                     v_row_stride,
+                     q_head_stride,
+                     k_head_stride,
+                     v_head_stride,
+                     o_row_stride,
+                     o_head_stride,
+                     q_batch_stride,
+                     k_batch_stride,
+                     v_batch_stride,
+                     o_batch_stride,
+                     varlen_padded_input,
                      const_cast<void *>(attn_mask),
                      nullptr,
                      -1,
                      mask_head_mod_size,
-                     mask_seq_q_mod_size);
+                     mask_seq_q_mod_size
+                    );
     
     params.rng_state = static_cast<uint64_t*>(rng_state);
 
@@ -503,7 +788,31 @@ bool flash_attn_bwd(const void * const dout,
                     const int64_t * const mask_dims,
                     const void * const attn_mask_start_row_indices,
                     const int64_t * const attn_mask_start_row_indices_dims,
-                    const int attn_mask_start_row) {
+                    const int attn_mask_start_row,
+                    const int q_row_stride,
+                    const int k_row_stride,
+                    const int v_row_stride,
+                    const int q_head_stride,
+                    const int k_head_stride,
+                    const int v_head_stride,
+                    const int o_row_stride,
+                    const int o_head_stride,
+                    const int q_batch_stride,
+                    const int k_batch_stride,
+                    const int v_batch_stride,
+                    const int o_batch_stride,
+                    const int dq_row_stride,
+                    const int dk_row_stride,
+                    const int dv_row_stride,
+                    const int dq_head_stride,
+                    const int dk_head_stride,
+                    const int dv_head_stride,
+                    const int do_row_stride,
+                    const int do_head_stride,
+                    const int dq_batch_stride,
+                    const int dk_batch_stride,
+                    const int dv_batch_stride,
+                    const int do_batch_stride) {
     FLASHATTNLIB_BEGIN_FUNC
     const bool is_dropout = p_dropout > 0.0;
     const int mask_head_mod_size = attn_mask ? mask_dims[1] : attn_mask_start_row_indices ? attn_mask_start_row_indices_dims[1] : 0;
@@ -517,7 +826,7 @@ bool flash_attn_bwd(const void * const dout,
 
     Flash_bwd_params params;
 
-    set_params_dgrad(params,
+    set_params_dgrad_strided(params,
                      batch_size,
                      seqlen_q, seqlen_k,
                      seqlen_q_rounded, seqlen_k_rounded,
@@ -543,6 +852,31 @@ bool flash_attn_bwd(const void * const dout,
                      softmax_unscale,
                      is_causal,
                      is_bf16,
+                     q_row_stride,
+                     k_row_stride,
+                     v_row_stride,
+                     q_head_stride,
+                     k_head_stride,
+                     v_head_stride,
+                     o_row_stride,
+                     o_head_stride,
+                     q_batch_stride,
+                     k_batch_stride,
+                     v_batch_stride,
+                     o_batch_stride,
+                     dq_row_stride,
+                     dk_row_stride,
+                     dv_row_stride,
+                     dq_head_stride,
+                     dk_head_stride,
+                     dv_head_stride,
+                     do_row_stride,
+                     do_head_stride,
+                     dq_batch_stride,
+                     dk_batch_stride,
+                     dv_batch_stride,
+                     do_batch_stride,
+                     false/*varlen_padded_input=*/,
                      num_splits,
                      const_cast<void *>(attn_mask),
                      const_cast<void *>(attn_mask_start_row_indices),
@@ -601,7 +935,32 @@ bool flash_attn_varlen_bwd(const void * const dout,
                            uint64_t seed,
                            uint64_t offset,
                            const void * const attn_mask,
-                           const int64_t * const mask_dims) {
+                           const int64_t * const mask_dims,
+                           const int q_row_stride,
+                           const int k_row_stride,
+                           const int v_row_stride,
+                           const int q_head_stride,
+                           const int k_head_stride,
+                           const int v_head_stride,
+                           const int o_row_stride,
+                           const int o_head_stride,
+                           const int q_batch_stride,
+                           const int k_batch_stride,
+                           const int v_batch_stride,
+                           const int o_batch_stride,
+                           const int dq_row_stride,
+                           const int dk_row_stride,
+                           const int dv_row_stride,
+                           const int dq_head_stride,
+                           const int dk_head_stride,
+                           const int dv_head_stride,
+                           const int do_row_stride,
+                           const int do_head_stride,
+                           const int dq_batch_stride,
+                           const int dk_batch_stride,
+                           const int dv_batch_stride,
+                           const int do_batch_stride,
+                           const bool varlen_padded_input) {
     FLASHATTNLIB_BEGIN_FUNC
     const bool is_dropout = p_dropout > 0.0;
     const int mask_head_mod_size = attn_mask ? mask_dims[1] : 0;
@@ -613,7 +972,7 @@ bool flash_attn_varlen_bwd(const void * const dout,
 
     Flash_bwd_params params;
 
-    set_params_dgrad(params,
+    set_params_dgrad_strided(params,
                      batch_size,
                      max_seqlen_q, max_seqlen_k,
                      seqlen_q_rounded, seqlen_k_rounded,
@@ -639,6 +998,31 @@ bool flash_attn_varlen_bwd(const void * const dout,
                      softmax_unscale,
                      is_causal,
                      is_bf16,
+                     q_row_stride,
+                     k_row_stride,
+                     v_row_stride,
+                     q_head_stride,
+                     k_head_stride,
+                     v_head_stride,
+                     o_row_stride,
+                     o_head_stride,
+                     q_batch_stride,
+                     k_batch_stride,
+                     v_batch_stride,
+                     o_batch_stride,
+                     dq_row_stride,
+                     dk_row_stride,
+                     dv_row_stride,
+                     dq_head_stride,
+                     dk_head_stride,
+                     dv_head_stride,
+                     do_row_stride,
+                     do_head_stride,
+                     dq_batch_stride,
+                     dk_batch_stride,
+                     dv_batch_stride,
+                     do_batch_stride,
+                     varlen_padded_input,
                      num_splits,
                      const_cast<void *>(attn_mask),
                      nullptr,

--- a/csrc/capi/flash_attn.h
+++ b/csrc/capi/flash_attn.h
@@ -37,7 +37,19 @@ bool flash_attn_fwd(const void * const q,         // batch_size x seqlen_q x num
                     const int64_t * const mask_dims,
                     const void * const attn_mask_start_row_indices,
                     const int64_t * const attn_mask_start_row_indices_dims,
-                    const int attn_mask_start_row);
+                    const int attn_mask_start_row,
+                    const int q_row_stride,
+                    const int k_row_stride,
+                    const int v_row_stride,
+                    const int q_head_stride,
+                    const int k_head_stride,
+                    const int v_head_stride,
+                    const int o_row_stride,
+                    const int o_head_stride,
+                    const int q_batch_stride,
+                    const int k_batch_stride,
+                    const int v_batch_stride,
+                    const int o_batch_stride);
 
 bool flash_attn_varlen_fwd(const void * const q,  // total_q x num_heads x head_size, total_q := \sum_{i=0}^{b} s_i
                            const void * const k,  // total_k x num_heads_k x head_size, total_k := \sum_{i=0}^{b} s_i
@@ -67,7 +79,20 @@ bool flash_attn_varlen_fwd(const void * const q,  // total_q x num_heads x head_
                            uint64_t seed,
                            uint64_t offset,
                            const void * const attn_mask,
-                           const void * const mask_dims);
+                           const void * const mask_dims,
+                           const int q_row_stride,
+                           const int k_row_stride,
+                           const int v_row_stride,
+                           const int q_head_stride,
+                           const int k_head_stride,
+                           const int v_head_stride,
+                           const int o_row_stride,
+                           const int o_head_stride,
+                           const int q_batch_stride,
+                           const int k_batch_stride,
+                           const int v_batch_stride,
+                           const int o_batch_stride,
+                           bool varlen_padded_input);
 
 bool flash_attn_bwd(const void * const dout,  // batch_size x seqlen_q x num_heads, x head_size_og
                     const void * const q,   // batch_size x seqlen_q x num_heads x head_size
@@ -103,7 +128,31 @@ bool flash_attn_bwd(const void * const dout,  // batch_size x seqlen_q x num_hea
                     const int64_t * const mask_dims,
                     const void * const attn_mask_start_row_indices,
                     const int64_t * const attn_mask_start_row_indices_dims,
-                    const int attn_mask_start_row);
+                    const int attn_mask_start_row,
+                    const int q_row_stride,
+                    const int k_row_stride,
+                    const int v_row_stride,
+                    const int q_head_stride,
+                    const int k_head_stride,
+                    const int v_head_stride,
+                    const int o_row_stride,
+                    const int o_head_stride,
+                    const int q_batch_stride,
+                    const int k_batch_stride,
+                    const int v_batch_stride,
+                    const int o_batch_stride,
+                    const int dq_row_stride,
+                    const int dk_row_stride,
+                    const int dv_row_stride,
+                    const int dq_head_stride,
+                    const int dk_head_stride,
+                    const int dv_head_stride,
+                    const int do_row_stride,
+                    const int do_head_stride,
+                    const int dq_batch_stride,
+                    const int dk_batch_stride,
+                    const int dv_batch_stride,
+                    const int do_batch_stride);
 
 bool flash_attn_varlen_bwd(const void * const dout,  // total_q x num_heads, x head_size
                            const void * const q,   // total_q x num_heads x head_size, total_q := \sum_{i=0}^{b} s_i
@@ -138,7 +187,32 @@ bool flash_attn_varlen_bwd(const void * const dout,  // total_q x num_heads, x h
                            uint64_t seed,
                            uint64_t offset,
                            const void * attn_mask,
-                           const int64_t * const mask_dims);
+                           const int64_t * const mask_dims,
+                           const int q_row_stride,
+                           const int k_row_stride,
+                           const int v_row_stride,
+                           const int q_head_stride,
+                           const int k_head_stride,
+                           const int v_head_stride,
+                           const int o_row_stride,
+                           const int o_head_stride,
+                           const int q_batch_stride,
+                           const int k_batch_stride,
+                           const int v_batch_stride,
+                           const int o_batch_stride,
+                           const int dq_row_stride,
+                           const int dk_row_stride,
+                           const int dv_row_stride,
+                           const int dq_head_stride,
+                           const int dk_head_stride,
+                           const int dv_head_stride,
+                           const int do_row_stride,
+                           const int do_head_stride,
+                           const int dq_batch_stride,
+                           const int dk_batch_stride,
+                           const int dv_batch_stride,
+                           const int do_batch_stride,
+                           const bool varlen_padded_input);
 
 bool flash_attn_fwd_with_bias_and_mask(const void *q,              // total_q x num_heads x head_size, total_q := \sum_{i=0}^{b} s_i
                                        const void *k,              // total_k x num_heads x head_size, total_k := \sum_{i=0}^{b} s_i

--- a/csrc/flash_attn/src/block_info.h
+++ b/csrc/flash_attn/src/block_info.h
@@ -13,10 +13,10 @@ struct BlockInfo {
 
     template<typename Params>
     __device__ BlockInfo(const Params &params, const int bidb)
-        : sum_s_q(!Varlen || params.cu_seqlens_q == nullptr ? -1 : params.cu_seqlens_q[bidb])
-        , sum_s_k(!Varlen || params.cu_seqlens_k == nullptr ? -1 : params.cu_seqlens_k[bidb])
-        , actual_seqlen_q(!Varlen || params.cu_seqlens_q == nullptr ? params.seqlen_q : params.cu_seqlens_q[bidb + 1] - sum_s_q)
-        , actual_seqlen_k(!Varlen || params.cu_seqlens_k == nullptr ? params.seqlen_k : params.cu_seqlens_k[bidb + 1] - sum_s_k)
+        : sum_s_q(!Varlen || params.varlen_padded_input || params.cu_seqlens_q == nullptr ? -1 : params.cu_seqlens_q[bidb])
+        , sum_s_k(!Varlen || params.varlen_padded_input || params.cu_seqlens_k == nullptr ? -1 : params.cu_seqlens_k[bidb])
+        , actual_seqlen_q(!Varlen || params.cu_seqlens_q == nullptr ? params.seqlen_q : params.cu_seqlens_q[bidb + 1] - params.cu_seqlens_q[bidb])
+        , actual_seqlen_k(!Varlen || params.cu_seqlens_k == nullptr ? params.seqlen_k : params.cu_seqlens_k[bidb + 1] - params.cu_seqlens_k[bidb])
         {
         }
 

--- a/csrc/flash_attn/src/flash.h
+++ b/csrc/flash_attn/src/flash.h
@@ -107,6 +107,8 @@ struct Flash_fwd_params : public Qkv_params {
     void * __restrict__ attn_mask_ptr;
     int mask_head_mod_size;
     int mask_seq_q_mod_size;
+
+    bool varlen_padded_input = false;
     void * __restrict__ attn_mask_start_row_indices_ptr;
     int attn_mask_start_row;
 };


### PR DESCRIPTION
q/k/v/o/dq/dk/dv的batch/row/head stride属性将作为参数传入并被正确设置
当varlen_padded_input被设置时，kernel将认为输入输出是padded，但是会根据cu_seq_len跳过padding部分的计算