### PR TITLE
Support hdimQK != hdimV backward

### DIFF
--- a/csrc/flash_attn_v3/flash_api.cu
+++ b/csrc/flash_attn_v3/flash_api.cu
@@ -236,38 +236,38 @@ void run_mha_bwd(Flash_bwd_params &params, cudaStream_t stream) {
             if (!params.is_bf16) {
                 #ifndef FLASHATTENTION_DISABLE_FP16
                 #ifndef FLASHATTENTION_DISABLE_HDIM64
-                if (params.d <= 64) { return run_mha_bwd_<Arch, cutlass::half_t, 64, Has_softcap>(params, stream); }
+                if (params.d_rounded <= 64) { return run_mha_bwd_<Arch, cutlass::half_t, 64, Has_softcap>(params, stream); }
                 #endif
                 #ifndef FLASHATTENTION_DISABLE_HDIM96
-                if (params.d <= 96) { return run_mha_bwd_<Arch, cutlass::half_t, 96, Has_softcap>(params, stream); }
+                if (params.d_rounded <= 96) { return run_mha_bwd_<Arch, cutlass::half_t, 96, Has_softcap>(params, stream); }
                 #endif
                 #ifndef FLASHATTENTION_DISABLE_HDIM128
-                if (params.d <= 128) { return run_mha_bwd_<Arch, cutlass::half_t, 128, Has_softcap>(params, stream); }
+                if (params.d_rounded <= 128) { return run_mha_bwd_<Arch, cutlass::half_t, 128, Has_softcap>(params, stream); }
                 #endif
                 #ifndef FLASHATTENTION_DISABLE_HDIM192
-                if (params.d <= 192) { return run_mha_bwd_<Arch, cutlass::half_t, 192, Has_softcap>(params, stream); }
+                if (params.d_rounded <= 192) { return run_mha_bwd_<Arch, cutlass::half_t, 192, Has_softcap>(params, stream); }
                 #endif
                 #ifndef FLASHATTENTION_DISABLE_HDIM256
-                if (params.d <= 256) { return run_mha_bwd_<Arch, cutlass::half_t, 256, Has_softcap>(params, stream); }
+                if (params.d_rounded <= 256) { return run_mha_bwd_<Arch, cutlass::half_t, 256, Has_softcap>(params, stream); }
                 #endif
                 #else
                 PADDLE_CHECK(false, "This flash attention build does not support FP16.");
                 #endif
             } else {
                 #ifndef FLASHATTENTION_DISABLE_HDIM64
-                if (params.d <= 64) { return run_mha_bwd_<Arch, cutlass::bfloat16_t, 64, Has_softcap>(params, stream); }
+                if (params.d_rounded <= 64) { return run_mha_bwd_<Arch, cutlass::bfloat16_t, 64, Has_softcap>(params, stream); }
                 #endif
                 #ifndef FLASHATTENTION_DISABLE_HDIM96
-                if (params.d <= 96) { return run_mha_bwd_<Arch, cutlass::bfloat16_t, 96, Has_softcap>(params, stream); }
+                if (params.d_rounded <= 96) { return run_mha_bwd_<Arch, cutlass::bfloat16_t, 96, Has_softcap>(params, stream); }
                 #endif
                 #ifndef FLASHATTENTION_DISABLE_HDIM128
-                if (params.d <= 128) { return run_mha_bwd_<Arch, cutlass::bfloat16_t, 128, Has_softcap>(params, stream); }
+                if (params.d_rounded <= 128) { return run_mha_bwd_<Arch, cutlass::bfloat16_t, 128, Has_softcap>(params, stream); }
                 #endif
                 #ifndef FLASHATTENTION_DISABLE_HDIM192
-                if (params.d <= 192) { return run_mha_bwd_<Arch, cutlass::bfloat16_t, 192, Has_softcap>(params, stream); }
+                if (params.d_rounded <= 192) { return run_mha_bwd_<Arch, cutlass::bfloat16_t, 192, Has_softcap>(params, stream); }
                 #endif
                 #ifndef FLASHATTENTION_DISABLE_HDIM256
-                if (params.d <= 256) { return run_mha_bwd_<Arch, cutlass::bfloat16_t, 256, Has_softcap>(params, stream); }
+                if (params.d_rounded <= 256) { return run_mha_bwd_<Arch, cutlass::bfloat16_t, 256, Has_softcap>(params, stream); }
                 #endif
             }
         });

--- a/csrc/flash_attn_v3/flash_bwd_launch_template.h
+++ b/csrc/flash_attn_v3/flash_bwd_launch_template.h
@@ -49,7 +49,7 @@ void run_flash_bwd(Flash_bwd_params &params, cudaStream_t stream) {
     using PreprocessKernel = flash::FlashAttnBwdPreprocess<TileShape_MK, Element, ElementAccum, ArchTag, /*Clear_dQaccum=*/true, Varlen>;
     typename PreprocessKernel::Arguments preprocess_args {
         static_cast<Element const*>(params.o_ptr),
-        {seqlen_q, params.d, params.h, batch_q},  // shape_O
+        {seqlen_q, params.dv, params.h, batch_q}, // shape_O
         {params.o_row_stride, _1{}, params.o_head_stride, !is_varlen_q ? params.o_batch_stride : 0},  // stride_O
         static_cast<Element const*>(params.do_ptr),
         {params.do_row_stride, _1{}, params.do_head_stride, !is_varlen_q ? params.do_batch_stride : 0},  // stride_dO
@@ -108,8 +108,10 @@ void run_flash_bwd(Flash_bwd_params &params, cudaStream_t stream) {
         {seqlen_k, params.d, params.h_k, batch_k},  // shape_K
         {params.k_row_stride, _1{}, params.k_head_stride, !is_varlen_k ? params.k_batch_stride : 0},  // stride_K
         static_cast<Element const*>(params.v_ptr),
+        {seqlen_k, params.dv, params.h_k, batch_k}, // shape_V
         {params.v_row_stride, _1{}, params.v_head_stride, !is_varlen_k ? params.v_batch_stride : 0},  // stride_V
         static_cast<Element const*>(params.do_ptr),
+        {seqlen_q, params.dv, params.h, batch_q}, // shape_dO
         {params.do_row_stride, _1{}, params.do_head_stride, !is_varlen_q ? params.do_batch_stride : 0},  // stride_dO
         static_cast<ElementAccum*>(params.dq_accum_ptr),
         {seqlen_q_rounded * params.d_rounded, params.h, batch_q},  // shape_dQaccum
@@ -147,9 +149,16 @@ void run_flash_bwd(Flash_bwd_params &params, cudaStream_t stream) {
         static_cast<typename CollectiveEpilogue::Element*>(!GQA ? params.dv_ptr : params.dv_accum_ptr),
         [&] {
             if constexpr (!GQA) {
+                return typename CollectiveEpilogue::ShapedKV {seqlen_k, params.dv, params.h, batch_k};  // shape_dV
+            } else {
+                return typename CollectiveEpilogue::ShapedKV {seqlen_k_rounded * params.dv_rounded, params.h_k, batch_k};  // shape_dVaccum
+            }
+        }(),
+        [&] {
+            if constexpr (!GQA) {
                 return typename CollectiveEpilogue::StridedKV {params.dv_row_stride, _1{}, params.dv_head_stride, !is_varlen_k ? params.dv_batch_stride : 0};  // stride_dV
             } else {
-                return typename CollectiveEpilogue::StridedKV {_1{}, params.d_rounded * seqlen_k_rounded, !is_varlen_k ? params.h_k * params.d_rounded * params.seqlen_k_rounded : 0};  // stride_dVaccum
+                return typename CollectiveEpilogue::StridedKV {_1{}, params.dv_rounded * seqlen_k_rounded, !is_varlen_k ? params.h_k * params.dv_rounded * params.seqlen_k_rounded : 0}; // stride_dVaccum
             }
         }(),
         params.h,
@@ -256,10 +265,10 @@ void run_flash_bwd(Flash_bwd_params &params, cudaStream_t stream) {
         typename PostprocessKerneldKV::Params postprocess_dK_params = PostprocessKerneldKV::to_underlying_arguments(postprocess_dK_args);
         typename PostprocessKerneldKV::Arguments postprocess_dV_args {
             static_cast<ElementAccum const*>(params.dv_accum_ptr),
-            {seqlen_k_rounded * params.d_rounded, params.h_k, batch_k},  // shape_dVaccum
-            {_1{}, seqlen_k_rounded * params.d_rounded, !is_varlen_k ? params.d_rounded * params.seqlen_k_rounded * params.h_k : 0},  // stride_dVaccum
+            {seqlen_k_rounded * params.dv_rounded, params.h_k, batch_k},  // shape_dVaccum
+            {_1{}, seqlen_k_rounded * params.dv_rounded, !is_varlen_k ? params.dv_rounded * params.seqlen_k_rounded * params.h_k : 0},  // stride_dVaccum
             static_cast<Element*>(params.dv_ptr),
-            {seqlen_k, params.d, params.h_k, batch_k},  // shape_dV
+            {seqlen_k, params.dv, params.h_k, batch_k}, // shape_dV
             {params.dv_row_stride, _1{}, params.dv_head_stride, params.dv_batch_stride},  // stride_dV
             1.f,
             params.cu_seqlens_k,

--- a/csrc/flash_attn_v3/mainloop_bwd_sm80.hpp
+++ b/csrc/flash_attn_v3/mainloop_bwd_sm80.hpp
@@ -284,8 +284,10 @@ struct CollectiveMainloopBwdSm80 {
         ShapeQKV const shape_K;
         StrideQKV const stride_K;
         Element const* const ptr_V;
+        ShapeQKV const shape_V;
         StrideQKV const stride_V;
         Element const* const ptr_dO;
+        ShapeQKV const shape_dO;
         StrideQKV const stride_dO;
         ElementAccum* const ptr_dQaccum;
         ShapedQaccum const shape_dQaccum;
@@ -315,8 +317,10 @@ struct CollectiveMainloopBwdSm80 {
         ShapeQKV const shape_K;
         StrideQKV const stride_K;
         Element const* const ptr_V;
+        ShapeQKV const shape_V;
         StrideQKV const stride_V;
         Element const* const ptr_dO;
+        ShapeQKV const shape_dO;
         StrideQKV const stride_dO;
         ElementAccum* const ptr_dQaccum;
         ShapedQaccum const shape_dQaccum;
@@ -352,8 +356,8 @@ struct CollectiveMainloopBwdSm80 {
         // (the original softmax_scale) at the end.
         return {args.ptr_Q, args.shape_Q, args.stride_Q,
                 args.ptr_K, args.shape_K, args.stride_K,
-                args.ptr_V, args.stride_V,
-                args.ptr_dO, args.stride_dO,
+                args.ptr_V, args.shape_V, args.stride_V,
+                args.ptr_dO, args.shape_dO, args.stride_dO,
                 args.ptr_dQaccum, args.shape_dQaccum, args.stride_dQaccum,
                 cutlass::FastDivmod(cute::ceil_div(get<2>(args.shape_Q), get<2>(args.shape_K))),
                 args.ptr_LSE_log2, args.shape_LSE, args.stride_LSE_log2, args.ptr_dPsum, args.stride_dPsum,
@@ -413,9 +417,9 @@ struct CollectiveMainloopBwdSm80 {
         bool const is_varlen_k = Varlen && params.cu_seqlens_k;
         int bidh_kv = params.qhead_per_khead_divmod.divide(bidh);
         Tensor mQ = make_tensor(make_gmem_ptr(params.ptr_Q), params.shape_Q, params.stride_Q)(_, _, bidh, !is_varlen_q ? bidb : 0);
-        Tensor mdO = make_tensor(make_gmem_ptr(params.ptr_dO), params.shape_Q, params.stride_dO)(_, _, bidh, !is_varlen_q ? bidb : 0);
+        Tensor mdO = make_tensor(make_gmem_ptr(params.ptr_dO), params.shape_dO, params.stride_dO)(_, _, bidh, !is_varlen_q ? bidb : 0);
         Tensor mK = make_tensor(make_gmem_ptr(params.ptr_K), params.shape_K, params.stride_K)(_, _, bidh_kv, !is_varlen_k ? bidb : 0);
-        Tensor mV = make_tensor(make_gmem_ptr(params.ptr_V), params.shape_K, params.stride_V)(_, _, bidh_kv, !is_varlen_k ? bidb : 0);
+        Tensor mV = make_tensor(make_gmem_ptr(params.ptr_V), params.shape_V, params.stride_V)(_, _, bidh_kv, !is_varlen_k ? bidb : 0);
         Tensor mLSE = make_tensor(make_gmem_ptr(params.ptr_LSE_log2), params.shape_LSE, params.stride_LSE_log2)(_, bidh, !is_varlen_q ? bidb : 0);
         Tensor mdPsum = make_tensor(make_gmem_ptr(params.ptr_dPsum), params.shape_LSE, params.stride_dPsum)(_, bidh, !is_varlen_q ? bidb : 0);
         Tensor mdQaccum = make_tensor(make_gmem_ptr(reinterpret_cast<ElementAccum*>(params.ptr_dQaccum)),
@@ -527,6 +531,9 @@ struct CollectiveMainloopBwdSm80 {
         for (int k = 0; k < size(tQpQ); ++k) { tQpQ(k) = get<1>(tQcQ(_0{}, _0{}, k)) < get<1>(params.shape_Q); }
         Tensor cLSE = cute::make_identity_tensor(select<0>(TileShape_MNK{}));
         Tensor tLSEcLSE = gmem_thr_copy_lse.partition_S(cLSE);
+        Tensor tdOpdO = make_tensor<bool>(make_shape(size<2>(tdOsdO)));
+        #pragma unroll
+        for (int k = 0; k < size(tdOpdO); ++k) { tdOpdO(k) = get<1>(tQcQ(_0{}, _0{}, k)) < get<1>(params.shape_dO); }
 
         int const seqlen_q = seqlen_info.seqlen_q;
         int const seqlen_k = seqlen_info.seqlen_k;
@@ -545,9 +552,12 @@ struct CollectiveMainloopBwdSm80 {
             Tensor cKV = cute::make_identity_tensor(select<1, 2>(TileShape_MNK{}));
             Tensor tKVcKV = gmem_thr_copy_QKV.partition_S(cKV);
             Tensor t0KVcKV = gmem_thr0_copy_QKV.partition_S(cKV);
-            Tensor tKVpKV = make_tensor<bool>(make_shape(size<2>(tKsK)));
+            Tensor tKpK = make_tensor<bool>(make_shape(size<2>(tKsK)));
+            Tensor tVpV = make_tensor<bool>(make_shape(size<2>(tVsV)));
             #pragma unroll
-            for (int k = 0; k < size(tKVpKV); ++k) { tKVpKV(k) = get<1>(tKVcKV(_0{}, _0{}, k)) < get<1>(params.shape_K); }
+            for (int k = 0; k < size(tKpK); ++k) { tKpK(k) = get<1>(tKVcKV(_0{}, _0{}, k)) < get<1>(params.shape_K); }
+            #pragma unroll
+            for (int k = 0; k < size(tVpV); ++k) { tVpV(k) = get<1>(tKVcKV(_0{}, _0{}, k)) < get<1>(params.shape_V); }
             // Do we need bound check to make sure the row doesn't go above kBlockN
             static constexpr bool EvenN = kBlockN % CUTE_STATIC_V(shape<0>(GmemLayoutAtom{})) == 0;
             // static_assert(EvenN);  // It simplifies the loading of K and V
@@ -567,7 +577,7 @@ struct CollectiveMainloopBwdSm80 {
                     bool const predicate_n = get<0>(t0KVcKV(_0{}, m, _0{})) < seqlenk_row_limit;
                     #pragma unroll
                     for (int k = 0; k < size<2>(tVsV); ++k) {
-                        cute::copy(gmem_tiled_copy_QKV.with(tKVpKV(k) && predicate_n), tVgV(_, m, k), tVsV(_, m, k));
+                        cute::copy(gmem_tiled_copy_QKV.with(tVpV(k) && predicate_n), tVgV(_, m, k), tVsV(_, m, k));
                     }
                 }
             }
@@ -580,7 +590,7 @@ struct CollectiveMainloopBwdSm80 {
                     bool const predicate_n = get<0>(t0KVcKV(_0{}, m, _0{})) < seqlenk_row_limit;
                     #pragma unroll
                     for (int k = 0; k < size<2>(tKsK); ++k) {
-                        cute::copy(gmem_tiled_copy_QKV.with(tKVpKV(k) && predicate_n), tKgK(_, m, k), tKsK(_, m, k));
+                        cute::copy(gmem_tiled_copy_QKV.with(tKpK(k) && predicate_n), tKgK(_, m, k), tKsK(_, m, k));
                     }
                 }
             }
@@ -653,7 +663,7 @@ struct CollectiveMainloopBwdSm80 {
                     bool const predicate_m = get<0>(t0QcQ(_0{}, m, _0{})) < seqlenq_row_limit;
                     #pragma unroll
                     for (int k = 0; k < size<2>(tdOsdO); ++k) {
-                        cute::copy(gmem_tiled_copy_QKV.with(tQpQ(k) && predicate_m), tdOgdO_cur(_, m, k), tdOsdO_cur(_, m, k));
+                        cute::copy(gmem_tiled_copy_QKV.with(tdOpdO(k) && predicate_m), tdOgdO_cur(_, m, k), tdOsdO_cur(_, m, k));
                     }
                 }
             }

--- a/csrc/flash_attn_v3/mainloop_bwd_sm90_tma_gmma_ws.hpp
+++ b/csrc/flash_attn_v3/mainloop_bwd_sm90_tma_gmma_ws.hpp
@@ -298,8 +298,10 @@ struct CollectiveMainloopBwdSm90 {
         ShapeQKV const shape_K;
         StrideQKV const stride_K;
         Element const* const ptr_V;
+        ShapeQKV const shape_V;
         StrideQKV const stride_V;
         Element const* const ptr_dO;
+        ShapeQKV const shape_dO;
         StrideQKV const stride_dO;
         ElementAccum* const ptr_dQaccum;
         ShapedQaccum const shape_dQaccum;
@@ -324,6 +326,8 @@ struct CollectiveMainloopBwdSm90 {
     struct Params {
         ShapeQKV const shape_Q;
         ShapeQKV const shape_K;
+        ShapeQKV const shape_V;
+        ShapeQKV const shape_dO;
         ElementAccum* const ptr_dQaccum;
         ShapedQaccum const shape_dQaccum;
         StridedQaccum stride_dQaccum;
@@ -356,7 +360,7 @@ struct CollectiveMainloopBwdSm90 {
             SmemLayoutQ{}(_, _, _0{}),
             TileShape_MNK{},
             ClusterShape{}); // mcast along N mode for this M load, if any
-        Tensor mdO = make_tensor(make_gmem_ptr(args.ptr_dO), args.shape_Q, args.stride_dO);
+        Tensor mdO = make_tensor(make_gmem_ptr(args.ptr_dO), args.shape_dO, args.stride_dO);
         TMA_QdO tma_load_dO = make_tma_copy_A_sm90(
             GmemTiledCopyQdO{},
             mdO,
@@ -370,7 +374,7 @@ struct CollectiveMainloopBwdSm90 {
             SmemLayoutK{},
             TileShape_MNK{},
             ClusterShape{}); // no mcast for KV
-        Tensor mV = make_tensor(make_gmem_ptr(args.ptr_V), args.shape_K, args.stride_V);
+        Tensor mV = make_tensor(make_gmem_ptr(args.ptr_V), args.shape_V, args.stride_V);
         TMA_V tma_load_V = make_tma_copy_B_sm90(
             GmemTiledCopyKV{},
             mV,
@@ -388,6 +392,7 @@ struct CollectiveMainloopBwdSm90 {
         // Instead we multiply by (1 - tanh^2) and multiply dK and dV by params.softmax_scale
         // (the original softmax_scale) at the end.
         return {args.shape_Q, args.shape_K,
+                args.shape_V, args.shape_dO,
                 args.ptr_dQaccum, args.shape_dQaccum, args.stride_dQaccum,
                 cutlass::FastDivmod(cute::ceil_div(get<2>(args.shape_Q), get<2>(args.shape_K))),
                 tma_load_Q, tma_load_dO, tma_load_K, tma_load_V,
@@ -453,9 +458,9 @@ struct CollectiveMainloopBwdSm90 {
         bool const is_varlen_q = Varlen && params.cu_seqlens_q;
         bool const is_varlen_k = Varlen && params.cu_seqlens_k;
         Tensor mQ = params.tma_load_Q.get_tma_tensor(params.shape_Q)(_, _, bidh, !is_varlen_q ? bidb : 0);
-        Tensor mdO = params.tma_load_dO.get_tma_tensor(params.shape_Q)(_, _, bidh, !is_varlen_q ? bidb : 0);
+        Tensor mdO = params.tma_load_dO.get_tma_tensor(params.shape_dO)(_, _, bidh, !is_varlen_q ? bidb : 0);
         Tensor mK = params.tma_load_K.get_tma_tensor(params.shape_K)(_, _, bidh_kv, !is_varlen_k ? bidb : 0);
-        Tensor mV = params.tma_load_V.get_tma_tensor(params.shape_K)(_, _, bidh_kv, !is_varlen_k ? bidb : 0);
+        Tensor mV = params.tma_load_V.get_tma_tensor(params.shape_V)(_, _, bidh_kv, !is_varlen_k ? bidb : 0);
         Tensor mLSE = make_tensor(make_gmem_ptr(params.ptr_LSE_log2), params.shape_LSE, params.stride_LSE_log2)(_, bidh, !is_varlen_q ? bidb : 0);
         Tensor mdPsum = make_tensor(make_gmem_ptr(params.ptr_dPsum), params.shape_LSE, params.stride_dPsum)(_, bidh, !is_varlen_q ? bidb : 0);
 

--- a/flash_attn/flash_attn_interface.py
+++ b/flash_attn/flash_attn_interface.py
@@ -238,9 +238,9 @@ class FlashAttnFunc(torch.autograd.Function):
             dq, dk, dv, ctx.dropout_p, ctx.softmax_scale, ctx.causal,
             rng_state=rng_state
         )
-        dq = dq[..., :dout.shape[-1]]  # We could have padded the head dimension
-        dk = dk[..., :dout.shape[-1]]
-        dv = dv[..., :dout.shape[-1]]
+        dq = dq[..., :q.shape[-1]]  # We could have padded the head dimension
+        dk = dk[..., :k.shape[-1]]
+        dv = dv[..., :v.shape[-1]]
         return dq, dk, dv, None, None, None, None, None, None, None, None
 
 
@@ -273,9 +273,9 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
             ctx.max_seqlen_q, ctx.max_seqlen_k, ctx.dropout_p, ctx.softmax_scale, ctx.causal,
             rng_state=rng_state
         )
-        dq = dq[..., :dout.shape[-1]]  # We could have padded the head dimension
-        dk = dk[..., :dout.shape[-1]]
-        dv = dv[..., :dout.shape[-1]]
+        dq = dq[..., :q.shape[-1]]  # We could have padded the head dimension
+        dk = dk[..., :k.shape[-1]]
+        dv = dv[..., :v.shape[-1]]
         return dq, dk, dv, None, None, None, None, None, None, None, None
 
 


### PR DESCRIPTION
将torch flashattn库 pr1604进行迁移，来支持  headdim != headdim_v 的情况。

# 精度压测
1. 1600组测试中前向逐位对齐
    1. 前向out是诸位对齐的
    2. softmax_lse 的相对最大误差分别是：0, 0

2. 保证反向paddle相较于torch 误差小于torch2次误差
    1. q.grad 从对齐角度，存在不一致率，但对比两次torch的不一致率，只增加了一两个数量级，可以接受
    2. q.grad 的误差基本和两次torch的误差齐平如图2,3
    3. k.grad, v.grad  都没有误差（相比于torch）
    
<img width="771" alt="image" src="https://github.com/user-attachments/assets/37e4f549-fd62-4ffd-bb3b-a69c72be3df2" />

图1 

<img width="785" alt="image" src="https://github.com/user-attachments/assets/60b52a87-4cd7-4436-9392-594f24efe504" />

图2

<img width="798" alt="image" src="https://github.com/user-attachments/assets/80345031-3bc4-4d4c-9607-86aa4ef01308" />

图3


3. 不同shape组间误差接近
    基本如是，见图2,3


# 性能测试（经典shape）

进行端到端性能测试新版paddle相比于torch基本持平

   <meta charset="UTF-8"><div class="mp-paragraph-wrapper hxj" data-morpho-type="paragraph" style="padding-left:0px;--indent-pixels:0px" data-slate-node="element" data-morpho-padding="0"><span data-morpho-text="%E7%9B%B8%E6%AF%94%E4%BA%8E%E6%97%A7%E7%89%88paddle%20%E7%9C%81%E5%8E%BB%E4%BA%86%E4%B8%80%E6%AC%A1">相比于旧版paddle 省去了一次</span><span data-morpho-text="ConcatTensorWithDifferentShape%20%20%E5%92%8C%20EigenMetaKernel"><span data-raw-font-value="#1C1D1F" style="color:#1C1D1F"><span>ConcatTensorWithDifferentShape  和 EigenMetaKernel</span></span></span><div class="mp-paragraph-block-selection"></div></div><div class="mp-table-align"><div class="mp-table-wrapper"><div data-slate-node="element" style="padding-left:0px" class="mp-table-container">
  | fw(us) | speedup(vs padding version) | bwd(us) | speedup(vs padding version) | 一次前反向的设备时间（us） | speedup (vs padding version)
-- | -- | -- | -- | -- | -- | --
paddle(new) | 958 | 1 x | 5039 | 1.1 x | 5997 | 1.09 x
paddle | 954 | - | 5605 | - | 6559 | -
torch | 958 | - | 4997 | - | 5955 | -

</div><div class="mp-table-serialize-flag"><br/></div></div></div><span data-morpho-doc-data='{"token":"eyJhbGciOiJkaXIiLCJlbmMiOiJBMjU2R0NNIiwiYXBwSWQiOjEsInVpZCI6IjBYbGdTY1hrVmIiLCJkb2NJZCI6IlpvZGJaRHpEVVNKOTY5In0..trcVJWZdid1-EZ-Z.nnhDUTUlTJVbGzZSX1fHqhlWH_5OkxCMR0RXCHTqzl00OtShvDrNa1BCFBII2BkgGCN-UZQ60Yw8LhSYGWHB04aSlNgwC7oLgvBC26qv1zGdfR8zQWcl67nZPcd3pFYwmsxJDUgPVPRRmFktYc3mPaZFGjszZCb9TltRvwlrUWZWckqGUmCzZHCUkYQHBzro9Gz0uqve4tmV4rxE1YiR5zOvUw.EZL6q8dw-R10f_6_tghs1Q","appId":"1"}' class='mp-morpho-clipboard-doc-data'></span>