### PR TITLE
FlashMaskV3 Single-node Speed Optimization

### DIFF
--- a/csrc/flashmask_v2/flash_bwd_launch_template.h
+++ b/csrc/flashmask_v2/flash_bwd_launch_template.h
@@ -421,7 +421,7 @@ void run_mha_bwd_hdim128(Flash_bwd_params &params, cudaStream_t stream) {
                 if constexpr (Is_causal || Is_local || Has_softcap) {
                     run_mha_bwd_dispatch<Arch, T, 64, 128, 128, Is_causal, Is_local, Has_softcap, Is_flashmask_, Has_lt_end, Has_ut_start, Deterministic, Is_blockmask_, 2, 2, true, false, false, 2, 1, 2, 1, false>(params, stream);
                 } else {
-                    if ((params.seqlen_q >= 1024 || params.seqlen_k >= 1024) && !(Has_lt_end && Has_ut_start)) {
+                    if (params.seqlen_q >= 1024 || params.seqlen_k >= 1024) {
                     run_mha_bwd_dispatch<Arch, T, 64, 128, 128, Is_causal, Is_local, Has_softcap, Is_flashmask_, Has_lt_end, Has_ut_start, Deterministic, Is_blockmask_, 2, 2, true, false, true, 2, 1, 2, 1, false>(params, stream);
                     } else {
                     run_mha_bwd_dispatch<Arch, T, 64, 64, 128, Is_causal, Is_local, Has_softcap, Is_flashmask_, Has_lt_end, Has_ut_start, Deterministic, Is_blockmask_, 2, 2, false, true, false, 2, 1, 2, 1, false>(params, stream);

--- a/csrc/flashmask_v2/mainloop_bwd_sm90_tma_gmma_ws.hpp
+++ b/csrc/flashmask_v2/mainloop_bwd_sm90_tma_gmma_ws.hpp
@@ -1123,8 +1123,6 @@ struct CollectiveMainloopBwdSm90 {
         );
         // int32_t flashmask_mem_[8]s;
         // load_n_block_info(n_block, flashmask_mem_, params);
-
-        int m_block = m_block_min;
         // if(thread_idx == 0) printf("m_block:%d",m_block);
         // get_next_m_block(n_block,m_block,partially_masked,m_block_max - 1,params);
 
@@ -1330,76 +1328,75 @@ struct CollectiveMainloopBwdSm90 {
         // this helps quite a bit to not have to do causal masking for most of the iterations.
 
         auto mask_fn = [&](auto& tSrS, int m_block) { mask.template apply<true /*Seqlenk_mask*/, Is_causal, Is_local>(tSrS, m_block, n_block); };
-        int loop_end = m_block_max;
-        if constexpr(!Is_causal){
-            if constexpr (Has_ut_start) {
-                loop_end = std::min(flashmask_mem_[5]/*ut_start_nblockmin*/, m_block_max);
-                CUTLASS_PRAGMA_NO_UNROLL
-                for (; m_block < loop_end; m_block++) {
-                    if constexpr (Is_blockmask){
-                        if(!blockmask_smem_[m_block / params.m_factor]) continue;
-                    }
-                    // if(threadIdx.x == 128) printf("consumer0 m_block,n_block: %d, %d\n", m_block,n_block);
-                    bwd_step(m_block, mask_fn, false, flashmask_index_smem_);
-                }
-                loop_end = flashmask_mem_[4]/*ut_start_nblockmax*/;
-                CUTLASS_PRAGMA_NO_UNROLL
-                for (; m_block <= loop_end; ++m_block) {
-                    if constexpr (Is_blockmask){
-                        if(!blockmask_smem_[m_block / params.m_factor]) continue;
-                    }
-                    // if(threadIdx.x == 128) printf("consumer0 m_block,n_block: %d, %d\n", m_block,n_block);
-                    bwd_step(m_block, mask_fn, true, flashmask_index_smem_);
-                }
-            }
-            m_block = std::max(m_block, flashmask_mem_[7]/*ut_end_nblockmin*/); 
-            loop_end = std::min(flashmask_mem_[6]/*ut_end_nblockmax*/, m_block_max - 1);
-            CUTLASS_PRAGMA_NO_UNROLL
-            for (; m_block <= loop_end; m_block++) {
-                if constexpr (Is_blockmask){
-                    if(!blockmask_smem_[m_block / params.m_factor]) continue;
-                }
-                // if(threadIdx.x == 128) printf("consumer-u-2 m_block,n_block,m_block_max,flashmask_mem_[2]: %d, %d, %d,%d\n", m_block,n_block,m_block_max,flashmask_mem_[6]);
-                bwd_step(m_block, mask_fn, true, flashmask_index_smem_);
-            }
-        } 
-       loop_end = std::min(flashmask_mem_[1]/*lt_start_nblockmin*/, m_block_max);
+
+        // Note(heqianyue): this is a state machine version for compacting multiple for-loops into one
+        // For the original separate loops impl, check `store_dq` and `load`. These two impls
+        // are kept, since they are not in MMA consumer and does not affect MMA registers. State machine 
+        // tries getting rid of multiple loops that might consume more registers than expected, possibly
+        // caused by the inlining of lambda functions (umiswing). For global
+        // swin mask, multiple for-loops related register spilling problem stops us from using bigger
+        // block sizes. Once a bigger block size can be applied with low cost, the speed can be boosted. 
+        // state -----------------> 0 1 (2 3) 4 5 (6 7) 8
+        // state & 0x3 -----------> 0 1 (2 3) 0 1 (2 3) 0
+        // mask triangle ---------> U U ( U ) L L ( L ) L
+        // is partially masked ---> F T ( T ) F T ( T ) F
+        // smem_pos = state ^ 5 --> 5 4 (7 6) 1 0 (3 2) [13 --- not used]
+        // (...) brackets means that the two states are combined into one (stride 2)
+        // Combined states (2,3)/(6,7): smem_index gives nblockmin (skip target),
+        //   smem_index - 1 gives nblockmax (loop_end). NOT +1, since XOR mapping
+        //   puts max at the lower index.
+        // State 0/4: use fm[smem_index] - 1 as loop_end to match original strict < semantics,
+        //   so the boundary block is processed by state 1/5 with partially_masked=true.
+
+        int loop_end = m_block_min - 1; // m_block_min > m_block_min-1 triggers first state transition
+        // starts with actual_state - 1 (since we have `++ state` at the very first step)
         CUTLASS_PRAGMA_NO_UNROLL
-        for (; m_block < loop_end; m_block++) {
-            if constexpr (Is_blockmask){
-                if(!blockmask_smem_[m_block / params.m_factor]) continue;
-            }
-            // if(threadIdx.x == 128) printf("consumer-l-0 m_block,n_block: %d, %d\n", m_block,n_block);
-            bwd_step(m_block, mask_fn, false, flashmask_index_smem_);
-        }
-        //partial_maskloop_end
-        loop_end = std::min(m_block_max - 1, flashmask_mem_[0]/*lt_start_nblockmax*/);
-        CUTLASS_PRAGMA_NO_UNROLL
-        for (; m_block <= loop_end; m_block++) {
-            if constexpr (Is_blockmask){
-                if(!blockmask_smem_[m_block / params.m_factor]) continue;
-            }
-            // if(threadIdx.x == 128) printf("consumer-l-1 m_block,n_block, flashmask_mem_[0]: %d, %d, %d\n", m_block,n_block,flashmask_mem_[0]);
-            bwd_step(m_block, mask_fn, true, flashmask_index_smem_);
-        }
-        if constexpr (Has_lt_end) {
-            m_block = std::max(m_block, flashmask_mem_[3]/*lt_end_nblockmin*/);  
-            //partial_maskloop_end
-            loop_end = std::min(flashmask_mem_[2]/*lt_end_nblockmax*/, m_block_max - 1);
-            CUTLASS_PRAGMA_NO_UNROLL
-            for (; m_block <= loop_end; m_block++) {
-                if constexpr (Is_blockmask){
-                    if(!blockmask_smem_[m_block / params.m_factor]) continue;
+        for (int state = Is_causal ? 3 : (Has_ut_start ? -1 : 1), 
+                 m_block = m_block_min; 
+                 /* loops forever, exit according to state */;
+                 m_block ++
+        ) {
+            // update the state machine
+            // compile time (static dispatch) state skipping
+            // 1. Is_causal, state starts from 4 (lt only)
+            // 2. Has_lt_end == false, state 6, 7 and 8 can be skipped
+            // 3. !Is_causal and:
+            //      Has_ut_start: all the states are kept
+            //      otherwise: state starts from 2
+            // Use `while` + strict `>` instead of `if` + `>=`:
+            //   `>` (not `>=`): when m_block == loop_end, current block still needs processing
+            //     before transitioning. `>=` would transition prematurely, skipping it.
+            //   `while` (not `if`): when a state's region is empty (loop_end < m_block),
+            //     keep advancing state without m_block++. With `if`, the for-loop's m_block++
+            //     fires once per empty state, drifting m_block ahead of load()'s producer → hang.
+            while (m_block > loop_end) {
+                ++ state;
+                if (state >= (Has_lt_end ? 9 : 6)) break;
+                const int smem_index = state ^ 0x5;
+                if (state < 8) {
+                    if ((state & 0x03) == 0x02) {   // state 2, 6: skip to nblockmin, loop_end = nblockmax (smem_index - 1)
+                        m_block = std::max(flashmask_mem_[smem_index], m_block);
+                        loop_end = std::min(flashmask_mem_[smem_index - 1], m_block_max - 1);
+                        ++ state;                   // one more ++, so that state = 3 and 7 are skipped
+                    } else {
+                        // state 1, 5: inclusive <= boundary (do not need to minus 1)
+                        // state 0, 4: strict < boundary (fm[x]-1 to exclude boundary block, minus 1 is needed)
+                        loop_end = std::min(flashmask_mem_[smem_index] - !(state & 0x03), m_block_max - 1);
+                    }
+                } else {                            // Has_lt_end, and state = 8 (loop till m_block_max)
+                    loop_end = m_block_max - 1;
                 }
-                // if(threadIdx.x == 128) printf("consumer2 m_block,n_block,m_block_max,flashmask_mem_[2]: %d, %d, %d,%d\n", m_block,n_block,m_block_max,flashmask_mem_[2]);
-                bwd_step(m_block, mask_fn, true, flashmask_index_smem_);
             }
-            CUTLASS_PRAGMA_NO_UNROLL
-            for (; m_block < m_block_max; m_block++) {
-                if constexpr (Is_blockmask){
-                    if(!blockmask_smem_[m_block / params.m_factor]) continue;
+            if (state >= (Has_lt_end ? 9 : 6)) break;
+            // m_block <= loop_end is guaranteed here (while exits when condition is false),
+            // so no need to check. Saves 1 branch + 1 predicate register per iteration.
+            if constexpr (Is_blockmask) {
+                if (blockmask_smem_[m_block / params.m_factor]) {
+                    bwd_step(m_block, mask_fn, (state & 0x3) > 0, flashmask_index_smem_);
                 }
-                bwd_step(m_block, mask_fn, false, flashmask_index_smem_);
+            } else {
+                // state 0, 4 and 8 is fully masked (false), otherwise partially masked
+                bwd_step(m_block, mask_fn, (state & 0x3) > 0, flashmask_index_smem_);
             }
         }
 

--- a/csrc/flashmask_v2/mainloop_bwd_sm90_tma_gmma_ws.hpp
+++ b/csrc/flashmask_v2/mainloop_bwd_sm90_tma_gmma_ws.hpp
@@ -1329,74 +1329,110 @@ struct CollectiveMainloopBwdSm90 {
 
         auto mask_fn = [&](auto& tSrS, int m_block) { mask.template apply<true /*Seqlenk_mask*/, Is_causal, Is_local>(tSrS, m_block, n_block); };
 
-        // Note(heqianyue): this is a state machine version for compacting multiple for-loops into one
-        // For the original separate loops impl, check `store_dq` and `load`. These two impls
-        // are kept, since they are not in MMA consumer and does not affect MMA registers. State machine 
-        // tries getting rid of multiple loops that might consume more registers than expected, possibly
-        // caused by the inlining of lambda functions (umiswing). For global
-        // swin mask, multiple for-loops related register spilling problem stops us from using bigger
-        // block sizes. Once a bigger block size can be applied with low cost, the speed can be boosted. 
-        // state -----------------> 0 1 (2 3) 4 5 (6 7) 8
-        // state & 0x3 -----------> 0 1 (2 3) 0 1 (2 3) 0
-        // mask triangle ---------> U U ( U ) L L ( L ) L
-        // is partially masked ---> F T ( T ) F T ( T ) F
-        // smem_pos = state ^ 5 --> 5 4 (7 6) 1 0 (3 2) [13 --- not used]
-        // (...) brackets means that the two states are combined into one (stride 2)
-        // Combined states (2,3)/(6,7): smem_index gives nblockmin (skip target),
-        //   smem_index - 1 gives nblockmax (loop_end). NOT +1, since XOR mapping
-        //   puts max at the lower index.
-        // State 0/4: use fm[smem_index] - 1 as loop_end to match original strict < semantics,
-        //   so the boundary block is processed by state 1/5 with partially_masked=true.
-
-        int loop_end = m_block_min - 1; // m_block_min > m_block_min-1 triggers first state transition
-        // starts with actual_state - 1 (since we have `++ state` at the very first step)
-        CUTLASS_PRAGMA_NO_UNROLL
-        for (int state = Is_causal ? 3 : (Has_ut_start ? -1 : 1), 
-                 m_block = m_block_min; 
-                 /* loops forever, exit according to state */;
-                 m_block ++
-        ) {
-            // update the state machine
-            // compile time (static dispatch) state skipping
-            // 1. Is_causal, state starts from 4 (lt only)
-            // 2. Has_lt_end == false, state 6, 7 and 8 can be skipped
-            // 3. !Is_causal and:
-            //      Has_ut_start: all the states are kept
-            //      otherwise: state starts from 2
-            // Use `while` + strict `>` instead of `if` + `>=`:
-            //   `>` (not `>=`): when m_block == loop_end, current block still needs processing
-            //     before transitioning. `>=` would transition prematurely, skipping it.
-            //   `while` (not `if`): when a state's region is empty (loop_end < m_block),
-            //     keep advancing state without m_block++. With `if`, the for-loop's m_block++
-            //     fires once per empty state, drifting m_block ahead of load()'s producer → hang.
-            while (m_block > loop_end) {
-                ++ state;
-                if (state >= (Has_lt_end ? 9 : 6)) break;
-                const int smem_index = state ^ 0x5;
-                if (state < 8) {
-                    if ((state & 0x03) == 0x02) {   // state 2, 6: skip to nblockmin, loop_end = nblockmax (smem_index - 1)
-                        m_block = std::max(flashmask_mem_[smem_index], m_block);
-                        loop_end = std::min(flashmask_mem_[smem_index - 1], m_block_max - 1);
-                        ++ state;                   // one more ++, so that state = 3 and 7 are skipped
+        // State machine reduces bwd_step call sites from 7 to 1, lowering register pressure.
+        // Only beneficial when all 9 states are active (!Is_causal && Has_ut_start && Has_lt_end).
+        // Other cases use the original multi-for-loop (fewer call sites, compiler can optimize each loop).
+        if constexpr (!Is_causal && Has_ut_start && Has_lt_end) {
+            // State machine version: single bwd_step call site for all 9 states.
+            // state -----------------> 0 1 (2 3) 4 5 (6 7) 8
+            // is partially masked ---> F T ( T ) F T ( T ) F
+            // smem_pos = state ^ 5 --> 5 4 (7 6) 1 0 (3 2) N/A
+            // Combined states (2,3)/(6,7): smem_index = nblockmin, smem_index-1 = nblockmax.
+            // State 0/4: fm[x]-1 as loop_end for strict < semantics.
+            int loop_end = m_block_min - 1;
+            CUTLASS_PRAGMA_NO_UNROLL
+            for (int state = -1, m_block = m_block_min; ; m_block++) {
+                while (m_block > loop_end) {
+                    ++ state;
+                    if (state >= 9) break;
+                    const int smem_index = state ^ 0x5;
+                    if (state < 8) {
+                        if ((state & 0x03) == 0x02) {
+                            m_block = std::max(flashmask_mem_[smem_index], m_block);
+                            loop_end = std::min(flashmask_mem_[smem_index - 1], m_block_max - 1);
+                            ++ state;
+                        } else {
+                            loop_end = std::min(flashmask_mem_[smem_index] - !(state & 0x03), m_block_max - 1);
+                        }
                     } else {
-                        // state 1, 5: inclusive <= boundary (do not need to minus 1)
-                        // state 0, 4: strict < boundary (fm[x]-1 to exclude boundary block, minus 1 is needed)
-                        loop_end = std::min(flashmask_mem_[smem_index] - !(state & 0x03), m_block_max - 1);
+                        loop_end = m_block_max - 1;
                     }
-                } else {                            // Has_lt_end, and state = 8 (loop till m_block_max)
-                    loop_end = m_block_max - 1;
                 }
-            }
-            if (state >= (Has_lt_end ? 9 : 6)) break;
-            // m_block <= loop_end is guaranteed here (while exits when condition is false),
-            // so no need to check. Saves 1 branch + 1 predicate register per iteration.
-            if constexpr (Is_blockmask) {
-                if (blockmask_smem_[m_block / params.m_factor]) {
+                if (state >= 9) break;
+                if constexpr (Is_blockmask) {
+                    if (blockmask_smem_[m_block / params.m_factor]) {
+                        bwd_step(m_block, mask_fn, (state & 0x3) > 0, flashmask_index_smem_);
+                    }
+                } else {
                     bwd_step(m_block, mask_fn, (state & 0x3) > 0, flashmask_index_smem_);
                 }
-            } else {
-                // state 0, 4 and 8 is fully masked (false), otherwise partially masked
-                bwd_step(m_block, mask_fn, (state & 0x3) > 0, flashmask_index_smem_);
+            }
+        } else {
+            // Original multi-for-loop version.
+            int m_block = m_block_min;
+            int loop_end = m_block_max;
+            if constexpr(!Is_causal){
+                if constexpr (Has_ut_start) {
+                    loop_end = std::min(flashmask_mem_[5]/*ut_start_nblockmin*/, m_block_max);
+                    CUTLASS_PRAGMA_NO_UNROLL
+                    for (; m_block < loop_end; m_block++) {
+                        if constexpr (Is_blockmask){
+                            if(!blockmask_smem_[m_block / params.m_factor]) continue;
+                        }
+                        bwd_step(m_block, mask_fn, false, flashmask_index_smem_);
+                    }
+                    loop_end = flashmask_mem_[4]/*ut_start_nblockmax*/;
+                    CUTLASS_PRAGMA_NO_UNROLL
+                    for (; m_block <= loop_end; ++m_block) {
+                        if constexpr (Is_blockmask){
+                            if(!blockmask_smem_[m_block / params.m_factor]) continue;
+                        }
+                        bwd_step(m_block, mask_fn, true, flashmask_index_smem_);
+                    }
+                }
+                m_block = std::max(m_block, flashmask_mem_[7]/*ut_end_nblockmin*/);
+                loop_end = std::min(flashmask_mem_[6]/*ut_end_nblockmax*/, m_block_max - 1);
+                CUTLASS_PRAGMA_NO_UNROLL
+                for (; m_block <= loop_end; m_block++) {
+                    if constexpr (Is_blockmask){
+                        if(!blockmask_smem_[m_block / params.m_factor]) continue;
+                    }
+                    bwd_step(m_block, mask_fn, true, flashmask_index_smem_);
+                }
+            }
+            loop_end = std::min(flashmask_mem_[1]/*lt_start_nblockmin*/, m_block_max);
+            CUTLASS_PRAGMA_NO_UNROLL
+            for (; m_block < loop_end; m_block++) {
+                if constexpr (Is_blockmask){
+                    if(!blockmask_smem_[m_block / params.m_factor]) continue;
+                }
+                bwd_step(m_block, mask_fn, false, flashmask_index_smem_);
+            }
+            loop_end = std::min(m_block_max - 1, flashmask_mem_[0]/*lt_start_nblockmax*/);
+            CUTLASS_PRAGMA_NO_UNROLL
+            for (; m_block <= loop_end; m_block++) {
+                if constexpr (Is_blockmask){
+                    if(!blockmask_smem_[m_block / params.m_factor]) continue;
+                }
+                bwd_step(m_block, mask_fn, true, flashmask_index_smem_);
+            }
+            if constexpr (Has_lt_end) {
+                m_block = std::max(m_block, flashmask_mem_[3]/*lt_end_nblockmin*/);
+                loop_end = std::min(flashmask_mem_[2]/*lt_end_nblockmax*/, m_block_max - 1);
+                CUTLASS_PRAGMA_NO_UNROLL
+                for (; m_block <= loop_end; m_block++) {
+                    if constexpr (Is_blockmask){
+                        if(!blockmask_smem_[m_block / params.m_factor]) continue;
+                    }
+                    bwd_step(m_block, mask_fn, true, flashmask_index_smem_);
+                }
+                CUTLASS_PRAGMA_NO_UNROLL
+                for (; m_block < m_block_max; m_block++) {
+                    if constexpr (Is_blockmask){
+                        if(!blockmask_smem_[m_block / params.m_factor]) continue;
+                    }
+                    bwd_step(m_block, mask_fn, false, flashmask_index_smem_);
+                }
             }
         }
 

--- a/csrc/flashmask_v2/mainloop_fwd_sm90_tma_gmma_ws.hpp
+++ b/csrc/flashmask_v2/mainloop_fwd_sm90_tma_gmma_ws.hpp
@@ -379,7 +379,7 @@ struct CollectiveMainloopFwdSm90 {
 
     // These are tuned for speed. They don't affect correctness.
     static constexpr bool UseSchedulerBarrier = (IntraWGOverlap
-        ? (NumMmaWarpGroups >= 2) && (!Is_FP8 ? kHeadDim <= 128 : kHeadDim >= 128)
+        ? (NumMmaWarpGroups >= 2) && (!Is_FP8 ? kHeadDim < 128 : kHeadDim >= 128)
         : NumMmaWarpGroups == 2)
         && !LargeHeadDimV;
     static constexpr bool RescaleOBeforeGemm = kHeadDim > 128 && (!Is_FP8 || V_colmajor) && IntraWGOverlap;

--- a/csrc/flashmask_v2/tile_size.h
+++ b/csrc/flashmask_v2/tile_size.h
@@ -15,16 +15,17 @@ constexpr std::tuple<int, int, bool, bool> tile_size_fwd_sm90(
             return {64, 64, false, true};
         }
         if (headdim <= 64) {
-            bool same_hdim = (headdim == headdim_v);  // if not same hdim, we're targeting hdimv=512
+            // bool same_hdim = (headdim == headdim_v);  // if not same hdim, we're targeting hdimv=512
             // return {same_hdim ? 192 : 64, same_hdim ? 128 : 64, same_hdim, same_hdim};
             // With this workaround in Cutlass 3.8, tile size 192 x 128 got slower for non-causal, idk why
             // https://github.com/NVIDIA/cutlass/blob/833f6990e031b48b4cd2fcf55e0849c51ef6bac2/include/cute/container/tuple.hpp#L131
             // Switch to tile size 192 x 192 for now
-            bool const use_blockN_128 = is_causal || is_local;
+            // bool const use_blockN_128 = is_causal || is_local;
             // return {same_hdim ? 192 : 64, same_hdim ? (use_blockN_128 ? 128 : 192) : 64, same_hdim && use_blockN_128, same_hdim};
-            return {192, use_blockN_128 ? 80 : 144, same_hdim && use_blockN_128, same_hdim};
+            // return {192, use_blockN_128 ? 80 : 144, same_hdim && use_blockN_128, same_hdim};
             // Good for long seqlen (>= 4k) but suffers from tile quantization at short seqlen
             // return {192, is_causal || is_local ? 192 : 176, true, false};
+            return {128, 128, true, true};
         } else if (headdim <= 96) {
             return {192, is_local || paged_kv_non_TMA ? 128 : 144, false, true};
         } else if (headdim <= 128) {


### PR DESCRIPTION
本 PR 包括如下三个部分：

- 对 global sliding window mask 优化 bwd multiple for loop & inline lambda 导致的寄存器溢出问题，使得大 tile size 可成功应用。解决 global sliding window 反向性能瓶颈问题。
- 对 scheduler barrier 的使用调整，可优化 hdim128 前向的性能。
- @xxyux 此前的 PR: #90。对 hdim64 进行的寄存器分配优化以及 tile size 调整。
