### PR TITLE
Adapt FlashMask v4 to nvidia-cutlass-dsl 4.4.1

### DIFF
--- a/flashmask/flash_mask/cute/pipeline.py
+++ b/flashmask/flash_mask/cute/pipeline.py
@@ -227,6 +227,7 @@ class PipelineTmaAsync(PipelineTmaAsyncOg):
         state: PipelineState,
         try_acquire_token: Optional[Boolean] = None,
         extra_tx_count: int = 0,
+        **kwargs,
     ):
         """
         TMA producer commit conditionally waits on buffer empty and sets the transaction barrier for leader threadblocks.
@@ -241,7 +242,7 @@ class PipelineTmaAsync(PipelineTmaAsyncOg):
             tx_count = self.sync_object_full.tx_count + extra_tx_count
             self.sync_object_full.arrive_and_expect_tx(state.index, tx_count)
 
-    def consumer_release(self, state: PipelineState):
+    def consumer_release(self, state: PipelineState, **kwargs):
         """
         TMA consumer release conditionally signals the empty buffer to the producer.
         """
@@ -300,10 +301,10 @@ class PipelineTmaUmma(PipelineTmaUmmaOg):
         producer = (producer_type, producer_group)
         consumer = (consumer_type, consumer_group)
 
-        sync_object_full = PipelineAsync._make_sync_object(
+        sync_object_full = PipelineTmaUmmaOg._make_sync_object(
             barrier_storage.align(min_align=8), num_stages, producer, tx_count
         )
-        sync_object_empty = PipelineAsync._make_sync_object(
+        sync_object_empty = PipelineTmaUmmaOg._make_sync_object(
             barrier_storage.align(min_align=8) + num_stages, num_stages, consumer
         )
 
@@ -344,6 +345,7 @@ class PipelineTmaUmma(PipelineTmaUmmaOg):
         state: PipelineState,
         try_acquire_token: Optional[Boolean] = None,
         extra_tx_count: int = 0,
+        **kwargs,
     ):
         """
         TMA producer commit conditionally waits on buffer empty and sets the transaction barrier for leader threadblocks.

--- a/flashmask/setup.py
+++ b/flashmask/setup.py
@@ -97,7 +97,7 @@ install_requires = ['typing_extensions']
 if BUILD_FA4:
     install_requires += [
         'nvidia-cutlass==4.2.0.0',
-        'nvidia-cutlass-dsl==4.3.0',
+        'nvidia-cutlass-dsl==4.4.1',
     ]
 
 # ============================================================


### PR DESCRIPTION
nvidia-cutlass-dsl 从 4.3.0 升级到 4.4.1 


### 修复1
使用 PipelineTmaUmmaOg 替换 PipelineAsync。
+ cutlass-dsl 4.4.1 PipelineAsync._make_sync_object（sm90.py）不再支持 PipelineOp.TCGen05Mma，调用会直接 assert 失败。
+ PipelineTmaUmmaOg._make_sync_object（sm100.py）重写了这个方法，增加了对 TCGen05Mma 的处理。



### 修复2
cutlass-dsl 4.4.1 中，上游的 producer_tail（sm90.py）加了 @dsl_user_op 装饰器，它在调用 self.producer_acquire() 时会自动传入 loc=loc, ip=ip。

FlashMask 重写了 producer_acquire 和 consumer_release，如果不接受这些额外的关键字参数，就会报：
```
DSLRuntimeError: PipelineTmaUmma.producer_acquire() got an unexpected keyword argument 'loc'
```
FlashMask 自身不需要 loc/ip，但必须能接收它们。**kwargs 是最简洁的做法 — 吞掉不需要的参数，不和上游的具体参数名耦合，未来上游再加新参数也不会崩。


### 修复3（TODO，不影响发版）
python setup.py bdist_wheel，现象：
+ 在编译路径运行 pip install ./dist/xxx.whl 后，测试路径找不到包
+ 在编译路径运行 pip install --force-reinstall ./dist/xxx.whl 后，测试路径可以找到包
+ 在测试路径运行 pip install ./dist/xxx.whl 后，可以正常使用

根因分析：
运行 python setup.py bdist_wheel 会生成 flash_mask.egg-info/ 目录。pip 在当前目录检测到此目录后，会错误地认为包已安装，导致后续安装命令被跳过。执行 --force-reinstall 则不会跳过安装。

解决方式：
添加自定义 bdist_wheel 命令类，构建后自动清理 .egg-info


