### PR TITLE
[NVIDIA] bugfix, add missing header, cstdio

### DIFF
--- a/csrc/flash_attn/src/cuda_utils.h
+++ b/csrc/flash_attn/src/cuda_utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdio>
 #include "cuda.h"
 #include "cuda_runtime.h"
 


### PR DESCRIPTION
The macro C10_CUDA_CHECK calls fprintf, so it should includes cstdio but it doesn't.