### PR TITLE
Migrate FlashAttention-4 headdim 256 support into FlashMask.

### DIFF
--- a/flashmask/flash_mask/flash_attn_v4/cache_utils.py
+++ b/flashmask/flash_mask/flash_attn_v4/cache_utils.py
@@ -60,7 +60,7 @@ def _compute_source_fingerprint() -> str:
     Hash all CuTe Python sources plus runtime ABI stamps into a short fingerprint.
 
     The fingerprint changes whenever:
-    - Any .py file under flash_attn/cute is added, removed, renamed, or modified.
+    - Any .py file under flash_mask/flash_attn_v4 is added, removed, renamed, or modified.
     - The Python minor version changes (e.g. 3.13 -> 3.14).
     - The cutlass or tvm_ffi package version changes.
 

--- a/flashmask/flash_mask/flash_attn_v4/flash_bwd_preprocess.py
+++ b/flashmask/flash_mask/flash_attn_v4/flash_bwd_preprocess.py
@@ -11,6 +11,7 @@
 #   dS_ij = P_ij * (dP_ij - D_i) + dLSE_i * P_ij
 #         = P_ij * (dP_ij - (D_i - dLSE_i))
 # So the main backward kernel is unchanged; we just replace D with D' = D - dLSE here.
+
 import math
 import operator
 from functools import partial
@@ -25,7 +26,6 @@ from cutlass.cutlass_dsl import Arch, BaseDSL
 
 from flash_mask.flash_attn_v4 import copy_utils
 from flash_mask.flash_attn_v4 import layout_utils
-
 from flash_mask.flash_attn_v4 import utils
 from flash_mask.flash_attn_v4.seqlen_info import SeqlenInfo
 from flash_mask.flash_attn_v4.cute_dsl_utils import ParamsBase
@@ -43,6 +43,7 @@ class FlashAttentionBackwardPreprocess:
         head_dim_v: int,
         tile_m: int = 128,
         num_threads: int = 256,
+        use_padded_offsets: bool = True,
     ):
         """
         All contiguous dimensions must be at least 16 bytes aligned which indicates the head dimension
@@ -64,6 +65,7 @@ class FlashAttentionBackwardPreprocess:
         self.head_dim_v_padded = int(math.ceil(head_dim_v / hdim_multiple_of) * hdim_multiple_of)
         self.check_hdim_v_oob = head_dim_v != self.head_dim_v_padded
         self.num_threads = num_threads
+        self.use_padded_offsets = use_padded_offsets
 
     @staticmethod
     def can_implement(dtype, head_dim, tile_m, num_threads) -> bool:
@@ -250,9 +252,15 @@ class FlashAttentionBackwardPreprocess:
             )
             mO_cur = seqlen.offset_batch(mO, batch_idx, dim=0)[None, head_idx, None]
             mdO_cur = seqlen.offset_batch(mdO, batch_idx, dim=0)[None, head_idx, None]
-            mPdPsum_cur = seqlen.offset_batch(mPdPsum, batch_idx, dim=2, padded=True)[
-                None, head_idx
-            ]
+            # Stats buffers (dpsum/lse_log2) are always consumed with padded q-offsets
+            # on the generic backward path (mdQaccum is present). Keep dedicated hd256
+            # behavior controlled by self.use_padded_offsets.
+            stats_use_padded_offsets = self.use_padded_offsets
+            if const_expr(mdQaccum is not None):
+                stats_use_padded_offsets = True
+            mPdPsum_cur = seqlen.offset_batch(
+                mPdPsum, batch_idx, dim=2, padded=stats_use_padded_offsets
+            )[None, head_idx]
             headdim_v = mO_cur.shape[cute.rank(mO_cur) - 1]
             seqlen_q = seqlen.seqlen
             seqlen_q_rounded = cute.round_up(seqlen_q, self.tile_m)
@@ -330,7 +338,11 @@ class FlashAttentionBackwardPreprocess:
             # Clear dQaccum
             if const_expr(mdQaccum is not None):
                 mdQaccum_cur = seqlen.offset_batch(
-                    mdQaccum, batch_idx, dim=2, padded=True, multiple=self.head_dim_padded
+                    mdQaccum,
+                    batch_idx,
+                    dim=2,
+                    padded=True,
+                    multiple=self.head_dim_padded,
                 )[None, head_idx]
                 blkdQaccum_shape = (self.tile_m * self.head_dim_padded,)
                 gdQaccum = cute.local_tile(mdQaccum_cur, blkdQaccum_shape, (m_block,))
@@ -341,9 +353,9 @@ class FlashAttentionBackwardPreprocess:
                 cute.copy(gmem_tiled_copy_dQaccum, zero, tdQgdQaccum)
 
             if const_expr(mLSE is not None):
-                mLSElog2_cur = seqlen.offset_batch(mLSElog2, batch_idx, dim=2, padded=True)[
-                    None, head_idx
-                ]
+                mLSElog2_cur = seqlen.offset_batch(
+                    mLSElog2, batch_idx, dim=2, padded=stats_use_padded_offsets
+                )[None, head_idx]
                 gLSElog2 = cute.local_tile(mLSElog2_cur, (self.tile_m,), (m_block,))
                 LOG2_E = math.log2(math.e)
                 if tidx < seqlen_q_rounded - m_block * self.tile_m:

--- a/flashmask/flash_mask/flash_attn_v4/mask.py
+++ b/flashmask/flash_mask/flash_attn_v4/mask.py
@@ -1,14 +1,17 @@
-# Copyright (c) 2025, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+# Copyright (c) 2025, Tri Dao, Siyu Wang, Shengbin Di, Yuxi Chi, Linfeng Zheng, Haoyan Huang, Lanbo Li, Yun Zhong, Man Yuan, Minmin Sun, Yong Li, Wei Lin.
 
-from typing import Optional, Callable, TypeAlias
+from typing import Optional, Callable, TypeAlias, Tuple
 from dataclasses import dataclass
+import enum
 
 import cutlass
 import cutlass.cute as cute
 from cutlass import Float32, Int32, Uint32, const_expr
+from cutlass.cutlass_dsl import min as dsl_min
 
 import flash_mask.flash_attn_v4.utils as utils
 import flash_mask.flash_attn_v4.utils as utils
+from flash_mask.flash_attn_v4.block_info import BlockInfo
 from flash_mask.flash_attn_v4.seqlen_info import SeqlenInfoQK
 
 MaskGenFn: TypeAlias = Callable[[int], Uint32]
@@ -709,3 +712,750 @@ class AttentionMask:
                         mask_gen_fn,
                         rank1=True,
                     )
+
+
+# -----------------------------------------------------------------------------
+# SM100 FMHA fused-mask policy layer (separate from generic mask primitives).
+# -----------------------------------------------------------------------------
+
+
+class Sm100MaskEnum(enum.Enum):
+    """Enumeration of mask types for FMHA operations.
+
+    - RESIDUAL_MASK: Residual mask for handling variable sequence lengths
+    - WINDOW_MASK: Window mask for attention which also includes causal and no mask
+    - WINDOW_MASK_INFERENCE: Same as the window mask, but has the limitation that the end of q is aligned with the end of k
+    - WINDOW_MASK_BWD: Window mask for backward pass
+    - WINDOW_MASK_BWD_INFERENCE: Same as the window mask for backward pass, but has the limitation that the end of q is aligned with the end of k
+    """
+
+    NO_MASK = enum.auto()
+    RESIDUAL_MASK = enum.auto()
+    CAUSAL_MASK = enum.auto()
+    WINDOW_MASK = enum.auto()
+    WINDOW_MASK_INFERENCE = enum.auto()
+    # Deprecated the following types
+    WINDOW_MASK_BWD = enum.auto()
+    WINDOW_MASK_BWD_INFERENCE = enum.auto()
+    RESIDUAL_MASK_BWD = enum.auto()
+
+
+class Sm100FusedMask:
+    """A fused mask implementation for FMHA operations.
+
+    This class handles different types of attention masks including no mask,
+    residual mask for variable sequence lengths, and causal mask for
+    autoregressive attention patterns.
+
+    The class provides methods to:
+    - Calculate trip counts for different mask types
+    - Apply masks to attention scores
+    - Handle masked and unmasked trip calculations
+    """
+
+    def get_trip_count(
+        mask_type: Sm100MaskEnum,
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+    ) -> Int32:
+        """
+        Calculate the number of trips needed for the current block.
+
+        The trip count depends on the mask type and the block coordinates.
+        For causal masks, it considers the autoregressive constraint.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.Sm100MaskEnum
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param tile_shape: Shape of the tile.
+        :type tile_shape: cute.Shape
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Int32
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+
+        :return: Number of trips needed.
+        :rtype: Int32
+        """
+        result = 0
+        offset = 0
+        if cutlass.const_expr(mask_type is Sm100MaskEnum.WINDOW_MASK_INFERENCE):
+            offset = seqlen_k - seqlen_q
+        if cutlass.const_expr(mask_type is Sm100MaskEnum.WINDOW_MASK_BWD_INFERENCE):
+            offset = seqlen_q - seqlen_k
+        if cutlass.const_expr(mask_type == Sm100MaskEnum.RESIDUAL_MASK):
+            result = cute.ceil_div(seqlen_k, tile_shape[1])
+        if cutlass.const_expr(mask_type is Sm100MaskEnum.RESIDUAL_MASK_BWD):
+            result = cute.ceil_div(seqlen_q, tile_shape[0])
+        if cutlass.const_expr(
+            mask_type == Sm100MaskEnum.WINDOW_MASK
+            or mask_type == Sm100MaskEnum.WINDOW_MASK_INFERENCE
+        ):
+            if cutlass.const_expr(window_size_right is None):
+                result = cute.ceil_div(seqlen_k, tile_shape[1])
+            else:
+                max_idx_q = (blk_coord[0] + 1) * tile_shape[0]
+                idx_k = max_idx_q + offset + window_size_right
+                tmp_blocks_k = cute.ceil_div(idx_k, tile_shape[1])
+                max_blocks_k = cute.ceil_div(seqlen_k, tile_shape[1])
+                result = dsl_min(max_blocks_k, tmp_blocks_k)
+        if cutlass.const_expr(
+            mask_type == Sm100MaskEnum.WINDOW_MASK_BWD
+            or mask_type == Sm100MaskEnum.WINDOW_MASK_BWD_INFERENCE
+        ):
+            if cutlass.const_expr(window_size_left is None):
+                result = cute.ceil_div(seqlen_q, tile_shape[0])
+            else:
+                max_idx_k = (blk_coord[1] + 1) * tile_shape[1]
+                idx_k = max_idx_k + offset + window_size_left
+                tmp_blocks_q = cute.ceil_div(idx_k, tile_shape[0])
+                max_blocks_q = cute.ceil_div(seqlen_q, tile_shape[0])
+                result = dsl_min(max_blocks_q, tmp_blocks_q)
+        start_block = Sm100FusedMask.get_trip_start(
+            mask_type,
+            blk_coord,
+            tile_shape,
+            seqlen_q,
+            seqlen_k,
+            window_size_left,
+            window_size_right,
+        )
+        result = result - start_block
+        return result
+
+    @cute.jit
+    def get_trip_start_count_via_block_info(
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        is_causal: cutlass.Constexpr[bool] = False,
+        is_local: cutlass.Constexpr[bool] = False,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+    ) -> Tuple[Int32, Int32]:
+        block_info = BlockInfo(
+            tile_m=tile_shape[0],
+            tile_n=tile_shape[1],
+            is_causal=is_causal,
+            is_local=is_local and not is_causal,
+            window_size_left=window_size_left,
+            window_size_right=window_size_right,
+        )
+
+        seqlen_info = SeqlenInfoQK(
+            offset_q=Int32(0),
+            offset_k=Int32(0),
+            padded_offset_q=Int32(0),
+            padded_offset_k=Int32(0),
+            seqlen_q=seqlen_q,
+            seqlen_k=seqlen_k,
+            has_cu_seqlens_q=False,
+            has_cu_seqlens_k=False,
+            has_seqused_q=False,
+            has_seqused_k=False,
+        )
+        n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen_info, blk_coord[0])
+        return n_block_min, n_block_max - n_block_min
+
+    @cute.jit
+    def get_trip_mask_bounds_via_block_info(
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        is_causal: cutlass.Constexpr[bool] = False,
+        is_local: cutlass.Constexpr[bool] = False,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+    ) -> Tuple[Int32, Int32]:
+        """Return SM100-style mask boundaries for dense iteration.
+
+        Returns:
+          - n_block_min_causal_local_mask: right-side masked region start
+          - n_block_min_before_local_mask: start of fully unmasked middle region
+        """
+        block_info = BlockInfo(
+            tile_m=tile_shape[0],
+            tile_n=tile_shape[1],
+            is_causal=is_causal,
+            is_local=is_local and not is_causal,
+            window_size_left=window_size_left,
+            window_size_right=window_size_right,
+        )
+        seqlen_info = SeqlenInfoQK(
+            offset_q=Int32(0),
+            offset_k=Int32(0),
+            padded_offset_q=Int32(0),
+            padded_offset_k=Int32(0),
+            seqlen_q=seqlen_q,
+            seqlen_k=seqlen_k,
+            has_cu_seqlens_q=False,
+            has_cu_seqlens_k=False,
+            has_seqused_q=False,
+            has_seqused_k=False,
+        )
+        n_block_min, _ = block_info.get_n_block_min_max(seqlen_info, blk_coord[0])
+        n_block_min_causal_local_mask = block_info.get_n_block_min_causal_local_mask(
+            seqlen_info, blk_coord[0], n_block_min
+        )
+        n_block_min_before_local_mask = block_info.get_n_block_min_before_local_mask(
+            seqlen_info, blk_coord[0], n_block_min
+        )
+        return n_block_min_causal_local_mask, n_block_min_before_local_mask
+
+    @cute.jit
+    def get_trip_start(
+        mask_type: Sm100MaskEnum,
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+    ) -> Int32:
+        """
+        Get the start of the trip for the current block.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.Sm100MaskEnum
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param tile_shape: Shape of the tile.
+        :type tile_shape: cute.Shape
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Int32
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+        """
+        result = 0
+        offset = 0
+        if cutlass.const_expr(mask_type is Sm100MaskEnum.WINDOW_MASK_INFERENCE):
+            offset = seqlen_k - seqlen_q
+        if cutlass.const_expr(mask_type is Sm100MaskEnum.WINDOW_MASK_BWD_INFERENCE):
+            offset = seqlen_q - seqlen_k
+        if cutlass.const_expr(
+            mask_type is Sm100MaskEnum.WINDOW_MASK
+            or mask_type is Sm100MaskEnum.WINDOW_MASK_INFERENCE
+        ):
+            if cutlass.const_expr(window_size_left is not None):
+                min_idx_q = blk_coord[0] * tile_shape[0]
+                idx_k = min_idx_q + offset - window_size_left
+                tmp_blocks_k = idx_k // tile_shape[1]
+                result = max(tmp_blocks_k, result)
+        if cutlass.const_expr(
+            mask_type is Sm100MaskEnum.WINDOW_MASK_BWD
+            or mask_type is Sm100MaskEnum.WINDOW_MASK_BWD_INFERENCE
+        ):
+            if cutlass.const_expr(window_size_right is not None):
+                min_idx_k = blk_coord[1] * tile_shape[1]
+                idx_q = min_idx_k + offset - window_size_right
+                tmp_blocks_q = idx_q // tile_shape[0]
+                result = max(tmp_blocks_q, result)
+        return result
+
+    @cute.jit
+    def get_leading_mask_id(
+        mask_type: Sm100MaskEnum,
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+    ) -> Tuple[Int32, Int32]:
+        """
+        Get the begin and end tile idx for the leading mask.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.Sm100MaskEnum
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param tile_shape: Shape of the tile.
+        :type tile_shape: cute.Shape
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Int32
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+
+        :return: Tuple of (begin, end) tile idx for the leading mask.
+        :rtype: Tuple[Int32, Int32]
+        """
+        offset = 0
+        if cutlass.const_expr(mask_type is Sm100MaskEnum.WINDOW_MASK_INFERENCE):
+            offset = seqlen_k - seqlen_q
+        if cutlass.const_expr(mask_type is Sm100MaskEnum.WINDOW_MASK_BWD_INFERENCE):
+            offset = seqlen_q - seqlen_k
+        leading_mask_begin = Sm100FusedMask.get_trip_start(
+            mask_type,
+            blk_coord,
+            tile_shape,
+            seqlen_q,
+            seqlen_k,
+            window_size_left,
+            window_size_right,
+        )
+        trip_count = Sm100FusedMask.get_trip_count(
+            mask_type,
+            blk_coord,
+            tile_shape,
+            seqlen_q,
+            seqlen_k,
+            window_size_left,
+            window_size_right,
+        )
+
+        leading_mask_end = leading_mask_begin
+        if cutlass.const_expr(
+            mask_type is Sm100MaskEnum.WINDOW_MASK
+            or mask_type is Sm100MaskEnum.WINDOW_MASK_INFERENCE
+        ):
+            if cutlass.const_expr(window_size_left is not None):
+                min_idx_q = (blk_coord[0] + 1) * tile_shape[0] + offset - window_size_left
+                leading_mask_end = dsl_min(
+                    cute.ceil_div(min_idx_q, tile_shape[1]) - 1,
+                    trip_count + leading_mask_begin - 1,
+                )
+            else:
+                leading_mask_end = leading_mask_begin - 1
+        elif cutlass.const_expr(
+            mask_type is Sm100MaskEnum.WINDOW_MASK_BWD
+            or mask_type is Sm100MaskEnum.WINDOW_MASK_BWD_INFERENCE
+        ):
+            if cutlass.const_expr(window_size_right is not None):
+                min_idx_k = (blk_coord[1] + 1) * tile_shape[1] + offset - window_size_right
+                leading_mask_end = cute.ceil_div(min_idx_k, tile_shape[0]) - 1
+            else:
+                leading_mask_end = leading_mask_begin - 1
+        return leading_mask_begin, leading_mask_end
+
+    @cute.jit
+    def get_trailing_mask_id(
+        mask_type: Sm100MaskEnum,
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+    ) -> Tuple[Optional[Int32], Optional[Int32]]:
+        """
+        Get the begin and end tile idx for the trailing mask.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.Sm100MaskEnum
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param tile_shape: Shape of the tile.
+        :type tile_shape: cute.Shape
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Int32
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+
+        :return: Tuple of (begin, end) tile idx for the trailing mask.
+        :rtype: Tuple[Int32, Int32]
+        """
+        offset = 0
+        if cutlass.const_expr(mask_type is Sm100MaskEnum.WINDOW_MASK_INFERENCE):
+            offset = seqlen_k - seqlen_q
+        if cutlass.const_expr(mask_type is Sm100MaskEnum.WINDOW_MASK_BWD_INFERENCE):
+            offset = seqlen_q - seqlen_k
+        trip_start = Sm100FusedMask.get_trip_start(
+            mask_type,
+            blk_coord,
+            tile_shape,
+            seqlen_q,
+            seqlen_k,
+            window_size_left,
+            window_size_right,
+        )
+        trip_count = Sm100FusedMask.get_trip_count(
+            mask_type,
+            blk_coord,
+            tile_shape,
+            seqlen_q,
+            seqlen_k,
+            window_size_left,
+            window_size_right,
+        )
+
+        trailing_mask_begin, trailing_mask_end = None, None
+        if cutlass.const_expr(
+            mask_type is Sm100MaskEnum.WINDOW_MASK
+            or mask_type is Sm100MaskEnum.WINDOW_MASK_INFERENCE
+        ):
+            if cutlass.const_expr(window_size_right is not None):
+                min_idx_q = blk_coord[0] * tile_shape[0] + offset + window_size_right
+                trailing_mask_begin = dsl_min(
+                    min_idx_q // tile_shape[1], trip_count + trip_start - 1
+                )
+                trailing_mask_end = trip_count + trip_start - 1
+            else:
+                # last tile, we always apply mask on it regardless whether it's a residual tile
+                trailing_mask_begin = trip_count + trip_start - 1
+                trailing_mask_end = trip_count + trip_start - 1
+        else:
+            if cutlass.const_expr(window_size_left is not None):
+                min_idx_k = blk_coord[1] * tile_shape[1] + offset + window_size_left + 1
+                max_idx_k = (blk_coord[1] + 1) * tile_shape[1] + offset + window_size_left
+                trailing_mask_begin = dsl_min(
+                    cute.ceil_div(min_idx_k, tile_shape[0]) - 1,
+                    trip_count + trip_start - 1,
+                )
+                trailing_mask_end = dsl_min(
+                    cute.ceil_div(max_idx_k, tile_shape[0]) - 1,
+                    trip_count + trip_start - 1,
+                )
+            else:
+                # last tile, we always apply mask on it regardless whether it's a residual tile
+                trailing_mask_begin = trip_count + trip_start - 1
+                trailing_mask_end = trip_count + trip_start - 1
+
+        return trailing_mask_begin, trailing_mask_end
+
+    @cute.jit
+    def get_masked_leading_count(
+        mask_type: Sm100MaskEnum,
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+    ) -> Int32:
+        """
+        Calculate the number of masked trips for the leading mask.
+
+        This is used for blocks that need special handling due to masking.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.Sm100MaskEnum
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param tile_shape: Shape of the tile.
+        :type tile_shape: cute.Shape
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Int32
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+
+        :return: Number of masked trips.
+        :rtype: Int32
+        """
+        result = 0
+        if cutlass.const_expr(
+            mask_type is not Sm100MaskEnum.RESIDUAL_MASK
+            and mask_type is not Sm100MaskEnum.RESIDUAL_MASK_BWD
+        ):
+            if cutlass.const_expr(window_size_left is not None or window_size_right is not None):
+                leading_mask_begin, leading_mask_end = Sm100FusedMask.get_leading_mask_id(
+                    mask_type,
+                    blk_coord,
+                    tile_shape,
+                    seqlen_q,
+                    seqlen_k,
+                    window_size_left,
+                    window_size_right,
+                )
+                result = max(leading_mask_end - leading_mask_begin + 1, 0)
+
+        return result
+
+    @cute.jit
+    def get_masked_trailing_count(
+        mask_type: Sm100MaskEnum,
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+        rem_count: Optional[Int32] = 0,
+    ) -> Int32:
+        """
+        Calculate the number of masked trips for the trailing mask.
+
+        This is used for blocks that need special handling due to masking.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.Sm100MaskEnum
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param tile_shape: Shape of the tile.
+        :type tile_shape: cute.Shape
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Int32
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+        :param rem_count: Remaining count from previous calculations.
+        :type rem_count: Int32
+
+        :return: Number of masked trips.
+        :rtype: Int32
+        """
+        result = 0
+
+        if cutlass.const_expr(
+            mask_type is not Sm100MaskEnum.RESIDUAL_MASK
+            and mask_type is not Sm100MaskEnum.RESIDUAL_MASK_BWD
+        ):
+            if cutlass.const_expr(window_size_left is not None or window_size_right is not None):
+                trailing_mask_begin, trailing_mask_end = Sm100FusedMask.get_trailing_mask_id(
+                    mask_type,
+                    blk_coord,
+                    tile_shape,
+                    seqlen_q,
+                    seqlen_k,
+                    window_size_left,
+                    window_size_right,
+                )
+                leading_mask_begin, leading_mask_end = Sm100FusedMask.get_leading_mask_id(
+                    mask_type,
+                    blk_coord,
+                    tile_shape,
+                    seqlen_q,
+                    seqlen_k,
+                    window_size_left,
+                    window_size_right,
+                )
+                if cutlass.const_expr(
+                    trailing_mask_begin is not None and trailing_mask_end is not None
+                ):
+                    if trailing_mask_begin <= leading_mask_end:
+                        result = max(trailing_mask_end - leading_mask_end, 0)
+                    else:
+                        result = max(trailing_mask_end - trailing_mask_begin + 1, 0)
+        else:
+            if seqlen_k % tile_shape[1] != 0:
+                result = 1
+            else:
+                result = 0
+
+        return result + rem_count
+
+    @cute.jit
+    def get_unmasked_trip_count(
+        mask_type: Sm100MaskEnum,
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+    ) -> Int32:
+        """
+        Calculate the number of unmasked trips for the current block.
+
+        This represents the number of trips that don't require special
+        masking treatment.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.Sm100MaskEnum
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param tile_shape: Shape of the tile.
+        :type tile_shape: cute.Shape
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Int32
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+
+        :return: Number of unmasked trips.
+        :rtype: Int32
+        """
+        result = (
+            Sm100FusedMask.get_trip_count(
+                mask_type,
+                blk_coord,
+                tile_shape,
+                seqlen_q,
+                seqlen_k,
+                window_size_left,
+                window_size_right,
+            )
+            - Sm100FusedMask.get_masked_leading_count(
+                mask_type,
+                blk_coord,
+                tile_shape,
+                seqlen_q,
+                seqlen_k,
+                window_size_left,
+                window_size_right,
+            )
+            - Sm100FusedMask.get_masked_trailing_count(
+                mask_type,
+                blk_coord,
+                tile_shape,
+                seqlen_q,
+                seqlen_k,
+                window_size_left,
+                window_size_right,
+                0,
+            )
+        )
+        return result
+
+    @cute.jit
+    def apply_mask(
+        mask_type: Sm100MaskEnum,
+        acc_qk: cute.Tensor,
+        index_qk: cute.Tensor,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[int] = None,
+        window_size_right: Optional[int] = None,
+        index_transform: cutlass.Constexpr = lambda index_q, index_k: (
+            index_q,
+            index_k,
+        ),
+    ):
+        """
+        Apply the appropriate mask to the attention scores.
+
+        This method modifies the attention scores (acc_qk) based on the mask type
+        and the positions in the index tensor.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.Sm100MaskEnum
+        :param acc_qk: Accumulated QK attention scores tensor.
+        :type acc_qk: cute.Tensor
+        :param index_qk: Index tensor containing position information.
+        :type index_qk: cute.Tensor
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Optional[int]
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[int]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[int]
+        """
+
+        tidx, tidy, tidx = cute.arch.thread_idx()
+        offset = 0
+        # NOTE: causal masking in this repo aligns the *end* of Q with the *end* of K
+        # when seqlen_k != seqlen_q (same as the test/reference implementation):
+        #   k_index <= q_index + (seqlen_k - seqlen_q) + window_right
+        # In our kernels, causal is represented by (window_left is None, window_right is not None).
+        if cutlass.const_expr(window_size_left is None and window_size_right is not None):
+            offset = seqlen_k - seqlen_q
+        elif cutlass.const_expr(
+            mask_type is Sm100MaskEnum.WINDOW_MASK_INFERENCE
+            or mask_type is Sm100MaskEnum.WINDOW_MASK_BWD_INFERENCE
+        ):
+            offset = seqlen_k - seqlen_q
+        for i in cutlass.range_constexpr(cute.size(acc_qk), unroll_full=True):
+            index_q, index_k = index_transform(*index_qk[i])
+            if cutlass.const_expr(window_size_left is not None or window_size_right is not None):
+                if cutlass.const_expr(window_size_left is None):
+                    if index_q + offset + window_size_right < index_k:
+                        acc_qk[i] = -Float32.inf
+                    if index_k >= seqlen_k or index_q >= seqlen_q:  # residual mask
+                        acc_qk[i] = -Float32.inf
+                elif cutlass.const_expr(window_size_right is None):
+                    if index_q + offset - window_size_left > index_k:
+                        acc_qk[i] = -Float32.inf
+                    if index_k >= seqlen_k or index_q >= seqlen_q:  # residual mask
+                        acc_qk[i] = -Float32.inf
+                else:
+                    max_K_index = dsl_min(index_q + offset + window_size_right, seqlen_k)
+                    min_K_index = max(0, index_q + offset - window_size_left)
+                    if index_k > max_K_index or index_k < min_K_index:
+                        acc_qk[i] = -Float32.inf
+                    if index_k >= seqlen_k or index_q >= seqlen_q:  # residual mask
+                        acc_qk[i] = -Float32.inf
+
+            if cutlass.const_expr(
+                mask_type == Sm100MaskEnum.RESIDUAL_MASK
+                or mask_type == Sm100MaskEnum.RESIDUAL_MASK_BWD
+            ):
+                if index_k >= seqlen_k or index_q >= seqlen_q:
+                    acc_qk[i] = -Float32.inf
+
+    @cute.jit
+    def apply_mask_via_causal_local(
+        acc_qk: cute.Tensor,
+        index_qk: cute.Tensor,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        apply_semantic_window: cutlass.Constexpr[bool] = True,
+        is_causal: cutlass.Constexpr[bool] = False,
+        is_local: cutlass.Constexpr[bool] = False,
+        window_size_left: Optional[int] = None,
+        window_size_right: Optional[int] = None,
+        index_transform: cutlass.Constexpr = lambda index_q, index_k: (
+            index_q,
+            index_k,
+        ),
+    ):
+        """Apply forward mask without mask_type.
+
+        - If apply_semantic_window=True, apply causal/local window constraints.
+        - Always apply residual OOB masking (index_k>=seqlen_k or index_q>=seqlen_q).
+        """
+        tidx, tidy, tidx = cute.arch.thread_idx()
+        offset = 0
+        if cutlass.const_expr(apply_semantic_window):
+            # Match WINDOW_MASK_INFERENCE semantics: end-align Q/K when lengths differ.
+            offset = seqlen_k - seqlen_q
+        for i in cutlass.range_constexpr(cute.size(acc_qk), unroll_full=True):
+            index_q, index_k = index_transform(*index_qk[i])
+            if cutlass.const_expr(apply_semantic_window):
+                if cutlass.const_expr(is_causal and not is_local):
+                    # Pure causal; tolerate both external forms:
+                    # - (None, None) from interface
+                    # - (None, 0) from fused-mask-style callers
+                    right = 0 if const_expr(window_size_right is None) else window_size_right
+                    if index_q + offset + right < index_k:
+                        acc_qk[i] = -Float32.inf
+                elif cutlass.const_expr(
+                    is_local or window_size_left is not None or window_size_right is not None
+                ):
+                    if cutlass.const_expr(window_size_left is None):
+                        if index_q + offset + window_size_right < index_k:
+                            acc_qk[i] = -Float32.inf
+                    elif cutlass.const_expr(window_size_right is None):
+                        if index_q + offset - window_size_left > index_k:
+                            acc_qk[i] = -Float32.inf
+                    else:
+                        max_K_index = dsl_min(index_q + offset + window_size_right, seqlen_k)
+                        min_K_index = max(0, index_q + offset - window_size_left)
+                        if index_k > max_K_index or index_k < min_K_index:
+                            acc_qk[i] = -Float32.inf
+            # Residual mask is always needed for boundary protection.
+            if index_k >= seqlen_k or index_q >= seqlen_q:
+                acc_qk[i] = -Float32.inf

--- a/flashmask/flash_mask/flash_attn_v4/paddle/interface.py
+++ b/flashmask/flash_mask/flash_attn_v4/paddle/interface.py
@@ -62,6 +62,8 @@ from flash_mask.flash_attn_v4.flash_bwd_sm100 import FlashAttentionBackwardSm100
 from flash_mask.flash_attn_v4.flash_bwd_sm120 import FlashAttentionBackwardSm120
 from flash_mask.flash_attn_v4.flash_bwd_postprocess import FlashAttentionBackwardPostprocess
 from flash_mask.flash_attn_v4.flash_fwd_combine import FlashAttentionForwardCombine
+from flash_mask.flash_attn_v4.sm100_hd256_2cta_fmha_forward import BlackwellFusedMultiHeadAttentionForward
+from flash_mask.flash_attn_v4.sm100_hd256_2cta_fmha_backward import BlackwellFusedMultiHeadAttentionBackward
 
 from flash_mask.flash_attn_v4.paddle.block_sparsity import (
     BlockSparseTensorsPaddle,
@@ -118,6 +120,7 @@ def _get_device_arch():
 def _validate_head_dims(head_dim: int, head_dim_v: int, compute_capability: int, alignment: int) -> None:
     """Validate head dimension constraints based on compute capability."""
     is_deepseek_shape = head_dim == 192 and head_dim_v == 128
+    is_dedicate_kernel_shape = head_dim == 256 and head_dim_v == 256
     is_standard_range = 8 <= head_dim <= 128 and 8 <= head_dim_v <= 128
 
     is_sm90_range = 8 <= head_dim <= 256 and 8 <= head_dim_v <= 256
@@ -127,9 +130,9 @@ def _validate_head_dims(head_dim: int, head_dim_v: int, compute_capability: int,
             f"head_dim and head_dim_v must be between 8 and 256 and divisible by {alignment}."
         )
     elif compute_capability in [10, 11]:
-        assert (is_standard_range or is_deepseek_shape) and head_dim % alignment == 0 and head_dim_v % alignment == 0, (
+        assert (is_standard_range or is_deepseek_shape or is_dedicate_kernel_shape) and head_dim % alignment == 0 and head_dim_v % alignment == 0, (
             f"(head_dim, head_dim_v)=({head_dim}, {head_dim_v}) is not supported on SM100/SM110. "
-            f"head_dim and head_dim_v must be between 8 and 128 and divisible by {alignment}, or (192, 128) for DeepSeek."
+            f"head_dim and head_dim_v must be between 8 and 128 and divisible by {alignment}, or (192, 128) for DeepSeek, or (256, 256) for hd256."
         )
 
 
@@ -506,6 +509,10 @@ def _flash_attn_fwd(
         and (tile_m % qhead_per_kvhead == 0 or not pack_gqa)
     )
 
+    # hd=256 2CTA forward uses dedicated kernel (SM100 only)
+    use_dedicated_hd256_kernel = arch // 10 == 10 and head_dim == 256 and head_dim_v == 256
+    use_2cta_instrs = use_2cta_instrs or use_dedicated_hd256_kernel
+
     if softcap is not None:
         assert score_mod is None, "softcap and score_mod cannot be used together"
         score_mod = utils.create_softcap_scoremod(softcap)
@@ -684,7 +691,23 @@ def _flash_attn_fwd(
                 paged_kv_non_tma=page_size not in [None, tile_n],
             )
         elif arch // 10 in [10, 11]:
-            fa_fwd = FlashAttentionForwardSm100(
+            if use_dedicated_hd256_kernel:
+                # hd=256 2CTA forward: check for currently unsupported features
+                assert softcap is None, "SM100 forward with head_dim=256 does not support softcap"
+                assert not use_block_sparsity, \
+                    "SM100 forward with head_dim=256 does not support block sparsity"
+                assert learnable_sink is None, \
+                    "SM100 forward with head_dim=256 does not support learnable_sink"
+                assert seqused_q is None and seqused_k is None, \
+                    "SM100 forward with head_dim=256 does not support seqused_q/seqused_k"
+                # pack_gqa is an auto-selected optimization; disable it for hd256 kernel
+                pack_gqa = False
+            flash_fwd_obj_cls = (
+                BlackwellFusedMultiHeadAttentionForward
+                if use_dedicated_hd256_kernel
+                else FlashAttentionForwardSm100
+            )
+            fa_fwd = flash_fwd_obj_cls(
                 head_dim,
                 head_dim_v,
                 qhead_per_kvhead=qhead_per_kvhead,
@@ -834,7 +857,8 @@ def make_fake_bwd_tensors(dtype, has_gqa, varlen_q, varlen_k):
 
 
 def _compile_bwd_preprocess(
-    dtype, head_dim, head_dim_v, m_block_size, has_cuseqlens_q, has_seqused_q, has_dlse,
+    dtype, head_dim, head_dim_v, m_block_size, has_cuseqlens_q, has_seqused_q, has_dlse, has_dq_accum,
+    use_padded_offsets,
 ):
     """Compile bwd preprocess kernel using cute fake tensors."""
     mQ, mK, mV, mO, mdO, mdQ, mdK, mdV, mLSE, mLSElog2, mPdPsum, mdQaccum, mdKaccum, mdVaccum = make_fake_bwd_tensors(
@@ -845,7 +869,8 @@ def _compile_bwd_preprocess(
     mCuSeqlensQ = fake_tensor(Int32, (batchp1,), divisibility=1) if has_cuseqlens_q else None
     mSequsedQ = fake_tensor(Int32, (batch,), divisibility=1) if has_seqused_q else None
     mdLSE = fake_tensor(Float32, mLSE.shape, divisibility=1) if has_dlse else None
-    fa_bwd_pre = FlashAttentionBackwardPreprocess(dtype, head_dim, head_dim_v, m_block_size)
+    mdQaccum = mdQaccum if has_dq_accum else None
+    fa_bwd_pre = FlashAttentionBackwardPreprocess(dtype, head_dim, head_dim_v, m_block_size, use_padded_offsets=use_padded_offsets)
     return cute.compile(
         fa_bwd_pre, mO, mdO, mPdPsum, mLSE, mLSElog2, mdQaccum, mCuSeqlensQ, mSequsedQ, mdLSE,
         cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
@@ -857,11 +882,13 @@ def _bwd_preprocess(
     out, dout, dpsum, lse, lse_log2, dq_accum,
     cu_seqlens_q, seqused_q, dlse,
     dtype, head_dim, head_dim_v, m_block_size,
+    use_padded_offsets=True,
 ):
     """Backward preprocess: compute (o * dout).sum(dim=-1) - dLSE, lse * log2_e, zero out dq_accum."""
     is_varlen = cu_seqlens_q is not None
     compile_key = (
         dtype, head_dim, head_dim_v, m_block_size, is_varlen, seqused_q is not None, dlse is not None,
+        dq_accum is not None, use_padded_offsets,
     )
     if compile_key not in _bwd_preprocess.compile_cache:
         _bwd_preprocess.compile_cache[compile_key] = _compile_bwd_preprocess(*compile_key)
@@ -1044,6 +1071,9 @@ def _flash_attn_bwd(
         cluster_size = 2 if head_dim >= 128 and not disable_2cta else 1
         use_2cta_instrs = cluster_size == 2
 
+    use_dedicated_hd256_kernel = arch // 10 == 10 and head_dim == 256 and head_dim_v == 256
+    use_2cta_instrs = use_2cta_instrs or use_dedicated_hd256_kernel
+
     q, k, v, out, dout, lse, cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k = [
         maybe_contiguous(t)
         for t in (q, k, v, out, dout, lse, cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k)
@@ -1160,9 +1190,13 @@ def _flash_attn_bwd(
     head_dim_rounded = (head_dim + 32 - 1) // 32 * 32
 
     if cu_seqlens_q is None:
-        dq_accum = paddle.empty(
-            [batch_size, num_head, seqlen_q_rounded * head_dim_rounded],
-            dtype=paddle.float32,
+        dq_accum = (
+            None
+            if use_dedicated_hd256_kernel
+            else paddle.empty(
+                [batch_size, num_head, seqlen_q_rounded * head_dim_rounded],
+                dtype=paddle.float32,
+            )
         )
         dpsum = paddle.empty([batch_size, num_head, seqlen_q_rounded], dtype=paddle.float32)
         lse_log2 = paddle.empty([batch_size, num_head, seqlen_q_rounded], dtype=paddle.float32)
@@ -1170,14 +1204,19 @@ def _flash_attn_bwd(
         total_q_rounded_padded = (
             (total_q + cu_seqlens_q.shape[0] * m_block_size - 1) // m_block_size * m_block_size
         )
-        dq_accum = paddle.empty(
-            [num_head, total_q_rounded_padded * head_dim_rounded], dtype=paddle.float32
+        dq_accum = (
+            None
+            if use_dedicated_hd256_kernel
+            else paddle.empty(
+                [num_head, total_q_rounded_padded * head_dim_rounded], dtype=paddle.float32
+            )
         )
         dpsum = paddle.empty([num_head, total_q_rounded_padded], dtype=paddle.float32)
         lse_log2 = paddle.empty([num_head, total_q_rounded_padded], dtype=paddle.float32)
 
     # GQA needs dK/dV accum+postprocess since multiple Q heads accumulate into the same dK/dV.
-    dKV_postprocess = qhead_per_kvhead > 1
+    # hd=256 2CTA backward has its own internal postprocess for dK/dV.
+    dKV_postprocess = qhead_per_kvhead > 1 and not use_dedicated_hd256_kernel
     if dKV_postprocess:
         head_dim_v_rounded = (head_dim_v + 32 - 1) // 32 * 32
         if cu_seqlens_k is None:
@@ -1227,11 +1266,13 @@ def _flash_attn_bwd(
         dK_semaphore = None
         dV_semaphore = None
 
-    # Preprocess kernel
+    # Preprocess kernel: compute (o * dout).sum(dim=-1) - dLSE, lse * log2_e, and zero out dq_accum.
+    # For hd=256 dedicated path, dq_accum is None so preprocess only fills dpsum/lse_log2.
     _bwd_preprocess(
         out, dout, dpsum, lse, lse_log2, dq_accum,
         cu_seqlens_q, seqused_q, dlse,
         dtype, head_dim, head_dim_v, m_block_size,
+        use_padded_offsets=use_dedicated_hd256_kernel,
     )
     if arch // 10 not in [9, 12]:
         num_threads = 384
@@ -1341,9 +1382,8 @@ def _flash_attn_bwd(
         q_tensor, k_tensor, v_tensor, do_tensor, dq_tensor, dk_tensor, dv_tensor = [
             to_cute_tensor(t) for t in (q, k, v, dout, dq, dk, dv)
         ]
-        dq_accum_tensor, dpsum_tensor, lse_log2_tensor = [
-            to_cute_tensor(t) for t in (dq_accum, dpsum, lse_log2)
-        ]
+        lse_log2_tensor, dpsum_tensor = [to_cute_tensor(t) for t in (lse_log2, dpsum)]
+        dq_accum_tensor = to_cute_tensor(dq_accum) if dq_accum is not None else None
         if dKV_postprocess:
             dk_accum_tensor, dv_accum_tensor = [
                 to_cute_tensor(t) for t in (dk_accum, dv_accum)
@@ -1413,27 +1453,62 @@ def _flash_attn_bwd(
                 dQ_single_wg=dQ_single_wg,
             )
         else:
-            fa_bwd_obj = FlashAttentionBackwardSm100(
-                head_dim,
-                head_dim_v,
-                is_causal=causal,
-                is_local=local,
-                qhead_per_kvhead=qhead_per_kvhead,
-                tile_m=m_block_size,
-                tile_n=n_block_size,
-                cluster_size=cluster_size,
-                use_2cta_instrs=use_2cta_instrs,
-                deterministic=deterministic,
-                score_mod=score_mod,
-                score_mod_bwd=score_mod_bwd,
-                mask_mod=mask_mod,
-                has_aux_tensors=aux_tensors is not None,
-                subtile_factor=subtile_factor,
-            )
+            if use_dedicated_hd256_kernel:
+                assert softcap == 0.0, "SM100 backward with head_dim=256 does not support softcap"
+                assert block_sparse_tensors is None, \
+                    "SM100 backward with head_dim=256 does not support block sparsity"
+                assert dlse is None, \
+                    "SM100 backward with head_dim=256 does not support dlse"
+                assert seqused_q is None and seqused_k is None, \
+                    "SM100 backward with head_dim=256 does not support seqused_q/seqused_k"
+
+                dq_tile_mn = (128, 128)
+                dkdv_tile_mn = (128, 64)
+                fa_bwd_obj = BlackwellFusedMultiHeadAttentionBackward(
+                    head_dim,
+                    head_dim_v,
+                    is_causal=causal,
+                    is_local=local,
+                    qhead_per_kvhead=qhead_per_kvhead,
+                    is_persistent=False,
+                    deterministic=deterministic,
+                    cluster_size=cluster_size,
+                    use_2cta_instrs=use_2cta_instrs,
+                    score_mod=score_mod,
+                    score_mod_bwd=score_mod_bwd,
+                    mask_mod=mask_mod,
+                    has_aux_tensors=aux_tensors is not None,
+                    subtile_factor=subtile_factor,
+                    tile_m_dq=dq_tile_mn[0],
+                    tile_n_dq=dq_tile_mn[1],
+                    tile_m_dkdv=dkdv_tile_mn[0],
+                    tile_n_dkdv=dkdv_tile_mn[1],
+                )
+            else:
+                fa_bwd_obj = FlashAttentionBackwardSm100(
+                    head_dim,
+                    head_dim_v,
+                    is_causal=causal,
+                    is_local=local,
+                    qhead_per_kvhead=qhead_per_kvhead,
+                    tile_m=m_block_size,
+                    tile_n=n_block_size,
+                    cluster_size=cluster_size,
+                    use_2cta_instrs=use_2cta_instrs,
+                    deterministic=deterministic,
+                    score_mod=score_mod,
+                    score_mod_bwd=score_mod_bwd,
+                    mask_mod=mask_mod,
+                    has_aux_tensors=aux_tensors is not None,
+                    subtile_factor=subtile_factor,
+                )
 
         sparse_tensors_compile = None
         if normalized_block_sparse_tensors is not None:
             sparse_tensors_compile = to_cute_block_sparse_tensors(normalized_block_sparse_tensors)
+
+        # For hd=256, pass dq (bf16/fp16) directly at the dQ_accum slot.
+        dq_accum_tensor = dq_tensor if use_dedicated_hd256_kernel else dq_accum_tensor
 
         _flash_attn_bwd.compile_cache[compile_key] = cute.compile(
             fa_bwd_obj,
@@ -1462,6 +1537,8 @@ def _flash_attn_bwd(
             options="--enable-tvm-ffi",
         )
     if not is_fake_mode():
+        # For hd=256, dq_accum is None; pass dq directly at the dQ_accum slot.
+        dq_accum = dq if use_dedicated_hd256_kernel else dq_accum
         _flash_attn_bwd.compile_cache[compile_key](
             q.detach(),
             k.detach(),
@@ -1486,37 +1563,39 @@ def _flash_attn_bwd(
             normalized_block_sparse_tensors[:4] if normalized_block_sparse_tensors is not None else None,
         )
 
-    if arch // 10 == 9:
-        num_threads_post_dQ = 128 if dQ_single_wg else cfg.num_wg * 128
-        num_threads_post_dKV = cfg.num_wg * 128
-    else:
-        num_threads_post_dQ = 128
-        num_threads_post_dKV = 128
-
     # Postprocess: convert dq_accum from float32 to dq in bf16/fp16
-    _bwd_postprocess_convert(
-        dq_accum, dq, softmax_scale,
-        cu_seqlens_q, seqused_q,
-        arch, dtype, head_dim, m_block_size, num_threads_post_dQ,
-        AtomLayoutMdQ, dQ_swapAB,
-        use_2cta_instrs=use_2cta_instrs, cluster_size=1,
-    )
+    # hd=256 2CTA backward has its own internal postprocess, skip here.
+    if not use_dedicated_hd256_kernel:
+        if arch // 10 == 9:
+            num_threads_post_dQ = 128 if dQ_single_wg else cfg.num_wg * 128
+            num_threads_post_dKV = cfg.num_wg * 128
+        else:
+            num_threads_post_dQ = 128
+            num_threads_post_dKV = 128
 
-    if dKV_postprocess:
         _bwd_postprocess_convert(
-            dk_accum, dk, softmax_scale,
-            cu_seqlens_k, seqused_k,
-            arch, dtype, head_dim, n_block_size, num_threads_post_dKV,
-            AtomLayoutNdKV, dKV_swapAB,
-            cluster_size=cluster_size,
+            dq_accum, dq, softmax_scale,
+            cu_seqlens_q, seqused_q,
+            arch, dtype, head_dim, m_block_size, num_threads_post_dQ,
+            AtomLayoutMdQ, dQ_swapAB,
+            use_2cta_instrs=use_2cta_instrs, cluster_size=1,
         )
-        _bwd_postprocess_convert(
-            dv_accum, dv, 1.0,
-            cu_seqlens_k, seqused_k,
-            arch, dtype, head_dim_v, n_block_size, num_threads_post_dKV,
-            AtomLayoutNdKV, dKV_swapAB,
-            cluster_size=cluster_size,
-        )
+
+        if dKV_postprocess:
+            _bwd_postprocess_convert(
+                dk_accum, dk, softmax_scale,
+                cu_seqlens_k, seqused_k,
+                arch, dtype, head_dim, n_block_size, num_threads_post_dKV,
+                AtomLayoutNdKV, dKV_swapAB,
+                cluster_size=cluster_size,
+            )
+            _bwd_postprocess_convert(
+                dv_accum, dv, 1.0,
+                cu_seqlens_k, seqused_k,
+                arch, dtype, head_dim_v, n_block_size, num_threads_post_dKV,
+                AtomLayoutNdKV, dKV_swapAB,
+                cluster_size=cluster_size,
+            )
 
     return dq, dk, dv
 

--- a/flashmask/flash_mask/flash_attn_v4/sm100_hd256_2cta_fmha_backward.py
+++ b/flashmask/flash_mask/flash_attn_v4/sm100_hd256_2cta_fmha_backward.py
@@ -9,6 +9,8 @@ Constraints:
 * Batch size must be the same for Q, K, and V tensors
 """
 
+from typing import Optional
+
 import cuda.bindings.driver as cuda
 
 import cutlass
@@ -213,7 +215,7 @@ class BlackwellFusedMultiHeadAttentionBackward:
         dQ_semaphore: cute.Tensor | None = None,
         dK_semaphore: cute.Tensor | None = None,
         dV_semaphore: cute.Tensor | None = None,
-        aux_tensors: tuple[cute.Tensor] | None = None,
+        aux_tensors: Optional[list] = None,
         block_sparse_tensors: cute.Tensor | None = None,
         stream: cuda.CUstream = None,
     ):

--- a/flashmask/flash_mask/flash_attn_v4/sm100_hd256_2cta_fmha_backward.py
+++ b/flashmask/flash_mask/flash_attn_v4/sm100_hd256_2cta_fmha_backward.py
@@ -1,0 +1,300 @@
+# Copyright (c) 2025, Siyu Wang, Shengbin Di, Yuxi Chi, Linfeng Zheng, Haoyan Huang, Lanbo Li, Yun Zhong, Man Yuan, Minmin Sun, Yong Li, Wei Lin.
+
+
+"""Fused multi-head attention (FMHA) backward for the SM100 architecture using CUTE DSL.
+
+Constraints:
+* Supported head dimensions: 256 only
+* mma_tiler_mn must be 64,64
+* Batch size must be the same for Q, K, and V tensors
+"""
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.typing import Int32
+
+try:
+    from flash_mask.flash_attn_v4.sm100_hd256_2cta_fmha_backward_dqkernel import (
+        BlackwellFusedMultiHeadAttentionBackwardDQKernel,
+    )
+    from flash_mask.flash_attn_v4.sm100_hd256_2cta_fmha_backward_dkdvkernel import (
+        BlackwellFusedMultiHeadAttentionBackwardDKDVKernel,
+    )
+except ImportError:
+    # Allow direct execution as a script (no package context).
+    from flash_mask.flash_attn_v4.sm100_hd256_2cta_fmha_backward_dqkernel import (
+        BlackwellFusedMultiHeadAttentionBackwardDQKernel,
+    )
+    from flash_mask.flash_attn_v4.sm100_hd256_2cta_fmha_backward_dkdvkernel import (
+        BlackwellFusedMultiHeadAttentionBackwardDKDVKernel,
+    )
+
+
+def _as_bshkrd_tensor(
+    tensor: cute.Tensor,
+    h_k: Int32,
+    h_r: Int32,
+    varlen: bool,
+) -> cute.Tensor:
+    """Normalize (B,S,H,D)/(S,H,D) tensors to (B,S,H_k,H_r,D) view."""
+    if cutlass.const_expr(cute.rank(tensor.layout) == 5):
+        return tensor
+    if cutlass.const_expr(cute.rank(tensor.layout) == 4):
+        return cute.make_tensor(
+            tensor.iterator,
+            cute.make_layout(
+                (tensor.shape[0], tensor.shape[1], h_k, h_r, tensor.shape[3]),
+                stride=(
+                    tensor.stride[0],
+                    tensor.stride[1],
+                    tensor.stride[2] * h_r,
+                    tensor.stride[2],
+                    tensor.stride[3],
+                ),
+            ),
+        )
+    assert cutlass.const_expr(cute.rank(tensor.layout) == 3), "Expected rank-3 varlen tensor"
+    assert cutlass.const_expr(varlen), "Rank-3 input is only valid for varlen backward"
+    return cute.make_tensor(
+        tensor.iterator,
+        cute.make_layout(
+            (1, tensor.shape[0], h_k, h_r, tensor.shape[2]),
+            stride=(
+                0,
+                tensor.stride[0],
+                tensor.stride[1] * h_r,
+                tensor.stride[1],
+                tensor.stride[2],
+            ),
+        ),
+    )
+
+
+def _as_shhb_tensor(
+    tensor: cute.Tensor,
+    h_k: Int32,
+    h_r: Int32,
+    b: Int32,
+    varlen: bool,
+) -> cute.Tensor:
+    """Normalize (B,H,S)/(H,S) tensors to (S, ((H_r, H_k), B)) view."""
+    if cutlass.const_expr(cute.rank(tensor.layout) == 3):
+        return cute.make_tensor(
+            tensor.iterator,
+            cute.make_layout(
+                (tensor.shape[2], ((h_r, h_k), tensor.shape[0])),
+                stride=(
+                    tensor.stride[2],
+                    ((tensor.stride[1], tensor.stride[1] * h_r), tensor.stride[0]),
+                ),
+            ),
+        )
+    assert cutlass.const_expr(cute.rank(tensor.layout) == 2), "Expected rank-2 varlen tensor"
+    assert cutlass.const_expr(varlen), "Rank-2 input is only valid for varlen backward"
+    return cute.make_tensor(
+        tensor.iterator,
+        cute.make_layout(
+            (tensor.shape[1], ((h_r, h_k), b)),
+            stride=(
+                tensor.stride[1],
+                ((tensor.stride[0], tensor.stride[0] * h_r), 0),
+            ),
+        ),
+    )
+
+
+class BlackwellFusedMultiHeadAttentionBackward:
+    """FMHA backward class for executing CuTeDSL kernel."""
+
+    def __init__(
+        self,
+        head_dim: int,
+        head_dim_v: int | None = None,
+        is_causal: bool = False,
+        is_local: bool = False,
+        qhead_per_kvhead: cutlass.Constexpr[int] = 1,
+        is_persistent: bool = False,
+        deterministic: bool = False,
+        cluster_size: int = 1,
+        use_2cta_instrs: bool = False,
+        score_mod: cutlass.Constexpr | None = None,
+        score_mod_bwd: cutlass.Constexpr | None = None,
+        mask_mod: cutlass.Constexpr | None = None,
+        has_aux_tensors: cutlass.Constexpr = False,
+        subtile_factor: cutlass.Constexpr[int] = 1,
+        tile_m_dq: int = 128,
+        tile_n_dq: int = 128,
+        tile_m_dkdv: int = 128,
+        tile_n_dkdv: int = 64,
+        window_size_left: int | None = None,
+        window_size_right: int | None = None,
+        use_clc_scheduler: bool = False,
+    ):
+        """Initialization."""
+        head_dim_v = head_dim if head_dim_v is None else head_dim_v
+        assert head_dim == 256 and head_dim_v == 256, (
+            "SM100 dedicated backward kernel only supports (head_dim, head_dim_v) = (256, 256)"
+        )
+        assert not is_local, "SM100 backward with head_dim=256 does not support local attention"
+        assert tile_m_dq == 128 and tile_n_dq == 128, (
+            "SM100 dedicated backward kernel only supports tile_m_dq=128 and tile_n_dq=128"
+        )
+        assert tile_m_dkdv == 128 and tile_n_dkdv == 64, (
+            "SM100 dedicated backward kernel only supports tile_m_dkdv=128 and tile_n_dkdv=64"
+        )
+        assert score_mod is None and score_mod_bwd is None and mask_mod is None, (
+            "SM100 backward with head_dim=256 does not support score_mod/mask_mod"
+        )
+        assert not deterministic, (
+            "SM100 backward with head_dim=256 does not support deterministic mode"
+        )
+        assert not has_aux_tensors, "SM100 backward with head_dim=256 does not support aux_tensors"
+        assert cluster_size in (1, 2), (
+            "SM100 backward with head_dim=256 only supports cluster_size in {1, 2}"
+        )
+        assert use_2cta_instrs, "SM100 backward with head_dim=256 requires use_2cta_instrs=True"
+        # subtile_factor is accepted for interface parity with FlashAttentionBackwardSm100,
+        # but this dedicated kernel uses fixed internal behavior.
+
+        self.acc_dtype = cutlass.Float32
+        self.is_causal = is_causal
+        self.window_size_left = (
+            None if (window_size_left is None or window_size_left < 0) else window_size_left
+        )
+        self.window_size_right = (
+            None if (window_size_right is None or window_size_right < 0) else window_size_right
+        )
+        self.tile_m_dq = tile_m_dq
+        self.tile_n_dq = tile_n_dq
+        self.tile_m_dkdv = tile_m_dkdv
+        self.tile_n_dkdv = tile_n_dkdv
+        self.use_clc_scheduler = use_clc_scheduler
+
+        self.dq_kernel = BlackwellFusedMultiHeadAttentionBackwardDQKernel(
+            self.acc_dtype,
+            (self.tile_m_dq, self.tile_n_dq, 256),
+            self.is_causal,
+            self.window_size_left,
+            self.window_size_right,
+            False,  # is_persistent
+            False,  # split_head
+            use_clc_scheduler=self.use_clc_scheduler,
+        )
+        self.dkdv_kernel = BlackwellFusedMultiHeadAttentionBackwardDKDVKernel(
+            self.acc_dtype,
+            (self.tile_m_dkdv, self.tile_n_dkdv, 256),
+            self.is_causal,
+            self.window_size_left,
+            self.window_size_right,
+            use_clc_scheduler=self.use_clc_scheduler,
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        Q: cute.Tensor,
+        K: cute.Tensor,
+        V: cute.Tensor,
+        dO: cute.Tensor,
+        lse_log2: cute.Tensor,
+        dpsum: cute.Tensor,
+        dQ_accum: cute.Tensor | None,
+        dK: cute.Tensor,
+        dV: cute.Tensor,
+        scale_softmax: cutlass.Float32,
+        cumulative_s_q: cute.Tensor | None,
+        cumulative_s_k: cute.Tensor | None,
+        seqused_q: cute.Tensor | None = None,
+        seqused_k: cute.Tensor | None = None,
+        window_size_left: Int32 | None = None,
+        window_size_right: Int32 | None = None,
+        dQ_semaphore: cute.Tensor | None = None,
+        dK_semaphore: cute.Tensor | None = None,
+        dV_semaphore: cute.Tensor | None = None,
+        aux_tensors: tuple[cute.Tensor] | None = None,
+        block_sparse_tensors: cute.Tensor | None = None,
+        stream: cuda.CUstream = None,
+    ):
+        """Host function to launch CuTeDSL kernel."""
+        assert seqused_q is None and seqused_k is None, (
+            "SM100 backward with head_dim=256 does not support seqused_q/seqused_k"
+        )
+        assert window_size_left is None and window_size_right is None, (
+            "SM100 backward with head_dim=256 uses constructor-provided window sizes"
+        )
+        assert dQ_semaphore is None and dK_semaphore is None and dV_semaphore is None, (
+            "SM100 backward with head_dim=256 does not use semaphores"
+        )
+        assert block_sparse_tensors is None, (
+            "SM100 backward with head_dim=256 does not support block sparse tensors"
+        )
+        assert aux_tensors is None or len(aux_tensors) == 0, (
+            "SM100 backward with head_dim=256 does not support aux_tensors"
+        )
+        assert dQ_accum is not None, (
+            "SM100 backward with head_dim=256 expects dQ tensor at dQ_accum slot"
+        )
+        dQ = dQ_accum
+        varlen = cumulative_s_q is not None or cumulative_s_k is not None
+        q_rank = cute.rank(Q.layout)
+        k_rank = cute.rank(K.layout)
+        if cutlass.const_expr(q_rank == 5):
+            h_q = Q.shape[2] * Q.shape[3]
+        elif cutlass.const_expr(q_rank == 4):
+            h_q = Q.shape[2]
+        else:
+            h_q = Q.shape[1]
+        if cutlass.const_expr(k_rank == 5):
+            h_k = K.shape[2]
+        elif cutlass.const_expr(k_rank == 4):
+            h_k = K.shape[2]
+        else:
+            h_k = K.shape[1]
+        h_r = h_q // h_k
+        if cutlass.const_expr(cumulative_s_q is not None):
+            b = cumulative_s_q.shape[0] - 1
+        elif cutlass.const_expr(cumulative_s_k is not None):
+            b = cumulative_s_k.shape[0] - 1
+        else:
+            b = Q.shape[0]
+
+        Q = _as_bshkrd_tensor(Q, h_k, h_r, varlen)
+        K = _as_bshkrd_tensor(K, h_k, 1, varlen)
+        V = _as_bshkrd_tensor(V, h_k, 1, varlen)
+        dQ = _as_bshkrd_tensor(dQ, h_k, h_r, varlen)
+        dK = _as_bshkrd_tensor(dK, h_k, 1, varlen)
+        dV = _as_bshkrd_tensor(dV, h_k, 1, varlen)
+        dO = _as_bshkrd_tensor(dO, h_k, h_r, varlen)
+        scaled_LSE = _as_shhb_tensor(lse_log2, h_k, h_r, b, varlen)
+        sum_OdO = _as_shhb_tensor(dpsum, h_k, h_r, b, varlen)
+
+        # Keep original order: dQ first, then dKdV.
+        self.dq_kernel(
+            Q,
+            K,
+            V,
+            dQ,
+            dO,
+            scaled_LSE,
+            sum_OdO,
+            cumulative_s_q,
+            cumulative_s_k,
+            scale_softmax,
+            stream,
+        )
+        self.dkdv_kernel(
+            Q,
+            K,
+            V,
+            dK,
+            dV,
+            dO,
+            scaled_LSE,
+            sum_OdO,
+            cumulative_s_q,
+            cumulative_s_k,
+            scale_softmax,
+            stream,
+        )

--- a/flashmask/flash_mask/flash_attn_v4/sm100_hd256_2cta_fmha_backward_dkdvkernel.py
+++ b/flashmask/flash_mask/flash_attn_v4/sm100_hd256_2cta_fmha_backward_dkdvkernel.py
@@ -1,0 +1,3155 @@
+# Copyright (c) 2025, Siyu Wang, Shengbin Di, Yuxi Chi, Linfeng Zheng, Haoyan Huang, Lanbo Li, Yun Zhong, Man Yuan, Minmin Sun, Yong Li, Wei Lin.
+
+"""Fused multi-head attention (FMHA) backward for the SM100 architecture using CUTE DSL.
+
+Constraints:
+* Supported head dimensions: 256 only
+* cta_tiler_mn must be 64,128
+* Batch size must be the same for Q, K, and V tensors
+"""
+
+import enum
+import math
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.nvgpu import cpasync, tcgen05
+import cutlass.utils as utils
+import cutlass.pipeline as pipeline
+import cutlass.utils.blackwell_helpers as sm100_utils
+from cutlass.cute.typing import Int32
+from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
+
+from cutlass.utils import ClcDynamicPersistentTileScheduler
+from flash_mask.flash_attn_v4.tile_scheduler import (
+    ClcState,
+    SM100_TMEM_CAPACITY_COLUMNS,
+    make_sm100_thread_cooperative_group as make_thread_cooperative_group,
+    Sm100FmhaClcDynamicTileSchedulerParams as FmhaClcDynamicTileSchedulerParams,
+    Sm100FmhaClcDynamicTileScheduler as FmhaClcDynamicTileScheduler,
+    Sm100FmhaStaticTileSchedulerParams as FmhaStaticTileSchedulerParams,
+)
+
+
+LAYOUT_RANK_CONSTANT = 3
+
+
+@cute.jit
+def split_wg(
+    t: cute.Tensor,
+    num_warp_groups: Int32,
+    wg_idx: Int32,
+) -> cute.Tensor:
+    """Split warp group."""
+    # dishengbin, TODO：need to double check if more efficient to split in other dimensions
+    ret = None
+    if cutlass.const_expr(cute.rank(t.layout) == LAYOUT_RANK_CONSTANT):
+        p = cute.composition(
+            t,
+            cute.make_layout(
+                (
+                    t.shape[0],
+                    t.shape[1],
+                    (num_warp_groups, cute.size(t, mode=[2]) // num_warp_groups),
+                )
+            ),
+        )
+        ret = p[None, None, (wg_idx, None)]
+    else:
+        p = cute.composition(
+            t,
+            cute.make_layout(
+                (
+                    t.shape[0],
+                    t.shape[1],
+                    t.shape[2],
+                    (num_warp_groups, cute.size(t, mode=[3]) // num_warp_groups),
+                )
+            ),
+        )
+        ret = p[None, None, None, (wg_idx, None)]
+    return ret
+
+
+class MaskType(enum.Enum):
+    """Mask type used in FMHA backward."""
+
+    NO_MASK = enum.auto()
+    RESIDUAL_MASK_FOR_BACKWARD = enum.auto()
+    CAUSAL_MASK_FOR_BACKWARD = enum.auto()
+
+
+def Tmemory_offset(lane, col):
+    """Tensor memory offset."""
+    return (lane << 16) + col
+
+
+permute_order = (0, 1, 2, 3, 4)
+
+
+class BlackwellFusedMultiHeadAttentionBackwardDKDVKernel:
+    """FMHA backward class for executing CuTeDSL kernel."""
+
+    def __init__(
+        self,
+        acc_dtype: type[cutlass.Numeric],
+        cta_tiler: tuple[int, int, int],
+        is_causal: bool,
+        window_size_left: int | None,
+        window_size_right: int | None,
+        use_clc_scheduler: bool = False,
+    ):
+        """Initialization."""
+        self.acc_dtype = acc_dtype
+        self.cta_tiler = cta_tiler
+        self.use_clc_scheduler = use_clc_scheduler
+        self.sched_warp_id = 10 if use_clc_scheduler else None
+        # TODO: need check, not sure whether need to *2 if 2cta
+        self.tile_shape_Q = cta_tiler[0]
+        self.tile_shape_K = cta_tiler[1]
+        self.tile_shape_dQ_K = cta_tiler[2]
+        self.tile_shape_dV_dO = cta_tiler[2]
+        # For S
+        self.KQ_mma_tiler = (
+            cta_tiler[1] * 2,
+            cta_tiler[0],
+            cta_tiler[2],
+        )
+        # For dP
+        self.VdO_mma_tiler = (
+            cta_tiler[1] * 2,
+            cta_tiler[0],
+            cta_tiler[2],
+        )
+        # For dV
+        self.PdO_mma_tiler = (
+            cta_tiler[1] * 2,
+            cta_tiler[2],
+            cta_tiler[0],
+        )
+        # For dK
+        self.dSQ_mma_tiler = (
+            cta_tiler[1] * 2,
+            cta_tiler[2],
+            cta_tiler[0],
+        )
+        # For dQ, dishengbin, need to remove
+        self.dSK_mma_tiler = (
+            cta_tiler[0] * 2,
+            cta_tiler[2],
+            cta_tiler[1],
+        )
+        self.cluster_shape_mn = (2, 1)
+        self.is_causal = is_causal
+        self.window_size_left: int = -1 if window_size_left is None else window_size_left
+        self.window_size_right: int = -1 if window_size_right is None else window_size_right
+        self.has_sliding_window = False
+        if self.window_size_left > 0 or self.window_size_right > 0:
+            self.has_sliding_window = True
+        if self.is_causal:
+            self.window_size_right = 0
+
+        self.compute_warp_id = (0, 1, 2, 3, 4, 5, 6, 7)
+        self.mma_warp_id = 8
+        self.load_warp_id = 9
+        self.empty_warp_id = 10
+
+        self.num_compute_warps = 8
+
+        self.tmem_alloc_cols = SM100_TMEM_CAPACITY_COLUMNS
+
+        self.threads_per_warp = 32
+        self.threads_per_cta = self.threads_per_warp * (self.num_compute_warps + 4)
+
+        self.cta_sync_bar_id = 0
+        self.tmem_alloc_sync_bar_id = 1
+        self.compute_sync_bar_id = 2
+        self.epilogue_sync_bar_id = 3
+        self.reduce_sync_bar_id = 4
+
+        self.tmem_dK_offset = 0
+        self.tmem_dV_offset = Tmemory_offset(0, cta_tiler[2] // 2)
+        self.tmem_dP_offset = Tmemory_offset(0, cta_tiler[2] + cta_tiler[0] // 2)
+        self.tmem_S_offset = Tmemory_offset(0, cta_tiler[2])
+
+        self.num_regs_reduce = 152
+        self.num_regs_compute = 128
+        self.num_regs_mma = 128
+        self.num_regs_empty = 96
+        self.num_regs_load = 96
+
+        self.buffer_align_bytes = 128
+
+    def _setup_attributes(self):
+        """Settings for pipeline stage."""
+        self.load_mma_Q_stage = 1
+        self.load_mma_K_stage = 1
+        self.load_mma_V_stage = 1
+        self.load_mma_QT_stage = 1
+        self.load_mma_dO_stage = 1
+        self.load_compute_LSE_stage = 1
+        self.load_compute_sum_OdO_stage = 1
+        self.mma_compute_S_stage = 1
+        self.mma_compute_dP_stage = 1
+        self.compute_mma_P_stage = 1
+        self.compute_mma_dS_stage = 1
+        self.mma_compute_dKdV_stage = 2
+
+        if cutlass.const_expr(self.use_clc_scheduler):
+            self.num_clc_stage = 1
+            self.num_clc_response_bytes = 16
+
+    @cute.jit
+    def __call__(
+        self,
+        Q: cute.Tensor,
+        K: cute.Tensor,
+        V: cute.Tensor,
+        dK: cute.Tensor,
+        dV: cute.Tensor,
+        dO: cute.Tensor,
+        scaled_LSE: cute.Tensor,
+        sum_OdO: cute.Tensor,
+        cumulative_s_q: cute.Tensor | None,
+        cumulative_s_k: cute.Tensor | None,
+        scale_softmax: cutlass.Float32,
+        stream: cuda.CUstream,
+    ):
+        """Host function to launch CuTeDSL kernel."""
+        varlen = cumulative_s_q is not None or cumulative_s_k is not None
+        # Infer shape metadata from normalized 5D tensors (B, S, H_k, H_r, D).
+        h_r = Q.shape[3]
+        h_k = Q.shape[2]
+        if cutlass.const_expr(cumulative_s_q is not None):
+            b = cumulative_s_q.shape[0] - 1
+        elif cutlass.const_expr(cumulative_s_k is not None):
+            b = cumulative_s_k.shape[0] - 1
+        else:
+            b = Q.shape[0]
+        problem_shape = (
+            Q.shape[1],
+            K.shape[1],
+            Q.shape[4],
+            ((h_r, h_k), b),
+        )
+        hb = ((h_r, h_k), b)
+        # (b, s, h_k, h_r, d) -> (s, d, ((h_r, h_k), b))
+        Q = cute.make_tensor(
+            Q.iterator,
+            cute.make_layout(
+                (Q.shape[1], Q.shape[4], hb),
+                stride=(
+                    cute.assume(Q.stride[1], divby=64),
+                    Q.stride[4],
+                    (
+                        (Q.shape[4], Q.shape[4] * Q.shape[3]),
+                        (
+                            0
+                            if varlen
+                            else cute.assume(Q.shape[1] * Q.shape[4] * h_r * h_k, divby=64)
+                        ),
+                    ),
+                ),
+            ),
+        )
+        # (b, s, h_k, 1, d) -> (s, d, ((1, h_k), b))
+        K = cute.make_tensor(
+            K.iterator,
+            cute.make_layout(
+                (K.shape[1], K.shape[4], hb),
+                stride=(
+                    cute.assume(K.stride[1], divby=64),
+                    K.stride[4],
+                    (
+                        (0, K.shape[4]),
+                        (0 if varlen else cute.assume(K.shape[1] * K.shape[4] * 1 * h_k, divby=64)),
+                    ),
+                ),
+            ),
+        )
+        # (b, s, h_k, 1, d) -> (s, d, ((1, h_k), b))
+        V = cute.make_tensor(
+            V.iterator,
+            cute.make_layout(
+                (V.shape[1], V.shape[4], hb),
+                stride=(
+                    cute.assume(V.stride[1], divby=64),
+                    V.stride[4],
+                    (
+                        (0, V.shape[4]),
+                        (0 if varlen else cute.assume(V.shape[1] * V.shape[4] * 1 * h_k, divby=64)),
+                    ),
+                ),
+            ),
+        )
+        # (s, d, ((h_r, h_k), b)) -> (d, s, ((h_r, h_k), b))
+        QT = cute.make_tensor(
+            Q.iterator,
+            cute.make_layout(
+                (Q.shape[1], Q.shape[0], Q.shape[2]),
+                stride=(
+                    Q.stride[1],
+                    Q.stride[0],
+                    Q.stride[2],
+                ),
+            ),
+        )
+        dK = cute.make_tensor(dK.iterator, K.layout)
+        dV = cute.make_tensor(dV.iterator, V.layout)
+        # (s, d, ((h_r, h_k), b))
+        dO = cute.make_tensor(dO.iterator, Q.layout)
+
+        # (s, d, ((h_r, h_k), b)) -> (d, s, ((h_r, h_k), b))
+        dOT = cute.make_tensor(
+            dO.iterator,
+            cute.make_layout(
+                (dO.shape[1], dO.shape[0], dO.shape[2]),
+                stride=(
+                    dO.stride[1],
+                    dO.stride[0],
+                    dO.stride[2],
+                ),
+            ),
+        )
+
+        self.Q_major_mode = utils.LayoutEnum.from_tensor(Q).mma_major_mode()
+        self.K_major_mode = utils.LayoutEnum.from_tensor(K).mma_major_mode()
+        self.dK_major_mode = utils.LayoutEnum.from_tensor(dK).mma_major_mode()
+        self.V_major_mode = utils.LayoutEnum.from_tensor(V).mma_major_mode()
+        self.dV_major_mode = utils.LayoutEnum.from_tensor(dV).mma_major_mode()
+        self.dO_major_mode = utils.LayoutEnum.from_tensor(dO).mma_major_mode()
+
+        if cutlass.const_expr(self.Q_major_mode != tcgen05.OperandMajorMode.K):
+            raise RuntimeError(f"The layout of q is not supported: {self.Q_major_mode}")
+        if cutlass.const_expr(self.K_major_mode != tcgen05.OperandMajorMode.K):
+            raise RuntimeError("The layout of k is not supported")
+        if cutlass.const_expr(self.dK_major_mode != tcgen05.OperandMajorMode.K):
+            raise RuntimeError("The layout of dk is not supported")
+        if cutlass.const_expr(self.V_major_mode != tcgen05.OperandMajorMode.K):
+            raise RuntimeError("The layout of v is not supported")
+        if cutlass.const_expr(self.dV_major_mode != tcgen05.OperandMajorMode.K):
+            raise RuntimeError("The layout of dv is not supported")
+
+        self._setup_attributes()
+
+        cta_group = tcgen05.CtaGroup.TWO
+        PT_source = tcgen05.OperandSource.SMEM
+
+        # compute S
+        KQ_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            K.element_type,
+            tcgen05.OperandMajorMode.K,
+            tcgen05.OperandMajorMode.K,
+            self.acc_dtype,
+            cta_group,
+            self.KQ_mma_tiler[:2],
+        )
+        # compute dP
+        VdO_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            V.element_type,
+            tcgen05.OperandMajorMode.K,
+            tcgen05.OperandMajorMode.K,
+            self.acc_dtype,
+            cta_group,
+            self.VdO_mma_tiler[:2],
+        )
+        # compute dV
+        PdO_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            dO.element_type,
+            tcgen05.OperandMajorMode.K,
+            tcgen05.OperandMajorMode.MN,
+            self.acc_dtype,
+            cta_group,
+            self.PdO_mma_tiler[:2],
+            PT_source,
+        )
+        # compute dK
+        dSQ_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            Q.element_type,
+            tcgen05.OperandMajorMode.K,
+            tcgen05.OperandMajorMode.MN,
+            self.acc_dtype,
+            cta_group,
+            self.dSQ_mma_tiler[:2],
+        )
+        # compute dQ
+        # dishengbin, need to remove, but used in dS_mem_layout_staged
+        dSK_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            K.element_type,
+            tcgen05.OperandMajorMode.MN,
+            tcgen05.OperandMajorMode.MN,
+            self.acc_dtype,
+            cta_group,
+            self.dSK_mma_tiler[:2],
+        )
+
+        atom_thr_size = cute.size(KQ_tiled_mma.thr_id.shape)
+        self.cluster_shape_mnk = (*self.cluster_shape_mn, 1)  # type: ignore[assignment]
+        self.cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout(self.cluster_shape_mnk),
+            (atom_thr_size,),
+        )
+
+        K_smem_layout_staged = sm100_utils.make_smem_layout_a(
+            KQ_tiled_mma,
+            self.KQ_mma_tiler,
+            K.element_type,
+            1,
+        )
+        Q_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            KQ_tiled_mma,
+            self.KQ_mma_tiler,
+            Q.element_type,
+            self.load_mma_Q_stage,
+        )
+        V_smem_layout_staged = sm100_utils.make_smem_layout_a(
+            VdO_tiled_mma,
+            self.VdO_mma_tiler,
+            V.element_type,
+            1,
+        )
+        dO_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            VdO_tiled_mma,
+            self.VdO_mma_tiler,
+            dO.element_type,
+            self.load_mma_dO_stage,
+        )
+        # dishengbin, need to remove, but used for sPT, need to double check
+        dS_smem_layout_staged = sm100_utils.make_smem_layout_a(
+            dSK_tiled_mma,
+            self.dSK_mma_tiler,
+            Q.element_type,
+            self.compute_mma_dS_stage,
+        )
+        dST_smem_layout_staged = sm100_utils.make_smem_layout_a(
+            dSQ_tiled_mma,
+            self.dSQ_mma_tiler,
+            Q.element_type,
+            self.compute_mma_dS_stage,
+        )
+        tiled_mma = dSQ_tiled_mma
+        is_k_major = tiled_mma.op.a_major_mode == tcgen05.OperandMajorMode.K
+        a_major_mode = tcgen05.OperandMajorMode.K if is_k_major else tcgen05.OperandMajorMode.MN
+        tmp = cute.dice(self.dSQ_mma_tiler, (1, None, 1))
+        a_smem_shape = tiled_mma.partition_shape_A(
+            cute.dice(self.dSQ_mma_tiler, (1, None, 1)),
+        )
+        a_smem_shape_mn_k = (
+            cute.size(a_smem_shape[0][0]) * a_smem_shape[1],
+            cute.size(a_smem_shape[0][1]) * a_smem_shape[2],
+        )
+        smem_layout_atom_kind = sm100_utils.get_smem_layout_atom_ab(
+            a_major_mode,
+            K.element_type,
+            a_smem_shape_mn_k,
+        )
+        a_smem_layout_atom = sm100_utils.make_smem_layout_atom(
+            smem_layout_atom_kind,
+            K.element_type,
+        )
+
+        a_smem_shape = cute.append(
+            a_smem_shape,
+            self.compute_mma_dS_stage,
+        )
+        order = (2, 1, 3) if not is_k_major else (1, 2, 3)
+        dST_smem_layout_staged_tmp = sm100_utils.tile_to_mma_shape(
+            a_smem_layout_atom,
+            a_smem_shape,
+            order=order,
+        )
+        QT_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            dSQ_tiled_mma,
+            self.dSQ_mma_tiler,
+            Q.element_type,
+            self.load_mma_QT_stage,
+        )
+        P_smem_layout_staged = sm100_utils.make_smem_layout_a(
+            PdO_tiled_mma,
+            self.PdO_mma_tiler,
+            Q.element_type,
+            self.compute_mma_P_stage,
+        )
+        dOT_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            PdO_tiled_mma,
+            self.PdO_mma_tiler,
+            dO.element_type,
+            self.load_mma_dO_stage,
+        )
+        LSE_smem_layout = cute.make_layout((self.cta_tiler[0], self.load_compute_LSE_stage))
+        sum_OdO_smem_layout = cute.make_layout((self.cta_tiler[0], self.load_compute_sum_OdO_stage))
+
+        tma_load_op = cpasync.CopyBulkTensorTileG2SOp(cta_group)
+        tma_reduce_op = cpasync.CopyReduceBulkTensorTileS2GOp()
+
+        K_smem_layout = cute.select(K_smem_layout_staged, mode=[0, 1, 2])
+        tma_atom_K, tma_tensor_K = cute.nvgpu.make_tiled_tma_atom_A(
+            tma_load_op,
+            K,
+            K_smem_layout,
+            self.KQ_mma_tiler,
+            KQ_tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        V_smem_layout = cute.select(V_smem_layout_staged, mode=[0, 1, 2])
+        tma_atom_V, tma_tensor_V = cute.nvgpu.make_tiled_tma_atom_A(
+            tma_load_op,
+            V,
+            V_smem_layout,
+            self.VdO_mma_tiler,
+            VdO_tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        Q_smem_layout = cute.select(Q_smem_layout_staged, mode=[0, 1, 2])
+        tma_atom_Q, tma_tensor_Q = cute.nvgpu.make_tiled_tma_atom_B(
+            tma_load_op,
+            Q,
+            Q_smem_layout,
+            self.KQ_mma_tiler,
+            KQ_tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+        QT_smem_layout = cute.select(QT_smem_layout_staged, mode=[0, 1, 2])
+        tma_atom_QT, tma_tensor_QT = cute.nvgpu.make_tiled_tma_atom_B(
+            tma_load_op,
+            QT,
+            QT_smem_layout,
+            self.dSQ_mma_tiler,
+            dSQ_tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        dO_smem_layout = cute.select(dO_smem_layout_staged, mode=[0, 1, 2])
+        tma_atom_dO, tma_tensor_dO = cute.nvgpu.make_tiled_tma_atom_B(
+            tma_load_op,
+            dO,
+            dO_smem_layout,
+            self.VdO_mma_tiler,
+            VdO_tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+        dOT_smem_layout = cute.select(dOT_smem_layout_staged, mode=[0, 1, 2])
+        tma_atom_dOT, tma_tensor_dOT = cute.nvgpu.make_tiled_tma_atom_B(
+            tma_load_op,
+            dOT,
+            dOT_smem_layout,
+            self.PdO_mma_tiler,
+            PdO_tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        # for 2cta, tma_copy_QT_bytes is same as the tma_copy_Q_bytes
+        self.tma_copy_Q_bytes = cute.size_in_bytes(Q.element_type, Q_smem_layout) * atom_thr_size
+        self.tma_copy_K_bytes = cute.size_in_bytes(K.element_type, K_smem_layout) * atom_thr_size
+        self.tma_copy_V_bytes = cute.size_in_bytes(V.element_type, V_smem_layout) * atom_thr_size
+        self.tma_copy_dO_bytes = cute.size_in_bytes(dO.element_type, dO_smem_layout) * atom_thr_size
+
+        @cute.struct
+        class SharedStorage:
+            # Pipeline barriers
+            load_mma_Q_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.load_mma_Q_stage * 2]
+            load_mma_K_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.load_mma_K_stage * 2]
+            load_mma_V_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.load_mma_V_stage * 2]
+            load_mma_QT_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.load_mma_QT_stage * 2]
+            load_mma_dO_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.load_mma_dO_stage * 2]
+            load_mma_dOT_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.load_mma_dO_stage * 2]
+            load_compute_lse_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.load_compute_LSE_stage * 2
+            ]
+            load_compute_sum_OdO_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.load_compute_sum_OdO_stage * 2
+            ]
+            mma_compute_S_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.mma_compute_S_stage * 2
+            ]
+            mma_compute_dP_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.mma_compute_dP_stage * 2
+            ]
+            compute_mma_P_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.compute_mma_P_stage * 2
+            ]
+            compute_mma_dS_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.compute_mma_dS_stage * 2
+            ]
+            mma_compute_dKdV_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.mma_compute_dKdV_stage * 2
+            ]
+            tmem_holding_buf: cutlass.Int32
+            tmem_dealloc_mbar_ptr: cutlass.Int64
+            clc_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2]
+            clc_response: cute.struct.MemRange[Int32, 4]
+            # Smem tensors
+            sK: cute.struct.Align[
+                cute.struct.MemRange[K.element_type, cute.cosize(K_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            # only used in 2cta
+            sV: cute.struct.Align[
+                cute.struct.MemRange[V.element_type, cute.cosize(V_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            sQ: cute.struct.Align[
+                cute.struct.MemRange[Q.element_type, cute.cosize(Q_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            sQT: cute.struct.Align[
+                cute.struct.MemRange[Q.element_type, cute.cosize(QT_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            sdO: cute.struct.Align[
+                cute.struct.MemRange[dO.element_type, cute.cosize(dO_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            sdOT: cute.struct.Align[
+                cute.struct.MemRange[dO.element_type, cute.cosize(dOT_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            # only used in 2cta
+            # dishengbin checked whether we need sP
+            sP: cute.struct.Align[
+                cute.struct.MemRange[Q.element_type, cute.cosize(P_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            sdST: cute.struct.Align[
+                cute.struct.MemRange[Q.element_type, cute.cosize(dST_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+
+            sLSE: cute.struct.Align[
+                cute.struct.MemRange[self.acc_dtype, cute.cosize(LSE_smem_layout)],
+                self.buffer_align_bytes,
+            ]
+            sSum_OdO: cute.struct.Align[
+                cute.struct.MemRange[self.acc_dtype, cute.cosize(sum_OdO_smem_layout)],
+                self.buffer_align_bytes,
+            ]
+
+        self.shared_storage = SharedStorage
+
+        # =============================== bwd ===============================
+        K_val = problem_shape[1]
+        _, H_K = problem_shape[3][0]
+        B = problem_shape[3][1]
+        problem_shape_mbh = (
+            cute.ceil_div(K_val, self.cta_tiler[1]),
+            cute.size(B),
+            cute.size(H_K),
+        )
+        if cutlass.const_expr(self.use_clc_scheduler):
+            self.tile_sched_params = FmhaClcDynamicTileSchedulerParams(
+                problem_shape_mbh,
+                (*self.cluster_shape_mn, 1),
+            )
+            bwd_grid = FmhaClcDynamicTileScheduler.get_grid_shape(self.tile_sched_params)
+        else:
+            self.tile_sched_params = FmhaStaticTileSchedulerParams(
+                is_persistent=False,
+                problem_shape_mbh=problem_shape_mbh,
+            )
+            bwd_grid = self._compute_bwd_grid(problem_shape, self.cta_tiler[1])
+            bwd_grid = cute.round_up(bwd_grid, self.cluster_shape_mnk)
+
+        self.dkdv_bwd(
+            KQ_tiled_mma,
+            VdO_tiled_mma,
+            PdO_tiled_mma,
+            dSQ_tiled_mma,
+            tma_atom_K,
+            tma_tensor_K,
+            K,
+            tma_atom_V,
+            tma_tensor_V,
+            tma_atom_Q,
+            tma_tensor_Q,
+            Q,
+            tma_atom_QT,
+            tma_tensor_QT,
+            tma_atom_dO,
+            tma_tensor_dO,
+            tma_atom_dOT,
+            tma_tensor_dOT,
+            dK,
+            dV,
+            scaled_LSE,
+            scale_softmax,
+            sum_OdO,
+            problem_shape,
+            cumulative_s_q,
+            cumulative_s_k,
+            self.cluster_layout_vmnk,
+            K_smem_layout_staged,
+            Q_smem_layout_staged,
+            V_smem_layout_staged,
+            dO_smem_layout_staged,
+            dS_smem_layout_staged,
+            dST_smem_layout_staged,
+            QT_smem_layout_staged,
+            dOT_smem_layout_staged,
+            P_smem_layout_staged,
+            LSE_smem_layout,
+            sum_OdO_smem_layout,
+            self.tile_sched_params,
+        ).launch(
+            grid=bwd_grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=self.cluster_shape_mnk,
+            smem=self.shared_storage.size_in_bytes(),  # type: ignore [attr-defined]
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+
+    @cute.kernel
+    def dkdv_bwd(
+        self,
+        KQ_tiled_mma: cute.TiledMma,
+        VdO_tiled_mma: cute.TiledMma,
+        PdO_tiled_mma: cute.TiledMma,
+        dSQ_tiled_mma: cute.TiledMma,
+        tma_atom_K: cute.CopyAtom,
+        K_in: cute.Tensor,
+        K_ref: cute.Tensor,
+        tma_atom_V: cute.CopyAtom,
+        V_in: cute.Tensor,
+        tma_atom_Q: cute.CopyAtom,
+        Q_in: cute.Tensor,
+        Q_ref: cute.Tensor,
+        tma_atom_QT: cute.CopyAtom,
+        QT_in: cute.Tensor,
+        tma_atom_dO: cute.CopyAtom,
+        dO_in: cute.Tensor,
+        tma_atom_dOT: cute.CopyAtom,
+        dOT_in: cute.Tensor,
+        dK: cute.Tensor,
+        dV: cute.Tensor,
+        LSE: cute.Tensor,
+        scale_softmax: cutlass.Float32,
+        sum_OdO: cute.Tensor,
+        problem_shape: tuple[Int32, Int32, Int32, tuple[tuple[Int32, Int32], Int32]],
+        cumulative_s_q: cute.Tensor | None,
+        cumulative_s_k: cute.Tensor | None,
+        cluster_layout_vmnk: cute.Layout,
+        K_smem_layout_staged: cute.ComposedLayout,
+        Q_smem_layout_staged: cute.ComposedLayout,
+        V_smem_layout_staged: cute.ComposedLayout,
+        dO_smem_layout_staged: cute.ComposedLayout,
+        dS_smem_layout_staged: cute.ComposedLayout,
+        dST_smem_layout_staged: cute.ComposedLayout,
+        QT_smem_layout_staged: cute.ComposedLayout,
+        dOT_smem_layout_staged: cute.ComposedLayout,
+        P_smem_layout_staged: cute.ComposedLayout,
+        LSE_smem_layout: cute.Layout,
+        sum_OdO_smem_layout: cute.Layout,
+        tile_sched_params: FmhaStaticTileSchedulerParams | FmhaClcDynamicTileSchedulerParams,
+    ):
+        """Core CuTeDSL backward kernel."""
+        bidx, bidy, bidz = cute.arch.block_idx()
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        varlen = cumulative_s_q is not None or cumulative_s_k is not None
+
+        mma_tile_coord_v = bidx % cute.size(KQ_tiled_mma.thr_id.shape)
+
+        if warp_idx == self.load_warp_id:
+            cpasync.prefetch_descriptor(tma_atom_K)
+            cpasync.prefetch_descriptor(tma_atom_Q)
+            cpasync.prefetch_descriptor(tma_atom_QT)
+            cpasync.prefetch_descriptor(tma_atom_V)
+            cpasync.prefetch_descriptor(tma_atom_dO)
+            cpasync.prefetch_descriptor(tma_atom_dOT)
+
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+
+        load_mma_Q_producer, load_mma_Q_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=self.load_mma_Q_stage,
+            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            tx_count=self.tma_copy_Q_bytes,
+            barrier_storage=storage.load_mma_Q_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+        load_mma_K_producer, load_mma_K_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=self.load_mma_K_stage,
+            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            tx_count=self.tma_copy_K_bytes,
+            barrier_storage=storage.load_mma_K_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+        load_mma_V_producer, load_mma_V_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=self.load_mma_V_stage,
+            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            tx_count=self.tma_copy_V_bytes,
+            barrier_storage=storage.load_mma_V_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+        load_mma_QT_producer, load_mma_QT_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=self.load_mma_QT_stage,
+            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            tx_count=self.tma_copy_Q_bytes,
+            barrier_storage=storage.load_mma_QT_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+        load_mma_dO_producer, load_mma_dO_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=self.load_mma_dO_stage,
+            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            tx_count=self.tma_copy_dO_bytes,
+            barrier_storage=storage.load_mma_dO_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+        load_mma_dOT_producer, load_mma_dOT_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=self.load_mma_dO_stage,
+            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            tx_count=self.tma_copy_dO_bytes,
+            barrier_storage=storage.load_mma_dOT_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+        load_compute_LSE_producer, load_compute_LSE_consumer = pipeline.PipelineCpAsync.create(
+            num_stages=self.load_compute_LSE_stage,
+            producer_group=make_thread_cooperative_group(self.threads_per_warp),
+            consumer_group=make_thread_cooperative_group(
+                self.threads_per_warp * self.num_compute_warps
+            ),
+            barrier_storage=storage.load_compute_lse_mbar_ptr.data_ptr(),
+        ).make_participants()
+        load_compute_sum_OdO_producer, load_compute_sum_OdO_consumer = (
+            pipeline.PipelineCpAsync.create(
+                num_stages=self.load_compute_sum_OdO_stage,
+                producer_group=make_thread_cooperative_group(self.threads_per_warp),
+                consumer_group=make_thread_cooperative_group(
+                    self.threads_per_warp * self.num_compute_warps
+                ),
+                barrier_storage=storage.load_compute_sum_OdO_mbar_ptr.data_ptr(),
+            ).make_participants()
+        )
+        mma_compute_S_producer, mma_compute_S_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=self.mma_compute_S_stage,
+            producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            consumer_group=make_thread_cooperative_group(
+                self.num_compute_warps * self.threads_per_warp * cluster_layout_vmnk.shape[0][0]
+            ),
+            barrier_storage=storage.mma_compute_S_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+        mma_compute_dP_producer, mma_compute_dP_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=self.mma_compute_dP_stage,
+            producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            consumer_group=make_thread_cooperative_group(
+                self.num_compute_warps * self.threads_per_warp * cluster_layout_vmnk.shape[0][0]
+            ),
+            barrier_storage=storage.mma_compute_dP_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+        compute_mma_P_producer, compute_mma_P_consumer = pipeline.PipelineAsyncUmma.create(
+            num_stages=self.compute_mma_P_stage,
+            producer_group=make_thread_cooperative_group(
+                self.num_compute_warps * self.threads_per_warp * cluster_layout_vmnk.shape[0][0]
+            ),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            barrier_storage=storage.compute_mma_P_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+        compute_mma_dS_producer, compute_mma_dS_consumer = pipeline.PipelineAsyncUmma.create(
+            num_stages=self.compute_mma_dS_stage,
+            producer_group=make_thread_cooperative_group(
+                self.num_compute_warps * self.threads_per_warp * cluster_layout_vmnk.shape[0][0]
+            ),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            barrier_storage=storage.compute_mma_dS_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+        mma_compute_dKdV_producer, mma_compute_dKdV_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=self.mma_compute_dKdV_stage,
+            producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            consumer_group=make_thread_cooperative_group(
+                self.num_compute_warps * self.threads_per_warp * cluster_layout_vmnk.shape[0][0]
+            ),
+            barrier_storage=storage.mma_compute_dKdV_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+
+        cute.arch.barrier(barrier_id=self.cta_sync_bar_id, number_of_threads=self.threads_per_cta)
+
+        # setup mma
+        sQ = storage.sQ.get_tensor(Q_smem_layout_staged.outer, swizzle=Q_smem_layout_staged.inner)
+        sK = storage.sK.get_tensor(K_smem_layout_staged.outer, swizzle=K_smem_layout_staged.inner)
+        sV = storage.sV.get_tensor(V_smem_layout_staged.outer, swizzle=V_smem_layout_staged.inner)
+        sdO = storage.sdO.get_tensor(
+            dO_smem_layout_staged.outer, swizzle=dO_smem_layout_staged.inner
+        )
+        sLSE = storage.sLSE.get_tensor(LSE_smem_layout)
+        sSum_OdO = storage.sSum_OdO.get_tensor(sum_OdO_smem_layout)
+        tmem_holding_buf = storage.tmem_holding_buf
+        # for 2cta, QT use different mem from Q
+
+        sQT = storage.sQT.get_tensor(
+            QT_smem_layout_staged.outer, swizzle=QT_smem_layout_staged.inner
+        )
+        sdST = storage.sdST.get_tensor(
+            dST_smem_layout_staged.outer, swizzle=dST_smem_layout_staged.inner
+        )
+        tP_fake_ptr = cute.make_ptr(sQ.element_type, 0, cute.AddressSpace.tmem)
+        tP = cute.make_tensor(tP_fake_ptr, P_smem_layout_staged.outer)
+
+        sP = storage.sP.get_tensor(P_smem_layout_staged.outer, swizzle=P_smem_layout_staged.inner)
+
+        sdOT = storage.sdOT.get_tensor(
+            dOT_smem_layout_staged.outer, swizzle=dOT_smem_layout_staged.inner
+        )
+
+        # tSTrK shape : (MMA, MMA_M, MMA_K, STAGE)
+        tSTrK = KQ_tiled_mma.make_fragment_A(sK)
+        # tSTrQ shape : (MMA, MMA_N, MMA_K, STAGE)
+        tSTrQ = KQ_tiled_mma.make_fragment_B(sQ)
+
+        # tdPTrV shape : (MMA, MMA_M, MMA_K, STAGE)
+        tdPTrV = VdO_tiled_mma.make_fragment_A(sV)
+        # tdPTrdO shape : (MMA, MMA_N, MMA_K, STAGE)
+        tdPTrdO = VdO_tiled_mma.make_fragment_B(sdO)
+
+        # tdKrdST shape: (MMA, MMA_M, MMA_K, STAGE)
+        tdKrdST = dSQ_tiled_mma.make_fragment_A(sdST)
+        # tdKrQT shape : (MMA, MMA_N, MMA_K, STAGE)
+        tdKrQT = dSQ_tiled_mma.make_fragment_B(sQT)
+
+        tmem_alloc_barrier = pipeline.NamedBarrier(
+            barrier_id=self.tmem_alloc_sync_bar_id,
+            num_threads=self.threads_per_cta,
+        )
+
+        tmem = utils.TmemAllocator(
+            storage.tmem_holding_buf,
+            barrier_for_retrieve=tmem_alloc_barrier,
+            allocator_warp_id=self.load_warp_id,
+            is_two_cta=True,
+            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar_ptr,
+        )
+
+        tmem.allocate(self.tmem_alloc_cols)
+
+        # wait for tmem allocation and retrieve the pointer
+        tmem.wait_for_alloc()
+        tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+
+        # Cluster arrive after barrier init
+        # is_relaxed=False has memory consistency guarantee
+        pipeline_init_arrive(cluster_shape_mn=cluster_layout_vmnk, is_relaxed=False)
+
+        if cutlass.const_expr(self.use_clc_scheduler):
+            clc_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+            cluster_size = cute.size(self.cluster_shape_mnk)
+            num_clc_consumer_threads = self.threads_per_warp * (
+                1  # sched_warp (CTA 0 only)
+                + cluster_size
+                * (
+                    len(self.compute_warp_id)
+                    + 1  # mma_warp
+                    + 1  # load_warp
+                )
+            )
+            clc_pipeline_consumer_group = pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, num_clc_consumer_threads
+            )
+            clc_response_ptr = storage.clc_response.data_ptr()
+            clc = ClcState.create(
+                hw_scheduler=ClcDynamicPersistentTileScheduler.create(
+                    self.tile_sched_params.clc_hw_params(),
+                    cute.arch.block_idx(),
+                    cute.arch.grid_dim(),
+                    clc_response_ptr,
+                ),
+                pipeline=pipeline.PipelineClcFetchAsync.create(
+                    barrier_storage=storage.clc_mbar_ptr.data_ptr(),
+                    num_stages=self.num_clc_stage,
+                    producer_group=clc_pipeline_producer_group,
+                    consumer_group=clc_pipeline_consumer_group,
+                    tx_count=self.num_clc_response_bytes,
+                    cta_layout_vmnk=cluster_layout_vmnk,
+                    defer_sync=True,
+                ),
+                consumer_state=pipeline.make_pipeline_state(
+                    pipeline.PipelineUserType.Consumer, self.num_clc_stage
+                ),
+                producer_state=pipeline.make_pipeline_state(
+                    pipeline.PipelineUserType.Producer, self.num_clc_stage
+                ),
+            )
+            tile_sched = FmhaClcDynamicTileScheduler.create(
+                tile_sched_params,
+                cute.arch.block_idx(),
+                cute.arch.grid_dim(),
+                clc_response_ptr,
+                clc,
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+        else:
+            clc = None
+            clc_response_ptr = None
+
+        tSTtST_shape = KQ_tiled_mma.partition_shape_C(cute.select(self.KQ_mma_tiler, mode=[0, 1]))
+        tSTtST = KQ_tiled_mma.make_fragment_C(tSTtST_shape)
+        # tSTtST shape : (MMA, MMA_M, MMA_N)
+        tSTtST = cute.make_tensor(tmem_ptr + self.tmem_S_offset, tSTtST.layout)
+
+        # tdVrP shape : (MMA, MMA_M, MMA_K, STAGE)
+        tdVrP = PdO_tiled_mma.make_fragment_A(sP)
+        # tdVrdOT shape : (MMA, MMA_N, MMA_K, STAGE)
+        tdVrdOT = PdO_tiled_mma.make_fragment_B(sdOT)
+
+        tdPTtdPT_shape = VdO_tiled_mma.partition_shape_C(
+            cute.select(self.VdO_mma_tiler, mode=[0, 1])
+        )
+        tdPTtdPT = VdO_tiled_mma.make_fragment_C(tdPTtdPT_shape)
+        # tdPTtdPT shape : (MMA, MMA_M, MMA_N)
+        tdPTtdPT = cute.make_tensor(tmem_ptr + self.tmem_dP_offset, tdPTtdPT.layout)
+
+        tdKtdK_shape = dSQ_tiled_mma.partition_shape_C(cute.select(self.dSQ_mma_tiler, mode=[0, 1]))
+        tdKtdK = dSQ_tiled_mma.make_fragment_C(tdKtdK_shape)
+        # tdKtdK shape : (MMA, MMA_M, MMA_N)
+        tdKtdK = cute.make_tensor(tmem_ptr + self.tmem_dK_offset, tdKtdK.layout)
+
+        tdVtdV_shape = PdO_tiled_mma.partition_shape_C(cute.select(self.PdO_mma_tiler, mode=[0, 1]))
+        tdVtdV = PdO_tiled_mma.make_fragment_C(tdVtdV_shape)
+        # tdVtdV shape : (MMA, MMA_M, MMA_N)
+        tdVtdV = cute.make_tensor(tmem_ptr + self.tmem_dV_offset, tdVtdV.layout)
+
+        # get the current batch problem shape
+
+        if cutlass.const_expr(self.use_clc_scheduler):
+            # ===== CLC PERSISTENT PATH: per-warp while loops =====
+            cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+            is_first_cta_in_cluster = cta_rank_in_cluster == 0
+            is_sched_warp = warp_idx == self.sched_warp_id and is_first_cta_in_cluster
+
+            # Register allocation ONCE (before any loop)
+            if warp_idx == self.load_warp_id:
+                cute.arch.warpgroup_reg_dealloc(self.num_regs_load)
+            elif warp_idx == self.mma_warp_id:
+                cute.arch.warpgroup_reg_alloc(self.num_regs_mma)
+            elif warp_idx >= self.compute_warp_id[0] and warp_idx <= self.compute_warp_id[-1]:
+                cute.arch.warpgroup_reg_alloc(self.num_regs_compute)
+            else:
+                cute.arch.warpgroup_reg_dealloc(self.num_regs_empty)
+
+            # Cluster wait
+            pipeline_init_wait(cluster_shape_mn=cluster_layout_vmnk)
+
+            # ===== SCHEDULER WARP =====
+            if is_sched_warp:
+                while work_tile.is_valid_tile:
+                    tile_sched.prefetch_next_work()
+                    work_tile = tile_sched.advance_to_next_work()
+                tile_sched.producer_tail()
+
+            # ===== LOAD WARP =====
+            elif warp_idx == self.load_warp_id:
+                while work_tile.is_valid_tile:
+                    # Decode coordinates from CLC work tile
+                    blk_coord_k = work_tile.tile_idx[0]
+                    blk_coord_b = work_tile.tile_idx[2][0]
+                    blk_coord_h_k = work_tile.tile_idx[2][1]
+                    blk_coord = (
+                        Int32(0),
+                        blk_coord_k,
+                        Int32(0),
+                        ((Int32(0), blk_coord_h_k), blk_coord_b),
+                    )
+                    seqlen_q_cur_batch = Q_ref.shape[0]
+                    seqlen_k_cur_batch = K_ref.shape[0]
+                    blk_offset = (Int32(0), Int32(0), Int32(0), ((Int32(0), Int32(0)), Int32(0)))
+                    if cutlass.const_expr(varlen):
+                        assert isinstance(cumulative_s_q, cute.Tensor)
+                        assert isinstance(cumulative_s_k, cute.Tensor)
+                        seqlen_q_cur_batch = (
+                            cumulative_s_q[blk_coord_b + 1] - cumulative_s_q[blk_coord_b]
+                        )
+                        seqlen_k_cur_batch = (
+                            cumulative_s_k[blk_coord_b + 1] - cumulative_s_k[blk_coord_b]
+                        )
+                        blk_offset = (
+                            cumulative_s_q[blk_coord_b],
+                            cumulative_s_k[blk_coord_b],
+                            Int32(0),
+                            ((Int32(0), Int32(0)), Int32(0)),
+                        )
+                    iter_start, iter_end = self.get_Q_block_min_max(
+                        seqlen_q_cur_batch,
+                        seqlen_k_cur_batch,
+                        blk_coord_k,
+                        is_2cta=True,
+                    )
+                    iter_count = (iter_end - iter_start) * problem_shape[3][0][0]
+                    if iter_count <= 0:
+                        if blk_coord_k * self.tile_shape_K < seqlen_k_cur_batch:
+                            problem_shape_cur_batch = (
+                                seqlen_q_cur_batch,
+                                seqlen_k_cur_batch,
+                                problem_shape[2],
+                                problem_shape[3],
+                            )
+                            self.epilogue_clear(
+                                blk_coord, blk_offset, problem_shape_cur_batch, dK, dV
+                            )
+                    else:
+                        problem_shape_cur_batch = (
+                            seqlen_q_cur_batch,
+                            seqlen_k_cur_batch,
+                            problem_shape[2],
+                            problem_shape[3],
+                        )
+                        (
+                            load_mma_Q_producer,
+                            load_mma_K_producer,
+                            load_mma_V_producer,
+                            load_compute_LSE_producer,
+                            load_mma_dO_producer,
+                            load_mma_dOT_producer,
+                            load_compute_sum_OdO_producer,
+                            load_mma_QT_producer,
+                        ) = self.load(
+                            K_in,
+                            V_in,
+                            Q_in,
+                            QT_in,
+                            dO_in,
+                            dOT_in,
+                            LSE,
+                            sum_OdO,
+                            sK,
+                            sQ,
+                            sQT,
+                            sV,
+                            sdO,
+                            sdOT,
+                            sLSE,
+                            sSum_OdO,
+                            KQ_tiled_mma,
+                            VdO_tiled_mma,
+                            PdO_tiled_mma,
+                            dSQ_tiled_mma,
+                            tma_atom_K,
+                            tma_atom_Q,
+                            tma_atom_QT,
+                            tma_atom_V,
+                            tma_atom_dO,
+                            tma_atom_dOT,
+                            blk_offset,
+                            problem_shape_cur_batch,
+                            varlen,
+                            iter_count,
+                            iter_start,
+                            iter_end,
+                            load_mma_Q_producer,
+                            load_mma_Q_consumer,
+                            load_mma_K_producer,
+                            load_mma_K_consumer,
+                            load_mma_V_producer,
+                            load_mma_V_consumer,
+                            load_compute_LSE_producer,
+                            load_compute_LSE_consumer,
+                            load_mma_dO_producer,
+                            load_mma_dO_consumer,
+                            load_mma_dOT_producer,
+                            load_mma_dOT_consumer,
+                            load_compute_sum_OdO_producer,
+                            load_compute_sum_OdO_consumer,
+                            load_mma_QT_producer,
+                            load_mma_QT_consumer,
+                            blk_coord_k,
+                            blk_coord_h_k,
+                            blk_coord_b,
+                        )
+                    # CLC advance
+                    work_tile = tile_sched.advance_to_next_work()
+                # producer_tail after loop
+                load_mma_K_producer.tail()
+                load_mma_V_producer.tail()
+                load_mma_Q_producer.tail()
+                load_compute_LSE_producer.tail()
+                load_mma_dO_producer.tail()
+                load_mma_dOT_producer.tail()
+                load_compute_sum_OdO_producer.tail()
+                load_mma_QT_producer.tail()
+
+            # ===== MMA WARP =====
+            elif warp_idx == self.mma_warp_id:
+                while work_tile.is_valid_tile:
+                    blk_coord_k = work_tile.tile_idx[0]
+                    blk_coord_b = work_tile.tile_idx[2][0]
+                    blk_coord_h_k = work_tile.tile_idx[2][1]
+                    blk_coord = (
+                        Int32(0),
+                        blk_coord_k,
+                        Int32(0),
+                        ((Int32(0), blk_coord_h_k), blk_coord_b),
+                    )
+                    seqlen_q_cur_batch = Q_ref.shape[0]
+                    seqlen_k_cur_batch = K_ref.shape[0]
+                    blk_offset = (Int32(0), Int32(0), Int32(0), ((Int32(0), Int32(0)), Int32(0)))
+                    if cutlass.const_expr(varlen):
+                        assert isinstance(cumulative_s_q, cute.Tensor)
+                        assert isinstance(cumulative_s_k, cute.Tensor)
+                        seqlen_q_cur_batch = (
+                            cumulative_s_q[blk_coord_b + 1] - cumulative_s_q[blk_coord_b]
+                        )
+                        seqlen_k_cur_batch = (
+                            cumulative_s_k[blk_coord_b + 1] - cumulative_s_k[blk_coord_b]
+                        )
+                        blk_offset = (
+                            cumulative_s_q[blk_coord_b],
+                            cumulative_s_k[blk_coord_b],
+                            Int32(0),
+                            ((Int32(0), Int32(0)), Int32(0)),
+                        )
+                    iter_start, iter_end = self.get_Q_block_min_max(
+                        seqlen_q_cur_batch,
+                        seqlen_k_cur_batch,
+                        blk_coord_k,
+                        is_2cta=True,
+                    )
+                    iter_count = (iter_end - iter_start) * problem_shape[3][0][0]
+                    if iter_count <= 0:
+                        if blk_coord_k * self.tile_shape_K < seqlen_k_cur_batch:
+                            problem_shape_cur_batch = (
+                                seqlen_q_cur_batch,
+                                seqlen_k_cur_batch,
+                                problem_shape[2],
+                                problem_shape[3],
+                            )
+                            self.epilogue_clear(
+                                blk_coord, blk_offset, problem_shape_cur_batch, dK, dV
+                            )
+                    else:
+                        (
+                            mma_compute_S_producer,
+                            mma_compute_dP_producer,
+                            mma_compute_dKdV_producer,
+                            load_mma_Q_consumer,
+                            load_mma_K_consumer,
+                            load_mma_V_consumer,
+                            load_mma_dO_consumer,
+                            load_mma_dOT_consumer,
+                            compute_mma_P_consumer,
+                            compute_mma_dS_consumer,
+                            load_mma_QT_consumer,
+                        ) = self.mma_2cta(
+                            KQ_tiled_mma,
+                            VdO_tiled_mma,
+                            PdO_tiled_mma,
+                            dSQ_tiled_mma,
+                            tSTtST,
+                            tSTrQ,
+                            tSTrK,
+                            tdPTtdPT,
+                            tdPTrV,
+                            tdPTrdO,
+                            tdVtdV,
+                            tdVrP,
+                            tdVrdOT,
+                            tdKrdST,
+                            tdKtdK,
+                            tdKrQT,
+                            iter_count,
+                            load_mma_Q_consumer,
+                            load_mma_K_consumer,
+                            load_mma_V_consumer,
+                            mma_compute_S_producer,
+                            load_mma_dO_consumer,
+                            mma_compute_dP_producer,
+                            load_mma_dOT_consumer,
+                            compute_mma_P_consumer,
+                            compute_mma_dS_consumer,
+                            load_mma_QT_consumer,
+                            mma_compute_dKdV_producer,
+                        )
+                    # CLC advance
+                    work_tile = tile_sched.advance_to_next_work()
+                # producer_tail after loop
+                mma_compute_S_producer.tail()
+                mma_compute_dP_producer.tail()
+                mma_compute_dKdV_producer.tail()
+
+            # ===== COMPUTE WARPS =====
+            elif warp_idx >= self.compute_warp_id[0] and warp_idx <= self.compute_warp_id[-1]:
+                while work_tile.is_valid_tile:
+                    blk_coord_k = work_tile.tile_idx[0]
+                    blk_coord_b = work_tile.tile_idx[2][0]
+                    blk_coord_h_k = work_tile.tile_idx[2][1]
+                    blk_coord = (
+                        Int32(0),
+                        blk_coord_k,
+                        Int32(0),
+                        ((Int32(0), blk_coord_h_k), blk_coord_b),
+                    )
+                    seqlen_q_cur_batch = Q_ref.shape[0]
+                    seqlen_k_cur_batch = K_ref.shape[0]
+                    blk_offset = (Int32(0), Int32(0), Int32(0), ((Int32(0), Int32(0)), Int32(0)))
+                    if cutlass.const_expr(varlen):
+                        assert isinstance(cumulative_s_q, cute.Tensor)
+                        assert isinstance(cumulative_s_k, cute.Tensor)
+                        seqlen_q_cur_batch = (
+                            cumulative_s_q[blk_coord_b + 1] - cumulative_s_q[blk_coord_b]
+                        )
+                        seqlen_k_cur_batch = (
+                            cumulative_s_k[blk_coord_b + 1] - cumulative_s_k[blk_coord_b]
+                        )
+                        blk_offset = (
+                            cumulative_s_q[blk_coord_b],
+                            cumulative_s_k[blk_coord_b],
+                            Int32(0),
+                            ((Int32(0), Int32(0)), Int32(0)),
+                        )
+                    iter_start, iter_end = self.get_Q_block_min_max(
+                        seqlen_q_cur_batch,
+                        seqlen_k_cur_batch,
+                        blk_coord_k,
+                        is_2cta=True,
+                    )
+                    iter_count = (iter_end - iter_start) * problem_shape[3][0][0]
+                    if iter_count <= 0:
+                        if blk_coord_k * self.tile_shape_K < seqlen_k_cur_batch:
+                            problem_shape_cur_batch = (
+                                seqlen_q_cur_batch,
+                                seqlen_k_cur_batch,
+                                problem_shape[2],
+                                problem_shape[3],
+                            )
+                            self.epilogue_clear(
+                                blk_coord, blk_offset, problem_shape_cur_batch, dK, dV
+                            )
+                    else:
+                        problem_shape_cur_batch = (
+                            seqlen_q_cur_batch,
+                            seqlen_k_cur_batch,
+                            problem_shape[2],
+                            problem_shape[3],
+                        )
+                        (
+                            compute_mma_P_producer,
+                            compute_mma_dS_producer,
+                            mma_compute_S_consumer,
+                            compute_mma_P_consumer,
+                            load_compute_LSE_consumer,
+                            load_compute_sum_OdO_consumer,
+                            mma_compute_dP_consumer,
+                            compute_mma_dS_consumer,
+                            mma_compute_dKdV_consumer,
+                        ) = self.compute(
+                            tSTtST,
+                            tdPTtdPT,
+                            tdVrP,
+                            sP,
+                            sLSE,
+                            sdST,
+                            sSum_OdO,
+                            dK,
+                            dV,
+                            tdKtdK,
+                            tdVtdV,
+                            PdO_tiled_mma,
+                            dSQ_tiled_mma,
+                            blk_coord,
+                            blk_offset,
+                            problem_shape_cur_batch,
+                            iter_count,
+                            iter_start,
+                            iter_end,
+                            scale_softmax,
+                            mma_compute_S_producer,
+                            mma_compute_S_consumer,
+                            compute_mma_P_producer,
+                            compute_mma_P_consumer,
+                            load_compute_LSE_producer,
+                            load_compute_LSE_consumer,
+                            load_compute_sum_OdO_producer,
+                            load_compute_sum_OdO_consumer,
+                            mma_compute_dP_producer,
+                            mma_compute_dP_consumer,
+                            compute_mma_dS_producer,
+                            compute_mma_dS_consumer,
+                            mma_compute_dKdV_producer,
+                            mma_compute_dKdV_consumer,
+                            varlen,
+                            sK,
+                            seqlen_k_cur_batch,
+                        )
+                        cute.arch.barrier(
+                            barrier_id=self.epilogue_sync_bar_id,
+                            number_of_threads=self.num_compute_warps * self.threads_per_warp,
+                        )
+                    # CLC advance
+                    work_tile = tile_sched.advance_to_next_work()
+                # producer_tail after loop
+                compute_mma_P_producer.tail()
+                compute_mma_dS_producer.tail()
+
+        else:
+            # ===== STATIC PATH: original non-persistent code =====
+            blk_coord = (Int32(0), bidx, Int32(0), ((Int32(0), bidy), bidz))
+            seqlen_q_cur_batch = Q_ref.shape[0]
+            seqlen_k_cur_batch = K_ref.shape[0]
+            blk_offset = (Int32(0), Int32(0), Int32(0), ((Int32(0), Int32(0)), Int32(0)))
+            if cutlass.const_expr(varlen):
+                assert isinstance(cumulative_s_q, cute.Tensor)
+                assert isinstance(cumulative_s_k, cute.Tensor)
+                seqlen_q_cur_batch = cumulative_s_q[bidz + 1] - cumulative_s_q[bidz]
+                seqlen_k_cur_batch = cumulative_s_k[bidz + 1] - cumulative_s_k[bidz]
+                blk_offset = (
+                    cumulative_s_q[bidz],
+                    cumulative_s_k[bidz],
+                    Int32(0),
+                    ((Int32(0), Int32(0)), Int32(0)),
+                )
+
+            iter_start, iter_end = self.get_Q_block_min_max(
+                seqlen_q_cur_batch,
+                seqlen_k_cur_batch,
+                blk_coord[1],
+                is_2cta=True,
+            )
+
+            # Cluster wait
+            pipeline_init_wait(cluster_shape_mn=cluster_layout_vmnk)
+
+            iter_count = (iter_end - iter_start) * problem_shape[3][0][0]
+            problem_shape_cur_batch = (
+                seqlen_q_cur_batch,
+                seqlen_k_cur_batch,
+                problem_shape[2],
+                problem_shape[3],
+            )
+            if iter_count <= 0:
+                if bidx * self.tile_shape_K < seqlen_k_cur_batch:
+                    self.epilogue_clear(
+                        blk_coord,
+                        blk_offset,
+                        problem_shape_cur_batch,
+                        dK,
+                        dV,
+                    )
+            # ///////////////////////////////////////////////////////////////////////////////
+            #  LOAD
+            # ///////////////////////////////////////////////////////////////////////////////
+            elif warp_idx == self.load_warp_id:
+                cute.arch.warpgroup_reg_dealloc(self.num_regs_load)
+
+                self.load(
+                    K_in,
+                    V_in,
+                    Q_in,
+                    QT_in,
+                    dO_in,
+                    dOT_in,
+                    LSE,
+                    sum_OdO,
+                    sK,
+                    sQ,
+                    sQT,
+                    sV,
+                    sdO,
+                    sdOT,
+                    sLSE,
+                    sSum_OdO,
+                    KQ_tiled_mma,
+                    VdO_tiled_mma,
+                    PdO_tiled_mma,
+                    dSQ_tiled_mma,
+                    tma_atom_K,
+                    tma_atom_Q,
+                    tma_atom_QT,
+                    tma_atom_V,
+                    tma_atom_dO,
+                    tma_atom_dOT,
+                    blk_offset,
+                    problem_shape_cur_batch,
+                    varlen,
+                    iter_count,
+                    iter_start,
+                    iter_end,
+                    load_mma_Q_producer,
+                    load_mma_Q_consumer,
+                    load_mma_K_producer,
+                    load_mma_K_consumer,
+                    load_mma_V_producer,
+                    load_mma_V_consumer,
+                    load_compute_LSE_producer,
+                    load_compute_LSE_consumer,
+                    load_mma_dO_producer,
+                    load_mma_dO_consumer,
+                    load_mma_dOT_producer,
+                    load_mma_dOT_consumer,
+                    load_compute_sum_OdO_producer,
+                    load_compute_sum_OdO_consumer,
+                    load_mma_QT_producer,
+                    load_mma_QT_consumer,
+                )
+
+            # ///////////////////////////////////////////////////////////////////////////////
+            #  MMA
+            # ///////////////////////////////////////////////////////////////////////////////
+            elif warp_idx == self.mma_warp_id:
+                cute.arch.warpgroup_reg_alloc(self.num_regs_mma)
+
+                self.mma_2cta(
+                    KQ_tiled_mma,
+                    VdO_tiled_mma,
+                    PdO_tiled_mma,
+                    dSQ_tiled_mma,
+                    tSTtST,
+                    tSTrQ,
+                    tSTrK,
+                    tdPTtdPT,
+                    tdPTrV,
+                    tdPTrdO,
+                    tdVtdV,
+                    tdVrP,
+                    tdVrdOT,
+                    tdKrdST,
+                    tdKtdK,
+                    tdKrQT,
+                    iter_count,
+                    load_mma_Q_consumer,
+                    load_mma_K_consumer,
+                    load_mma_V_consumer,
+                    mma_compute_S_producer,
+                    load_mma_dO_consumer,
+                    mma_compute_dP_producer,
+                    load_mma_dOT_consumer,
+                    compute_mma_P_consumer,
+                    compute_mma_dS_consumer,
+                    load_mma_QT_consumer,
+                    mma_compute_dKdV_producer,
+                )
+
+            # ///////////////////////////////////////////////////////////////////////////////
+            #  Compute
+            # ///////////////////////////////////////////////////////////////////////////////
+            elif warp_idx >= self.compute_warp_id[0] and warp_idx <= self.compute_warp_id[-1]:
+                cute.arch.warpgroup_reg_alloc(self.num_regs_compute)
+
+                self.compute(
+                    tSTtST,
+                    tdPTtdPT,
+                    tdVrP,
+                    sP,
+                    sLSE,
+                    sdST,
+                    sSum_OdO,
+                    dK,
+                    dV,
+                    tdKtdK,
+                    tdVtdV,
+                    PdO_tiled_mma,
+                    dSQ_tiled_mma,
+                    blk_coord,
+                    blk_offset,
+                    problem_shape_cur_batch,
+                    iter_count,
+                    iter_start,
+                    iter_end,
+                    scale_softmax,
+                    mma_compute_S_producer,
+                    mma_compute_S_consumer,
+                    compute_mma_P_producer,
+                    compute_mma_P_consumer,
+                    load_compute_LSE_producer,
+                    load_compute_LSE_consumer,
+                    load_compute_sum_OdO_producer,
+                    load_compute_sum_OdO_consumer,
+                    mma_compute_dP_producer,
+                    mma_compute_dP_consumer,
+                    compute_mma_dS_producer,
+                    compute_mma_dS_consumer,
+                    mma_compute_dKdV_producer,
+                    mma_compute_dKdV_consumer,
+                    varlen,
+                    sK,
+                    seqlen_k_cur_batch,
+                )
+
+                cute.arch.barrier(
+                    barrier_id=self.epilogue_sync_bar_id,
+                    number_of_threads=self.num_compute_warps * self.threads_per_warp,
+                )
+
+            else:
+                cute.arch.warpgroup_reg_dealloc(self.num_regs_empty)
+
+        cute.arch.cluster_arrive()
+        cute.arch.cluster_wait()
+        # dishengbin Deallocate tmem for early exit
+        # Dealloc the tensor memory
+        tmem.relinquish_alloc_permit()
+        tmem.free(tmem_ptr)
+
+    @cute.jit
+    def get_Q_block_min_max(
+        self,
+        seq_Q: Int32,
+        seq_K: Int32,
+        blk_coord_k: Int32,
+        is_2cta: bool,
+    ):
+        """Get Q tiles range."""
+        Q_block_max = cute.ceil_div(seq_Q, self.tile_shape_Q)
+        Q_block_min = cutlass.Int32(0)
+        if cutlass.const_expr(self.has_sliding_window):
+            # For 2cta, use the last K block in the cluster so both CTAs get the same Q_block_max
+            blk_coord_k_for_max = (blk_coord_k // 2) * 2 + 1
+            Q_block_max_tmp = cute.ceil_div(
+                (blk_coord_k_for_max + 1) * self.tile_shape_K
+                + seq_Q
+                - seq_K
+                + self.window_size_left,
+                self.tile_shape_Q,
+            )
+            Q_block_max = min(Q_block_max, Q_block_max_tmp)
+        if cutlass.const_expr(self.is_causal or self.has_sliding_window):
+            # For 2cta, use the first K block in the cluster so both CTAs get the same Q_block_min.
+            # This ensures both CTAs in a cluster run the same number of pipeline iterations,
+            # avoiding hang from mismatched producer_commit / consumer_wait counts.
+            blk_coord_k_for_min = (blk_coord_k // 2) * 2
+            Q_block_min_tmp = (
+                blk_coord_k_for_min * self.tile_shape_K + seq_Q - seq_K - self.window_size_right
+            ) // self.tile_shape_Q
+            # Consider the case of 2cta, we need to ensure the K block is aligned to 2
+            Q_block_min_tmp = Q_block_min_tmp - Q_block_min_tmp % 2
+            Q_block_min = max(Q_block_min_tmp, Q_block_min)
+        return Q_block_min, Q_block_max
+
+    @cute.jit
+    def load(
+        self,
+        K_in: cute.Tensor,
+        V_in: cute.Tensor,
+        Q_in: cute.Tensor,
+        QT_in: cute.Tensor,
+        dO_in: cute.Tensor,
+        dOT_in: cute.Tensor,
+        LSE_in: cute.Tensor,
+        sum_OdO_in: cute.Tensor,
+        sK: cute.Tensor,
+        sQ: cute.Tensor,
+        sQT: cute.Tensor,
+        sV: cute.Tensor,
+        sdO: cute.Tensor,
+        sdOT: cute.Tensor,
+        sLSE: cute.Tensor,
+        sSum_OdO: cute.Tensor,
+        KQ_tiled_mma: cute.TiledMma,
+        VdO_tiled_mma: cute.TiledMma,
+        PdO_tiled_mma: cute.TiledMma,
+        dSQ_tiled_mma: cute.TiledMma,
+        tma_atom_K: cute.CopyAtom,
+        tma_atom_Q: cute.CopyAtom,
+        tma_atom_QT: cute.CopyAtom,
+        tma_atom_V: cute.CopyAtom,
+        tma_atom_dO: cute.CopyAtom,
+        tma_atom_dOT: cute.CopyAtom,
+        blk_offset: cute.Shape,
+        problem_shape: tuple[Int32, Int32, Int32, tuple[tuple[Int32, Int32], Int32]],
+        varlen: bool,
+        iter_count: Int32,
+        iter_start: Int32,
+        iter_end: Int32,
+        load_mma_Q_producer,
+        load_mma_Q_consumer,
+        load_mma_K_producer,
+        load_mma_K_consumer,
+        load_mma_V_producer,
+        load_mma_V_consumer,
+        load_compute_LSE_producer,
+        load_compute_LSE_consumer,
+        load_mma_dO_producer,
+        load_mma_dO_consumer,
+        load_mma_dOT_producer,
+        load_mma_dOT_consumer,
+        load_compute_sum_OdO_producer,
+        load_compute_sum_OdO_consumer,
+        load_mma_QT_producer,
+        load_mma_QT_consumer,
+        blk_coord_k_override: Int32 = Int32(-1),
+        blk_coord_h_k_override: Int32 = Int32(-1),
+        blk_coord_b_override: Int32 = Int32(-1),
+    ):
+        """TMA load."""
+        tidx, _, _ = cute.arch.thread_idx()
+        if cutlass.const_expr(self.use_clc_scheduler):
+            blk_coord_k = blk_coord_k_override
+            blk_coord_h_k = blk_coord_h_k_override
+            blk_coord_b = blk_coord_b_override
+        else:
+            blk_coord_k, blk_coord_h_k, blk_coord_b = cute.arch.block_idx()
+        blk_coord_h_r = Int32(0)
+        blk_coord_h = (blk_coord_h_r, blk_coord_h_k)
+        iter_index = iter_start
+        mma_tile_coord_v = blk_coord_k % cute.size(KQ_tiled_mma.thr_id.shape)
+        mma_tile_coord_m = blk_coord_k // cute.size(KQ_tiled_mma.thr_id.shape)
+
+        K = cute.domain_offset(cute.select(blk_offset, mode=[1, 2, 3]), K_in)
+        V = cute.domain_offset(cute.select(blk_offset, mode=[1, 2, 3]), V_in)
+        Q = cute.domain_offset(cute.select(blk_offset, mode=[0, 2, 3]), Q_in)
+        QT = cute.domain_offset(cute.select(blk_offset, mode=[2, 0, 3]), QT_in)
+        dO = cute.domain_offset(cute.select(blk_offset, mode=[0, 2, 3]), dO_in)
+        dOT = cute.domain_offset(cute.select(blk_offset, mode=[2, 0, 3]), dOT_in)
+        blk_offset_stats = blk_offset
+        if cutlass.const_expr(varlen):
+            cuseqlen_q_stats = cute.assume(
+                (blk_offset[0] + blk_coord_b * self.tile_shape_Q)
+                // self.tile_shape_Q
+                * self.tile_shape_Q,
+                divby=self.tile_shape_Q,
+            )
+            blk_offset_stats = (
+                cuseqlen_q_stats,
+                blk_offset[1],
+                blk_offset[2],
+                blk_offset[3],
+            )
+        LSE = cute.domain_offset(cute.select(blk_offset_stats, mode=[0, 3]), LSE_in)
+        sum_OdO = cute.domain_offset(cute.select(blk_offset_stats, mode=[0, 3]), sum_OdO_in)
+
+        gK = cute.local_tile(K, cute.select(self.KQ_mma_tiler, mode=[0, 2]), (None, None, None))
+        gQ = cute.local_tile(Q, cute.select(self.KQ_mma_tiler, mode=[1, 2]), (None, None, None))
+        gQT = cute.local_tile(QT, cute.select(self.dSQ_mma_tiler, mode=[1, 2]), (None, None, None))
+        gV = cute.local_tile(V, cute.select(self.VdO_mma_tiler, mode=[0, 2]), (None, None, None))
+        gdO = cute.local_tile(dO, cute.select(self.VdO_mma_tiler, mode=[1, 2]), (None, None, None))
+        gdOT = cute.local_tile(
+            dOT, cute.select(self.PdO_mma_tiler, mode=[1, 2]), (None, None, None)
+        )
+
+        KQ_thr_mma = KQ_tiled_mma.get_slice(mma_tile_coord_v)
+        VdO_thr_mma = VdO_tiled_mma.get_slice(mma_tile_coord_v)
+        PdO_thr_mma = PdO_tiled_mma.get_slice(mma_tile_coord_v)
+        dSQ_thr_mma = dSQ_tiled_mma.get_slice(mma_tile_coord_v)
+
+        tSTgK = KQ_thr_mma.partition_A(gK)
+        tSTgQ = KQ_thr_mma.partition_B(gQ)
+        tdKgQT = dSQ_thr_mma.partition_B(gQT)
+        tdPTgV = VdO_thr_mma.partition_A(gV)
+        tdPTgdO = VdO_thr_mma.partition_B(gdO)
+        tdVgdOT = PdO_thr_mma.partition_B(gdOT)
+
+        cta_layout_mnk = cute.make_layout(self.cluster_shape_mnk)
+        cta_layout_vmnk = cute.tiled_divide(cta_layout_mnk, (KQ_tiled_mma.thr_id,))
+        cta_in_cluster_coord_vmnk = cta_layout_vmnk.get_flat_coord(cute.arch.block_idx_in_cluster())
+
+        tKsK, tKgK_mkl = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_K,
+            cta_in_cluster_coord_vmnk[2],
+            cute.make_layout(cute.size(cta_layout_vmnk, mode=[2])),
+            cute.group_modes(sK, 0, 3),
+            cute.group_modes(tSTgK, 0, 3),
+        )
+        tQsQ, tQgQ_mkl = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_Q,
+            cta_in_cluster_coord_vmnk[1],
+            cute.make_layout(cute.size(cta_layout_vmnk, mode=[1])),
+            cute.group_modes(sQ, 0, 3),
+            cute.group_modes(tSTgQ, 0, 3),
+        )
+        tQTsQT, tQTgQT_mkl = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_QT,
+            cta_in_cluster_coord_vmnk[1],
+            cute.make_layout(cute.size(cta_layout_vmnk, mode=[1])),
+            cute.group_modes(sQT, 0, 3),
+            cute.group_modes(tdKgQT, 0, 3),
+        )
+        tVsV, tVgV_mkl = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_V,
+            cta_in_cluster_coord_vmnk[2],
+            cute.make_layout(cute.size(cta_layout_vmnk, mode=[2])),
+            cute.group_modes(sV, 0, 3),
+            cute.group_modes(tdPTgV, 0, 3),
+        )
+        tdOsdO, tdOgdO_mkl = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_dO,
+            cta_in_cluster_coord_vmnk[1],
+            cute.make_layout(cute.size(cta_layout_vmnk, mode=[1])),
+            cute.group_modes(sdO, 0, 3),
+            cute.group_modes(tdPTgdO, 0, 3),
+        )
+        tdOTsdOT, tdOTgdOT_mkl = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_dOT,
+            cta_in_cluster_coord_vmnk[1],
+            cute.make_layout(cute.size(cta_layout_vmnk, mode=[1])),
+            cute.group_modes(sdOT, 0, 3),
+            cute.group_modes(tdVgdOT, 0, 3),
+        )
+
+        k_handle = load_mma_K_producer.acquire_and_advance()
+        cute.copy(
+            tma_atom_K,
+            tKgK_mkl[(None, mma_tile_coord_m, 0, (blk_coord_h, blk_coord_b))],
+            tKsK[None, 0],
+            tma_bar_ptr=k_handle.barrier,
+        )
+
+        q_handle = load_mma_Q_producer.acquire_and_advance()
+        cute.copy(
+            tma_atom_Q,
+            tQgQ_mkl[(None, iter_index, 0, (blk_coord_h, blk_coord_b))],
+            tQsQ[None, q_handle.index],
+            tma_bar_ptr=q_handle.barrier,
+        )
+
+        lse_handle = load_compute_LSE_producer.acquire_and_advance()
+        thread_idx = tidx % self.threads_per_warp
+        async_copy_num_elts = sLSE.shape[0] // self.threads_per_warp
+        atom_async_copy = cute.make_copy_atom(
+            cpasync.CopyG2SOp(cache_mode=cpasync.LoadCacheMode.ALWAYS),
+            self.acc_dtype,
+            num_bits_per_copy=self.acc_dtype.width,
+        )
+        sLSE_for_copy = cute.flat_divide(sLSE, (1,))
+        LSE_for_copy = cute.flat_divide(LSE, (1,))
+        for i in cutlass.range_constexpr(async_copy_num_elts):
+            LSE_idx = self.tile_shape_Q * iter_index + thread_idx * async_copy_num_elts
+            if cute.elem_less(LSE_idx + i, problem_shape[0]):
+                cute.copy(
+                    atom_async_copy,
+                    LSE_for_copy[None, LSE_idx + i, (blk_coord_h, blk_coord_b)],
+                    sLSE_for_copy[
+                        None,
+                        thread_idx * async_copy_num_elts + i,
+                        lse_handle.index,
+                    ],
+                )
+            else:
+                sLSE_for_copy[
+                    None,
+                    thread_idx * async_copy_num_elts + i,
+                    lse_handle.index,
+                ].fill(0.0)
+        lse_handle.commit()
+
+        v_handle = load_mma_V_producer.acquire_and_advance()
+        cute.copy(
+            tma_atom_V,
+            tVgV_mkl[(None, mma_tile_coord_m, 0, (blk_coord_h, blk_coord_b))],
+            tVsV[(None, 0)],
+            tma_bar_ptr=v_handle.barrier,
+        )
+
+        do_handle = load_mma_dO_producer.acquire_and_advance()
+        cute.copy(
+            tma_atom_dO,
+            tdOgdO_mkl[(None, iter_index, 0, (blk_coord_h, blk_coord_b))],
+            tdOsdO[(None, do_handle.index)],
+            tma_bar_ptr=do_handle.barrier,
+        )
+
+        sum_odo_handle = load_compute_sum_OdO_producer.acquire_and_advance()
+        sSum_OdO_for_copy = cute.flat_divide(sSum_OdO, (1,))
+        sum_OdO_for_copy = cute.flat_divide(sum_OdO, (1,))
+        for i in cutlass.range_constexpr(async_copy_num_elts):
+            sum_OdO_idx = self.tile_shape_Q * iter_index + thread_idx * async_copy_num_elts
+            if cute.elem_less(sum_OdO_idx + i, problem_shape[0]):
+                cute.copy(
+                    atom_async_copy,
+                    sum_OdO_for_copy[None, sum_OdO_idx + i, (blk_coord_h, blk_coord_b)],
+                    sSum_OdO_for_copy[
+                        None,
+                        thread_idx * async_copy_num_elts + i,
+                        sum_odo_handle.index,
+                    ],
+                )
+            else:
+                sSum_OdO_for_copy[
+                    None,
+                    thread_idx * async_copy_num_elts + i,
+                    sum_odo_handle.index,
+                ].fill(0.0)
+        sum_odo_handle.commit()
+
+        dot_handle = load_mma_dOT_producer.acquire_and_advance()
+        cute.copy(
+            tma_atom_dOT,
+            tdOTgdOT_mkl[(None, 0, iter_index, (blk_coord_h, blk_coord_b))],
+            tdOTsdOT[None, dot_handle.index],
+            tma_bar_ptr=dot_handle.barrier,
+        )
+
+        qt_handle = load_mma_QT_producer.acquire_and_advance()
+        cute.copy(
+            tma_atom_QT,
+            tQTgQT_mkl[(None, 0, iter_index, (blk_coord_h, blk_coord_b))],
+            tQTsQT[None, qt_handle.index],
+            tma_bar_ptr=qt_handle.barrier,
+        )
+
+        iter_count -= 1
+        iter_index += 1
+
+        while iter_count > 0:
+            if iter_index == iter_end:
+                iter_index = iter_start
+                blk_coord_h_r += 1
+                blk_coord_h = (blk_coord_h_r, blk_coord_h_k)
+
+            q_handle = load_mma_Q_producer.acquire_and_advance()
+            cute.copy(
+                tma_atom_Q,
+                tQgQ_mkl[(None, iter_index, 0, (blk_coord_h, blk_coord_b))],
+                tQsQ[None, q_handle.index],
+                tma_bar_ptr=q_handle.barrier,
+            )
+
+            lse_handle = load_compute_LSE_producer.acquire_and_advance()
+            sLSE_for_copy = cute.flat_divide(sLSE, (1,))
+            LSE_for_copy = cute.flat_divide(LSE, (1,))
+            for i in cutlass.range_constexpr(async_copy_num_elts):
+                LSE_idx = self.tile_shape_Q * iter_index + thread_idx * async_copy_num_elts
+                if cute.elem_less(LSE_idx + i, problem_shape[0]):
+                    cute.copy(
+                        atom_async_copy,
+                        LSE_for_copy[None, LSE_idx + i, (blk_coord_h, blk_coord_b)],
+                        sLSE_for_copy[
+                            None,
+                            thread_idx * async_copy_num_elts + i,
+                            lse_handle.index,
+                        ],
+                    )
+                else:
+                    sLSE_for_copy[
+                        None,
+                        thread_idx * async_copy_num_elts + i,
+                        lse_handle.index,
+                    ].fill(0.0)
+            lse_handle.commit()
+
+            do_handle = load_mma_dO_producer.acquire_and_advance()
+            cute.copy(
+                tma_atom_dO,
+                tdOgdO_mkl[(None, iter_index, 0, (blk_coord_h, blk_coord_b))],
+                tdOsdO[None, do_handle.index],
+                tma_bar_ptr=do_handle.barrier,
+            )
+
+            sum_odo_handle = load_compute_sum_OdO_producer.acquire_and_advance()
+            sSum_OdO_for_copy = cute.flat_divide(sSum_OdO, (1,))
+            sum_OdO_for_copy = cute.flat_divide(sum_OdO, (1,))
+            for i in cutlass.range_constexpr(async_copy_num_elts):
+                sum_OdO_idx = self.tile_shape_Q * iter_index + thread_idx * async_copy_num_elts
+                if cute.elem_less(sum_OdO_idx + i, problem_shape[0]):
+                    cute.copy(
+                        atom_async_copy,
+                        sum_OdO_for_copy[None, sum_OdO_idx + i, (blk_coord_h, blk_coord_b)],
+                        sSum_OdO_for_copy[
+                            None,
+                            thread_idx * async_copy_num_elts + i,
+                            sum_odo_handle.index,
+                        ],
+                    )
+                else:
+                    sSum_OdO_for_copy[
+                        None,
+                        thread_idx * async_copy_num_elts + i,
+                        sum_odo_handle.index,
+                    ].fill(0.0)
+            sum_odo_handle.commit()
+
+            dot_handle = load_mma_dOT_producer.acquire_and_advance()
+            cute.copy(
+                tma_atom_dOT,
+                tdOTgdOT_mkl[(None, 0, iter_index, (blk_coord_h, blk_coord_b))],
+                tdOTsdOT[None, dot_handle.index],
+                tma_bar_ptr=dot_handle.barrier,
+            )
+
+            qt_handle = load_mma_QT_producer.acquire_and_advance()
+            cute.copy(
+                tma_atom_QT,
+                tQTgQT_mkl[(None, 0, iter_index, (blk_coord_h, blk_coord_b))],
+                tQTsQT[None, qt_handle.index],
+                tma_bar_ptr=qt_handle.barrier,
+            )
+
+            iter_count -= 1
+            iter_index += 1
+
+        if not cutlass.const_expr(self.use_clc_scheduler):
+            load_mma_K_producer.tail()
+            load_mma_V_producer.tail()
+            load_mma_Q_producer.tail()
+            load_compute_LSE_producer.tail()
+            load_mma_dO_producer.tail()
+            load_mma_dOT_producer.tail()
+            load_compute_sum_OdO_producer.tail()
+            load_mma_QT_producer.tail()
+
+        return (
+            load_mma_Q_producer,
+            load_mma_K_producer,
+            load_mma_V_producer,
+            load_compute_LSE_producer,
+            load_mma_dO_producer,
+            load_mma_dOT_producer,
+            load_compute_sum_OdO_producer,
+            load_mma_QT_producer,
+        )
+
+    @cute.jit
+    def mma_2cta(
+        self,
+        KQ_tiled_mma: cute.TiledMma,
+        VdO_tiled_mma: cute.TiledMma,
+        PdO_tiled_mma: cute.TiledMma,
+        dSQ_tiled_mma: cute.TiledMma,
+        tSTtST: cute.Tensor,
+        tSTrQ: cute.Tensor,
+        tSTrK: cute.Tensor,
+        tdPTtdPT: cute.Tensor,
+        tdPTrV: cute.Tensor,
+        tdPTrdO: cute.Tensor,
+        tdVtdV: cute.Tensor,
+        tdVrP: cute.Tensor,
+        tdVrdOT: cute.Tensor,
+        tdKrdST: cute.Tensor,
+        tdKtdK: cute.Tensor,
+        tdKrQT: cute.Tensor,
+        iter_count: Int32,
+        load_mma_Q_consumer,
+        load_mma_K_consumer,
+        load_mma_V_consumer,
+        mma_compute_S_producer,
+        load_mma_dO_consumer,
+        mma_compute_dP_producer,
+        load_mma_dOT_consumer,
+        compute_mma_P_consumer,
+        compute_mma_dS_consumer,
+        load_mma_QT_consumer,
+        mma_compute_dKdV_producer,
+    ):
+        """CuTeDSL kernel for mma pipeline."""
+        load_mma_Q_releaser = load_mma_Q_consumer.clone()
+        load_mma_K_releaser = load_mma_K_consumer.clone()
+        load_mma_V_releaser = load_mma_V_consumer.clone()
+
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+        is_leader_cta = cta_rank_in_cluster % 2 == 0
+
+        if is_leader_cta:
+            s_handle = mma_compute_S_producer.acquire_and_advance()
+            k_handle = load_mma_K_consumer.wait_and_advance()
+            q_handle = load_mma_Q_consumer.wait_and_advance()
+
+            # Compute S = K * Q
+            for k_block in cutlass.range(0, cute.size(tSTrQ, mode=[2]), unroll_full=True):
+                KQ_tiled_mma.set(tcgen05.Field.ACCUMULATE, k_block != 0)
+                cute.gemm(
+                    KQ_tiled_mma,
+                    tSTtST,
+                    tSTrK[None, None, k_block, 0],
+                    tSTrQ[None, None, k_block, q_handle.index],
+                    tSTtST,
+                )
+            q_handle.release()
+
+            cute.arch.fence_view_async_tmem_store()
+            s_handle.commit()
+
+            do_handle = load_mma_dO_consumer.wait_and_advance()
+            v_handle = load_mma_V_consumer.wait_and_advance()
+
+            dp_handle = mma_compute_dP_producer.acquire_and_advance()
+
+            # Compute dP = V * dO
+            VdO_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+            for k_block in cutlass.range(0, cute.size(tdPTrV, mode=[2]), unroll_full=True):
+                cute.gemm(
+                    VdO_tiled_mma,
+                    tdPTtdPT,
+                    tdPTrV[None, None, k_block, 0],
+                    tdPTrdO[None, None, k_block, do_handle.index],
+                    tdPTtdPT,
+                )
+                VdO_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+
+            dp_handle.commit()
+            do_handle.release()
+            # V only produced once by load(); hold v_handle until end, release there via releaser
+
+            p_handle = compute_mma_P_consumer.wait_and_advance()
+            dot_handle = load_mma_dOT_consumer.wait_and_advance()
+
+            # Compute dV = P * dO (First iteration)
+            PdO_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+            for k_block in cutlass.range(0, cute.size(tdVrP, mode=[2]), unroll_full=True):
+                cute.gemm(
+                    PdO_tiled_mma,
+                    tdVtdV,
+                    tdVrP[None, None, k_block, 0],
+                    tdVrdOT[None, None, k_block, dot_handle.index],
+                    tdVtdV,
+                )
+                PdO_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+
+            dot_handle.release()
+            p_handle.release()
+
+        iter_count -= 1
+
+        dSQ_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+        while iter_count > 0:
+            if is_leader_cta:
+                q_handle = load_mma_Q_consumer.wait_and_advance()
+                s_handle = mma_compute_S_producer.acquire_and_advance()
+
+                # Compute S = K * Q
+                for k_block in cutlass.range(0, cute.size(tSTrQ, mode=[2]), unroll_full=True):
+                    KQ_tiled_mma.set(tcgen05.Field.ACCUMULATE, k_block != 0)
+                    cute.gemm(
+                        KQ_tiled_mma,
+                        tSTtST,
+                        tSTrK[None, None, k_block, 0],
+                        tSTrQ[None, None, k_block, q_handle.index],
+                        tSTtST,
+                    )
+                q_handle.release()
+                s_handle.commit()
+
+            if is_leader_cta:
+                qt_handle = load_mma_QT_consumer.wait_and_advance()
+                ds_handle = compute_mma_dS_consumer.wait_and_advance()
+
+                # Compute dK = dS * QT
+                for k_block in cutlass.range(0, cute.size(tdKrdST, mode=[2]), unroll_full=True):
+                    cute.gemm(
+                        dSQ_tiled_mma,
+                        tdKtdK,
+                        tdKrdST[
+                            None,
+                            None,
+                            k_block,
+                            ds_handle.index,
+                        ],
+                        tdKrQT[None, None, k_block, qt_handle.index],
+                        tdKtdK,
+                    )
+                    dSQ_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                qt_handle.release()
+                ds_handle.release()
+
+            if is_leader_cta:
+                dp_handle = mma_compute_dP_producer.acquire_and_advance()
+                do_handle = load_mma_dO_consumer.wait_and_advance()
+                # V only produced once by load(); reuse same V (index 0) for all loop iterations
+                VdO_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+                for k_block in cutlass.range(0, cute.size(tdPTrV, mode=[2]), unroll_full=True):
+                    cute.gemm(
+                        VdO_tiled_mma,
+                        tdPTtdPT,
+                        tdPTrV[None, None, k_block, 0],
+                        tdPTrdO[None, None, k_block, do_handle.index],
+                        tdPTtdPT,
+                    )
+                    VdO_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+
+                dp_handle.commit()
+                do_handle.release()
+
+            if is_leader_cta:
+                p_handle = compute_mma_P_consumer.wait_and_advance()
+                dot_handle = load_mma_dOT_consumer.wait_and_advance()
+
+                # Compute dV = P * dO (Loop iterations)
+                for k_block in cutlass.range(0, cute.size(tdVrP, mode=[2]), unroll_full=True):
+                    cute.gemm(
+                        PdO_tiled_mma,
+                        tdVtdV,
+                        tdVrP[None, None, k_block, 0],
+                        tdVrdOT[None, None, k_block, dot_handle.index],
+                        tdVtdV,
+                    )
+                    PdO_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+
+                p_handle.release()
+                dot_handle.release()
+
+            iter_count -= 1
+
+        if is_leader_cta:
+            dkdv_handle = mma_compute_dKdV_producer.acquire_and_advance()
+            dkdv_handle.commit()
+
+            load_mma_K_releaser.release()
+            load_mma_K_releaser.advance()
+            load_mma_V_releaser.release()
+            load_mma_V_releaser.advance()
+
+        if is_leader_cta:
+            dkdv_handle = mma_compute_dKdV_producer.acquire_and_advance()
+
+            ds_handle = compute_mma_dS_consumer.wait_and_advance()
+            qt_handle = load_mma_QT_consumer.wait_and_advance()
+
+            # Compute dK = dS * Q
+            for k_block in cutlass.range(0, cute.size(tdKrdST, mode=[2]), unroll_full=True):
+                cute.gemm(
+                    dSQ_tiled_mma,
+                    tdKtdK,
+                    tdKrdST[None, None, k_block, ds_handle.index],
+                    tdKrQT[None, None, k_block, qt_handle.index],
+                    tdKtdK,
+                )
+                dSQ_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+
+            dkdv_handle.commit()
+            qt_handle.release()
+            ds_handle.release()
+
+        if not cutlass.const_expr(self.use_clc_scheduler):
+            mma_compute_S_producer.tail()
+            mma_compute_dP_producer.tail()
+            mma_compute_dKdV_producer.tail()
+
+        return (
+            mma_compute_S_producer,
+            mma_compute_dP_producer,
+            mma_compute_dKdV_producer,
+            load_mma_Q_consumer,
+            load_mma_K_consumer,
+            load_mma_V_consumer,
+            load_mma_dO_consumer,
+            load_mma_dOT_consumer,
+            compute_mma_P_consumer,
+            compute_mma_dS_consumer,
+            load_mma_QT_consumer,
+        )
+
+    @cute.jit
+    def reg_to_smem_mma64x64(
+        self,
+        regs: cute.Tensor,
+        smem: cute.Tensor,
+        index: Int32,
+        tiler_mn: tuple[Int32, Int32],
+        dp_idx: Int32,
+        wg_idx: Int32,
+    ):
+        smem_slice = smem[None, None, None, index]
+        # TODO: double check the layout of the data in reg.
+        # TODO: this may introduce additional smem transpose.
+        thread_layout = cute.make_ordered_layout(
+            tiler_mn,
+            (0, 1),  # TODO: (0,1) or (1,0) ???
+        )
+        smem_slice_tmp = cute.composition(smem_slice, thread_layout)
+
+        # TODO: temporary code for tile 64 x 64.
+        tmp_shape = ((8, 2, 4), (2, 4, 2, 2, 2))
+        tmp_stride = ((64, 512, 1024), (1, 2, 8, 16, 32))
+        smem_copy = cute.composition(smem_slice_tmp, cute.make_layout(tmp_shape, stride=tmp_stride))
+
+        # TODO: the following code is only for tile 64 x 64.
+        # TODO: need to modify the code for other tile sizes.
+        lane_idx = dp_idx % 32
+        reg_shape = regs.shape
+        atom_loops = reg_shape[0][0][2]
+        block_loops = reg_shape[2]
+        # | 00 ~ 07 | 08 ~ 15 | 16 ~ 23 | 24 ~ 31 | 32 ~ 39 | 40 ~ 47 | 48 ~ 55 | 56 ~ 63 |
+        # |---- atom size ----|---- atom size ----|---- atom size ----|---- atom size ----|
+        # |----     wg0   ----|----     wg1   ----|----     wg0   ----|----     wg1   ----|
+        for ia in cutlass.range(atom_loops):
+            for ib in cutlass.range(block_loops):
+                # the lower 8 lines
+                regs_copy = regs[((None, 0, ia), 0), 0, ib]  # two elements
+                smem_copy_slice = smem_copy[
+                    (lane_idx // 4, 0, dp_idx // 32),
+                    (None, lane_idx % 4, ia, wg_idx, ib),
+                ]
+                cute.autovec_copy(regs_copy, smem_copy_slice)
+                # the upper 8 lines
+                regs_copy = regs[((None, 1, ia), 0), 0, ib]
+                smem_copy_slice = smem_copy[
+                    (lane_idx // 4, 1, dp_idx // 32),
+                    (None, lane_idx % 4, ia, wg_idx, ib),
+                ]
+                cute.autovec_copy(regs_copy, smem_copy_slice)
+
+    @cute.jit
+    def reg_to_smem_mma128x128_2cta(
+        self,
+        regs: cute.Tensor,
+        smem: cute.Tensor,
+        index: Int32,
+        tiler_mn: tuple[Int32, Int32],
+        dp_idx: Int32,
+        wg_idx: Int32,
+        smem_RowMajor: bool = True,
+    ):
+        smem_slice = smem[None, None, None, index]
+        # K>> smem_slice:  tensor<ptr<f16, smem, align<1024>, S<3,4,3>> o ((64,16),1,(4,2)):((64,1),0,(16,4096))>
+        thread_layout = cute.make_ordered_layout(
+            # (tileN, tileM)
+            tiler_mn,
+            (0, 1),
+        )
+        # K>> thread_layout:  (64,128):(128,1)
+        smem_slice_tmp = cute.composition(smem_slice, thread_layout)
+
+        # NOTE: hardcode for tcgen05.ld.32x32b.x8 & mma128x64+2cta
+        # tmp_shape = ((32, 2), (8, 2, 2, 2)) # for 64x64 tile
+        # tmp_stride = ((64, 32*64), (1, 8, 16, 32))
+        # NOTE: hardcode for tcgen05.ld.32x32b.x16 & mma128x64+2cta
+        tmp_shape = ((32, 2), (16, 2, 2, 2))  # for 128x64 tile
+        tmp_stride = ((64, 32 * 64), (1, 16, 32, 64 * 64))
+        # smem_copy = cute.composition(smem_slice_tmp, cute.make_layout(tmp_shape, stride=tmp_stride))
+        smem_copy = cute.make_tensor(
+            smem_slice_tmp.iterator, cute.make_layout(tmp_shape, stride=tmp_stride)
+        )
+
+        warp_idx = dp_idx // 32
+        warp_row_idx = warp_idx % 2
+        warp_col_idx = warp_idx // 2  # corresponding to the second 64 cols in smem
+        lane_idx = dp_idx % 32
+        reg_shape = (
+            regs.shape
+        )  # ((8,1),1,2):((1,0),0,8) for 64x64, ((16,1),1,2):((1,0),0,16) for 128x64
+        block_loops = reg_shape[2]
+
+        # TODO: maybe can use cp.async for optimization
+        for ib in cutlass.range(block_loops):
+            regs_copy = regs[(None, 0), 0, ib]
+            smem_copy_slice = smem_copy[(lane_idx, warp_row_idx), (None, wg_idx, ib, warp_col_idx)]
+            cute.autovec_copy(regs_copy, smem_copy_slice)
+
+    @cute.jit
+    def reg_to_smem_mma128x64_2cta(
+        self,
+        regs: cute.Tensor,
+        smem: cute.Tensor,
+        index: Int32,
+        tiler_mn: tuple[Int32, Int32],
+        dp_idx: Int32,
+        wg_idx: Int32,
+        smem_RowMajor: bool = True,
+    ):
+        smem_slice = smem[None, None, None, index]
+        thread_layout = cute.make_ordered_layout(
+            # (tileN, tileM)
+            tiler_mn,
+            (1, 0) if smem_RowMajor else (0, 1),
+        )
+        smem_slice_tmp = cute.composition(smem_slice, thread_layout)
+        # NOTE: hardcode for tcgen05.ld.32x32b.x8 & mma128x64+2cta
+        tmp_shape = ((32, 2), (8, 2, 2, 2))
+        tmp_stride = ((64, 32 * 64), (1, 8, 16, 32))
+        smem_copy = cute.composition(smem_slice_tmp, cute.make_layout(tmp_shape, stride=tmp_stride))
+
+        warp_idx = dp_idx // 32
+        warp_row_idx = warp_idx % 2
+        warp_col_idx = warp_idx // 2
+        lane_idx = dp_idx % 32
+        reg_shape = regs.shape  # ((8,1),1,2):((1,0),0,8)
+        block_loops = reg_shape[2]
+
+        # TODO: maybe can use cp.async for optimization
+        for ib in cutlass.range(block_loops):
+            regs_copy = regs[(None, 0), 0, ib]
+            smem_copy_slice = smem_copy[(lane_idx, warp_row_idx), (None, wg_idx, ib, warp_col_idx)]
+            cute.autovec_copy(regs_copy, smem_copy_slice)
+
+    @cute.jit
+    def compute(
+        self,
+        tSTtST: cute.Tensor,
+        tdPTtdPT: cute.Tensor,
+        tdVrP: cute.Tensor,
+        sP: cute.Tensor,
+        sLSE: cute.Tensor,
+        # sdS: cute.Tensor,
+        sdST: cute.Tensor,
+        sSum_OdO: cute.Tensor,
+        dK: cute.Tensor,
+        dV: cute.Tensor,
+        tdKtdK: cute.Tensor,
+        tdVtdV: cute.Tensor,
+        PdO_tiled_mma: cute.TiledMma,
+        dSQ_tiled_mma: cute.TiledMma,
+        blk_coord: cute.Coord,
+        blk_offset: cute.Shape,
+        problem_shape: tuple[Int32, Int32, Int32, tuple[tuple[Int32, Int32], Int32]],
+        iter_count: Int32,
+        iter_start: Int32,
+        iter_end: Int32,
+        scale_softmax: cutlass.Float32,
+        mma_compute_S_producer,
+        mma_compute_S_consumer,
+        compute_mma_P_producer,
+        compute_mma_P_consumer,
+        load_compute_LSE_producer,
+        load_compute_LSE_consumer,
+        load_compute_sum_OdO_producer,
+        load_compute_sum_OdO_consumer,
+        mma_compute_dP_producer,
+        mma_compute_dP_consumer,
+        compute_mma_dS_producer,
+        compute_mma_dS_consumer,
+        mma_compute_dKdV_producer,
+        mma_compute_dKdV_consumer,
+        varlen: bool,
+        sK: cute.Tensor,
+        problem_shape_k_cur_batch: Int32,
+    ):
+        """CuTeDSL kernel for recomputing softmax and producing dk and dv."""
+        tidx, _, _ = cute.arch.thread_idx()
+        Q, K, _, _ = problem_shape
+        _, blk_coord_k, _, _ = blk_coord
+
+        iter_index = iter_start
+
+        # adi: TMEM_ST, TMEM_DPT
+        tmem_load_op = tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(16))
+        tmem_load_atom = cute.make_copy_atom(
+            tmem_load_op,
+            self.acc_dtype,
+        )
+
+        tSTtST = tSTtST[(None, None), 0, 0]
+        tdPTtdPT = tdPTtdPT[(None, None), 0, 0]
+
+        cST = cute.make_identity_tensor(cute.select(self.cta_tiler, mode=[1, 0]))
+        cdPT = cute.make_identity_tensor(cute.select(self.cta_tiler, mode=[1, 0]))
+
+        num_warp_groups = self.num_compute_warps // 4
+        dp_idx = tidx % 128
+        wg_idx = (tidx % (self.num_compute_warps * self.threads_per_warp)) // 128
+        tiled_t2r = tcgen05.make_tmem_copy(tmem_load_atom, tSTtST)
+        thr_t2r = tiled_t2r.get_slice(dp_idx)
+
+        tTR_cST = thr_t2r.partition_D(cST)
+        tTR_cST = split_wg(tTR_cST, num_warp_groups, wg_idx)
+        tTR_rST = cute.make_rmem_tensor(tTR_cST.shape, self.acc_dtype)
+
+        tTR_tST = thr_t2r.partition_S(tSTtST)
+        tTR_tST = split_wg(tTR_tST, num_warp_groups, wg_idx)
+
+        tTR_cdPT_p = thr_t2r.partition_D(cdPT)
+        tTR_cdPT = split_wg(tTR_cdPT_p, num_warp_groups, wg_idx)
+        tTR_rdPT = cute.make_rmem_tensor(tTR_cdPT.shape, self.acc_dtype)
+
+        tTR_tdPT = thr_t2r.partition_S(tdPTtdPT)
+        tTR_tdPT = split_wg(tTR_tdPT, num_warp_groups, wg_idx)
+
+        tdVcST = PdO_tiled_mma.get_slice(0).partition_A(cST)
+
+        is_residual_k = blk_coord_k * self.tile_shape_K + self.tile_shape_K > K
+        last_iter = iter_end - 1
+
+        while iter_count > 0:
+            s_handle = mma_compute_S_consumer.wait_and_advance()
+            p_handle = compute_mma_P_producer.acquire_and_advance()
+            lse_handle = load_compute_LSE_consumer.wait_and_advance()
+
+            leading_causal_masking = cutlass.Boolean(False)
+            if cutlass.const_expr(self.is_causal):
+                # TODO: could be optimized by specify an exact iter_index
+                #
+                # NOTE (causal + 2CTA correctness):
+                # `iter_start` can be rounded down to an even index for 2CTA. When the true
+                # causal boundary Q tile is odd, it becomes (iter_start + 1). In that case,
+                # we must treat both (iter_start, iter_start + 1) as "masked tiles" so the
+                # per-element causal mask is applied on the boundary tile too.
+                leading_causal_masking = iter_index == iter_start
+                q_block_min_unaligned = (
+                    blk_coord_k * self.tile_shape_K + Q - K - self.window_size_right
+                ) // self.tile_shape_Q
+                boundary_in_second = (q_block_min_unaligned % 2) == 1
+                leading_causal_masking = leading_causal_masking or (
+                    boundary_in_second and (iter_index == iter_start + 1)
+                )
+                offset_partial_tile = (K - Q) % self.tile_shape_K
+                need_additional_mask = offset_partial_tile and iter_index == iter_start + 1
+                leading_causal_masking = leading_causal_masking or need_additional_mask
+                leading_causal_masking = cute.arch.shuffle_sync(leading_causal_masking, 0)
+
+            trailing_residual_masking = cutlass.Boolean(False)
+            trailing_residual_masking = iter_index == last_iter or is_residual_k
+            trailing_residual_masking = cute.arch.shuffle_sync(trailing_residual_masking, 0)
+
+            # For causal, every tile may contain (q,k) with k > q; we must apply per-element mask for all Q tiles.
+            is_masked_tile = (
+                leading_causal_masking
+                or trailing_residual_masking
+                or self.has_sliding_window
+                or cutlass.const_expr(self.is_causal)
+            )
+
+            # Compute P = softmax(S, LSE)
+            cute.copy(tiled_t2r, tTR_tST, tTR_rST)
+
+            if is_masked_tile:
+                for i in cutlass.range(cute.size(tTR_rST), unroll_full=True):
+                    c_transpose = tTR_cST[i]
+                    pos = (
+                        cute.get(c_transpose, mode=[1]) + iter_index * self.tile_shape_Q,
+                        cute.get(c_transpose, mode=[0]) + blk_coord_k * self.tile_shape_K,
+                    )
+                    if cutlass.const_expr(self.has_sliding_window):
+                        if cutlass.const_expr(self.window_size_left < 0):
+                            tTR_rST[i] = (
+                                -cutlass.Float32.inf
+                                if pos[1] > pos[0] + K - Q + self.window_size_right
+                                else tTR_rST[i]
+                            )
+                        else:
+                            max_K_index = min(pos[0] + K - Q + self.window_size_right, K)
+                            min_K_index = max(0, pos[0] + K - Q - self.window_size_left)
+                            tTR_rST[i] = (
+                                -cutlass.Float32.inf
+                                if pos[1] > max_K_index or pos[1] < min_K_index
+                                else tTR_rST[i]
+                            )
+                    if cutlass.const_expr(self.is_causal) and (
+                        pos[0] + K - Q < pos[1] or not cute.elem_less(pos, (Q, K))
+                    ):
+                        tTR_rST[i] = -cutlass.Float32.inf
+                    if not cute.elem_less(pos, (Q, K)):
+                        tTR_rST[i] = -cutlass.Float32.inf
+
+            log2_e = cutlass.Float32(math.log2(math.e))
+            softmax_scale_log2_e = scale_softmax * log2_e
+
+            for i in cutlass.range(0, cute.size(tTR_rST), 2, unroll_full=True):
+                lse = (
+                    -sLSE[
+                        cute.get(tTR_cST[i], mode=[1]),
+                        lse_handle.index,
+                    ],
+                    -sLSE[
+                        cute.get(tTR_cST[i + 1], mode=[1]),
+                        lse_handle.index,
+                    ],
+                )
+                tTR_rST[i], tTR_rST[i + 1] = cute.arch.fma_packed_f32x2(
+                    (tTR_rST[i], tTR_rST[i + 1]),
+                    (softmax_scale_log2_e, softmax_scale_log2_e),
+                    lse,
+                )
+                tTR_rST[i] = cute.math.exp2(tTR_rST[i], fastmath=True)
+                tTR_rST[i + 1] = cute.math.exp2(tTR_rST[i + 1], fastmath=True)
+
+            # convert fp32 P to fp16 P which will be used in the PdO
+            tTR_rPT = self.quantize(tTR_rST, dV.element_type)  # tTR_rST is ST in fp32 in RF.
+            self.reg_to_smem_mma128x128_2cta(
+                tTR_rPT,
+                sP,
+                p_handle.index,
+                (self.tile_shape_K, self.tile_shape_Q),
+                dp_idx,
+                wg_idx,
+            )
+            cute.arch.fence_view_async_shared()
+            cute.arch.barrier(
+                barrier_id=self.compute_sync_bar_id,
+                number_of_threads=self.num_compute_warps * self.threads_per_warp,
+            )
+
+            p_handle.commit()
+
+            s_handle.release()
+            lse_handle.release()
+
+            sum_odo_handle = load_compute_sum_OdO_consumer.wait_and_advance()
+            dp_handle = mma_compute_dP_consumer.wait_and_advance()
+            ds_handle = compute_mma_dS_producer.acquire_and_advance()
+
+            # Compute dS = dsoftmax(P, dP, sum_OdO)
+            cute.copy(tiled_t2r, tTR_tdPT, tTR_rdPT)
+
+            for i in cutlass.range(0, cute.size(tTR_rdPT), 2, unroll_full=True):
+                dpsum_0 = -sSum_OdO[
+                    cute.get(tTR_cdPT[i], mode=[1]),
+                    sum_odo_handle.index,
+                ]
+                dpsum_1 = -sSum_OdO[
+                    cute.get(tTR_cdPT[i + 1], mode=[1]),
+                    sum_odo_handle.index,
+                ]
+                if cutlass.const_expr(varlen):
+                    if not cute.elem_less(cute.get(tTR_cdPT[i], mode=[1]), Q):
+                        dpsum_0 = 0.0
+                    if not cute.elem_less(cute.get(tTR_cdPT[i + 1], mode=[1]), Q):
+                        dpsum_1 = 0.0
+                tTR_rdPT[i], tTR_rdPT[i + 1] = cute.arch.add_packed_f32x2(
+                    (tTR_rdPT[i], tTR_rdPT[i + 1]),
+                    (dpsum_0, dpsum_1),
+                )
+                tTR_rdPT[i], tTR_rdPT[i + 1] = cute.arch.mul_packed_f32x2(
+                    (tTR_rdPT[i], tTR_rdPT[i + 1]), (tTR_rST[i], tTR_rST[i + 1])
+                )
+            # For causal, force dS to zero at masked (q,k) so dK/dV accumulation is correct
+            if cutlass.const_expr(self.is_causal):
+                for i in cutlass.range(cute.size(tTR_rdPT), unroll_full=True):
+                    c_transpose = tTR_cdPT[i]
+                    pos = (
+                        cute.get(c_transpose, mode=[1]) + iter_index * self.tile_shape_Q,
+                        cute.get(c_transpose, mode=[0]) + blk_coord_k * self.tile_shape_K,
+                    )
+                    if pos[0] + K - Q < pos[1] or not cute.elem_less(pos, (Q, K)):
+                        tTR_rdPT[i] = cutlass.Float32(0.0)
+            # convert fp32 dS to fp16 dS which will be used in the computation of dK and DQ
+            tTR_rdST = self.quantize(tTR_rdPT, dV.element_type)
+
+            cute.arch.fence_view_async_tmem_load()
+            dp_handle.release()
+
+            self.reg_to_smem_mma128x128_2cta(
+                tTR_rdST,
+                sdST,
+                ds_handle.index,
+                (self.tile_shape_K, self.tile_shape_Q),
+                dp_idx,
+                wg_idx,
+            )
+            cute.arch.fence_view_async_shared()
+            cute.arch.barrier(
+                barrier_id=self.compute_sync_bar_id,
+                number_of_threads=self.num_compute_warps * self.threads_per_warp,
+            )
+
+            ds_handle.commit()
+            sum_odo_handle.release()
+
+            iter_count -= 1
+            iter_index += 1
+            if iter_index == iter_end:
+                iter_index = iter_start
+
+        # Epilogue
+        mma_compute_dKdV_consumer = self.epilogue(
+            blk_coord,
+            blk_offset,
+            problem_shape,
+            dK,
+            dV,
+            tdKtdK,
+            tdVtdV,
+            scale_softmax,
+            mma_compute_dKdV_producer,
+            mma_compute_dKdV_consumer,
+            problem_shape_k_cur_batch,
+        )
+
+        if not cutlass.const_expr(self.use_clc_scheduler):
+            compute_mma_P_producer.tail()
+            compute_mma_dS_producer.tail()
+
+        return (
+            compute_mma_P_producer,
+            compute_mma_dS_producer,
+            mma_compute_S_consumer,
+            compute_mma_P_consumer,
+            load_compute_LSE_consumer,
+            load_compute_sum_OdO_consumer,
+            mma_compute_dP_consumer,
+            compute_mma_dS_consumer,
+            mma_compute_dKdV_consumer,
+        )
+
+    @cute.jit
+    def quantize(
+        self,
+        input_t: cute.Tensor,
+        element_dtype: type[cutlass.Numeric],
+    ) -> cute.Tensor:
+        """Convert Float32 to element dtype."""
+        output = cute.make_rmem_tensor(input_t.shape, element_dtype)
+        output.store(input_t.load().to(element_dtype))
+        return output
+
+    @cute.jit
+    def store(
+        self,
+        gmem: cute.Tensor,
+        regs: cute.Tensor,
+        coord: cute.Tensor,
+        tensor_shape: cute.Shape,
+    ):
+        for i in cutlass.range(cute.size(coord, mode=[2]), unroll_full=True):
+            coord_i = coord[None, 0, i]
+            gmem_i = gmem[None, 0, i]
+            regs_i = regs[None, 0, i]
+            if cute.elem_less(coord_i[0], tensor_shape):
+                gmem_i.store(regs_i.load().to(gmem.element_type))
+
+    @cute.jit
+    def epilogue_clear(
+        self,
+        blk_coord: cute.Coord,
+        blk_offset: cute.Shape,
+        problem_shape: tuple[Int32, Int32, Int32, tuple[tuple[Int32, Int32], Int32]],
+        dK: cute.Tensor,
+        dV: cute.Tensor,
+    ):
+        """Early stopping needs to clear dK and dV."""
+        tidx, _, _ = cute.arch.thread_idx()
+        block_dim_x, _, _ = cute.arch.block_dim()
+        _, K, _, HB = problem_shape
+        _, blk_coord_k, _, blk_coord_batch = blk_coord
+
+        mdK_offset = cute.assume(blk_offset[1] * dK.stride[0], divby=64)
+        mdK = cute.make_tensor(
+            dK.iterator + mdK_offset,
+            cute.make_layout((K, self.tile_shape_dQ_K, HB), stride=dK.stride),
+        )
+        gdK = cute.local_tile(
+            mdK, (self.dSQ_mma_tiler[0], self.dSQ_mma_tiler[1]), (None, None, None)
+        )
+        gdK = gdK[None, None, blk_coord_k, 0, blk_coord_batch]
+        cdK = cute.domain_offset(
+            (blk_coord_k * self.tile_shape_K, 0),
+            cute.make_identity_tensor((self.dSQ_mma_tiler[0], self.dSQ_mma_tiler[1])),
+        )
+
+        mdV_offset = cute.assume(blk_offset[1] * dV.stride[0], divby=64)
+        mdV = cute.make_tensor(
+            dV.iterator + mdV_offset,
+            cute.make_layout((K, self.tile_shape_dV_dO, HB), stride=dV.stride),
+        )
+        gdV = cute.local_tile(
+            mdV, (self.PdO_mma_tiler[0], self.PdO_mma_tiler[1]), (None, None, None)
+        )
+        gdV = gdV[None, None, blk_coord_k, 0, blk_coord_batch]
+        cdV = cute.domain_offset(
+            (blk_coord_k * self.tile_shape_K, 0),
+            cute.make_identity_tensor((self.PdO_mma_tiler[0], self.PdO_mma_tiler[1])),
+        )
+
+        for i in cutlass.range(tidx * 8, cute.size(gdK), block_dim_x * 8):
+            if cute.elem_less(cdK[i], cute.select(problem_shape, mode=[1, 2])):
+                gdK_i = cute.make_tensor(gdK.iterator + cute.assume(i, divby=8), (8))
+                gdK_i.fill(0)
+
+        for i in cutlass.range(tidx * 8, cute.size(gdV), block_dim_x * 8):
+            if cute.elem_less(cdV[i], cute.select(problem_shape, mode=[1, 2])):
+                gdV_i = cute.make_tensor(gdV.iterator + cute.assume(i, divby=8), (8))
+                gdV_i.fill(0)
+
+    @cute.jit
+    def epilogue(
+        self,
+        blk_coord: cute.Coord,
+        blk_offset: cute.Shape,
+        problem_shape: tuple[Int32, Int32, Int32, tuple[tuple[Int32, Int32], Int32]],
+        dK: cute.Tensor,
+        dV: cute.Tensor,
+        tdKtdK: cute.Tensor,
+        tdVtdV: cute.Tensor,
+        scale_softmax: cutlass.Float32,
+        mma_compute_dKdV_producer,
+        mma_compute_dKdV_consumer,
+        problem_shape_k_cur_batch: Int32,
+    ):
+        """Epilogue phase to store result from tensor memory to register, then global memory."""
+        tidx, _, _ = cute.arch.thread_idx()
+        _, K, D, HB = problem_shape
+        _, blk_coord_k, _, blk_coord_batch = blk_coord
+
+        # adi: TMEM_DK, TMEM_DV
+        tmem_copy_op = tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32))
+        load_op = cute.make_copy_atom(
+            tmem_copy_op,
+            self.acc_dtype,
+        )
+
+        tdKtdK = tdKtdK[(None, None), 0, 0]
+        mdK_offset = cute.assume(blk_offset[1] * dK.stride[0], divby=64)
+        mdK = cute.make_tensor(
+            dK.iterator + mdK_offset,
+            cute.make_layout((K, self.tile_shape_dQ_K, HB), stride=dK.stride),
+        )
+        gdK = cute.local_tile(mdK, (self.cta_tiler[1], self.cta_tiler[2]), (None, None, None))
+        gdK = gdK[None, None, blk_coord_k, 0, blk_coord_batch]
+        cdK = cute.domain_offset(
+            (blk_coord_k * self.tile_shape_K, 0),
+            cute.make_identity_tensor((self.cta_tiler[1], self.cta_tiler[2])),
+        )
+
+        num_warp_groups = self.num_compute_warps // 4
+        dp_idx = tidx % 128
+        wg_idx = (tidx % (self.num_compute_warps * self.threads_per_warp)) // 128
+
+        tiled_t2r_dK = tcgen05.make_tmem_copy(load_op, tdKtdK)
+        thread_t2r_dK = tiled_t2r_dK.get_slice(dp_idx)
+
+        tTR_cdK = thread_t2r_dK.partition_D(cdK)
+        tTR_cdK = split_wg(tTR_cdK, num_warp_groups, wg_idx)
+        tTR_gdK = thread_t2r_dK.partition_D(gdK)
+        tTR_gdK = split_wg(tTR_gdK, num_warp_groups, wg_idx)
+        tTR_rdK = cute.make_rmem_tensor(tTR_cdK.shape, self.acc_dtype)
+        tTR_tdK = thread_t2r_dK.partition_S(tdKtdK)
+        tTR_tdK = split_wg(tTR_tdK, num_warp_groups, wg_idx)
+
+        mdV_in = cute.make_tensor(
+            dV.iterator, cute.make_layout((K, self.cta_tiler[2], HB), stride=dV.stride)
+        )
+        offset_mdV = cute.assume(blk_offset[1] * mdV_in.stride[0], divby=64)
+        mdV = cute.make_tensor(mdV_in.iterator + offset_mdV, mdV_in.layout)
+        gdV = cute.local_tile(mdV, (self.cta_tiler[1], self.cta_tiler[2]), (None, None, None))
+        gdV = gdV[None, None, blk_coord_k, 0, blk_coord_batch]
+
+        cdV = cute.domain_offset(
+            (blk_coord_k * self.cta_tiler[1], 0),
+            cute.make_identity_tensor((self.cta_tiler[1], self.cta_tiler[2])),
+        )
+
+        tdVtdV = tdVtdV[(None, None), 0, 0]
+
+        tiled_t2r_dV = tcgen05.make_tmem_copy(load_op, tdVtdV)
+        thread_t2r_dV = tiled_t2r_dV.get_slice(dp_idx)
+
+        tTR_cdV = thread_t2r_dV.partition_D(cdV)
+        tTR_cdV = split_wg(tTR_cdV, num_warp_groups, wg_idx)
+        tTR_gdV = thread_t2r_dV.partition_D(gdV)
+        tTR_gdV = split_wg(tTR_gdV, num_warp_groups, wg_idx)
+        tTR_rdV = cute.make_rmem_tensor(tTR_cdV.shape, self.acc_dtype)
+        tTR_tdV = thread_t2r_dV.partition_S(tdVtdV)
+        tTR_tdV = split_wg(tTR_tdV, num_warp_groups, wg_idx)
+
+        dkdv_handle = mma_compute_dKdV_consumer.wait_and_advance()
+
+        if blk_coord_k * self.tile_shape_K < problem_shape_k_cur_batch:
+            cute.copy(tiled_t2r_dV, tTR_tdV, tTR_rdV)
+            self.store(tTR_gdV, tTR_rdV, tTR_cdV, (K, D))
+
+        cute.arch.fence_view_async_tmem_load()
+        dkdv_handle.release()
+
+        dkdv_handle = mma_compute_dKdV_consumer.wait_and_advance()
+
+        if blk_coord_k * self.tile_shape_K < problem_shape_k_cur_batch:
+            cute.copy(tiled_t2r_dK, tTR_tdK, tTR_rdK)
+
+            for i in cutlass.range(cute.size(tTR_rdK), unroll_full=True):
+                tTR_rdK[i] = scale_softmax * tTR_rdK[i]
+
+            self.store(tTR_gdK, tTR_rdK, tTR_cdK, (K, D))
+
+        cute.arch.fence_view_async_tmem_load()
+        dkdv_handle.release()
+
+        return mma_compute_dKdV_consumer
+
+    def get_workspace_tensor(
+        self,
+        problem_shape: tuple[Int32, Int32, Int32, tuple[tuple[Int32, Int32], Int32]],
+        workspace: cute.Tensor,
+        acc_dtype: type[cutlass.Numeric],
+        varlen: bool,
+    ) -> tuple[cute.Tensor, cute.Tensor, cute.Tensor]:
+        """Get workspace tensor."""
+        D = problem_shape[2]
+        H, B = cute.size(problem_shape[3][0]), cute.size(problem_shape[3][1])
+        H_r, H_k = problem_shape[3][0]
+        D = cute.round_up(D, 8)
+
+        # b = 1 for varlen, else batch_size
+        b = workspace.shape[0]
+        # s_q_sum for varlen, else s_q_max, already rounded to 8
+        S_Q = workspace.shape[1]
+
+        acc_bytes = acc_dtype.width // 8
+        sum_OdO_bytes = cute.assume(b * H * S_Q * acc_bytes, divby=acc_bytes)
+        scaled_lse_bytes = cute.assume(b * H * S_Q * acc_bytes, divby=acc_bytes)
+
+        sum_OdO_iter = workspace.iterator
+        scaled_lse_iter = sum_OdO_iter + sum_OdO_bytes
+
+        sum_OdO_iter = cute.recast_ptr(sum_OdO_iter, dtype=self.acc_dtype)
+        scaled_lse_iter = cute.recast_ptr(scaled_lse_iter, dtype=self.acc_dtype)
+
+        sum_OdO = cute.make_tensor(
+            sum_OdO_iter,
+            cute.make_layout(
+                (S_Q, ((H_r, H_k), B)),
+                stride=(1, ((S_Q, S_Q * H_r), 0 if varlen else S_Q * H)),
+            ),
+        )
+        scaled_lse = cute.make_tensor(
+            scaled_lse_iter,
+            cute.make_layout(
+                (S_Q, ((H_r, H_k), B)),
+                stride=(1, ((S_Q, S_Q * H_r), 0 if varlen else S_Q * H)),
+            ),
+        )
+
+        return sum_OdO, scaled_lse
+
+    @staticmethod
+    def _compute_sum_OdO_grid(
+        problem_shape: tuple[Int32, Int32, Int32, tuple[tuple[Int32, Int32], Int32]],
+        block_q: int,
+    ) -> tuple[Int32, Int32, Int32]:
+        """Compute grid shape for sum_OdO kernel."""
+        return (
+            cute.ceil_div(cute.size(problem_shape[0]), block_q),
+            cute.size(problem_shape[3][0]),  # H
+            cute.size(problem_shape[3][1]),  # B
+        )
+
+    @staticmethod
+    def _compute_bwd_grid(
+        problem_shape: tuple[Int32, Int32, Int32, tuple[tuple[Int32, Int32], Int32]],
+        block_k: int,
+    ) -> tuple[Int32, Int32, Int32]:
+        """Compute grid shape for bwd kernel."""
+        K = problem_shape[1]
+        _, H_K = problem_shape[3][0]
+        B = problem_shape[3][1]
+        return (cute.ceil_div(K, block_k), cute.size(H_K), cute.size(B))
+
+    @staticmethod
+    def get_workspace_size(s_q: int, d: int, h: int, b: int, acc_dtype: type[cutlass.Numeric]):
+        """Get workspace size."""
+        d = (d + 7) // 8 * 8  # round up to 8
+        s_q = (s_q + 7) // 8 * 8  # round up to 8
+        workspace_bytes = 0
+        # OdO vector
+        workspace_bytes += acc_dtype.width // 8
+        # scaled LSE vector
+        workspace_bytes += acc_dtype.width // 8
+        # FP32 versions of outputs that are churned (start off with Q only)
+        workspace_bytes += d * acc_dtype.width // 8
+        return (b, s_q, h, workspace_bytes)
+
+    def make_and_init_load_mma_K_pipeline(self, load_mma_K_mbar_ptr, cluster_layout_vmnk):
+        """Create and initialize barrier for load mma Q."""
+        load_mma_K_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, len([self.load_warp_id])
+        )
+        load_mma_K_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, len([self.mma_warp_id])
+        )
+        return pipeline.PipelineTmaUmma.create(
+            barrier_storage=load_mma_K_mbar_ptr,
+            num_stages=self.load_mma_K_stage,
+            producer_group=load_mma_K_producer_group,
+            consumer_group=load_mma_K_consumer_group,
+            tx_count=self.tma_copy_K_bytes,
+            cta_layout_vmnk=cluster_layout_vmnk,
+        )
+
+    def make_and_init_load_mma_V_pipeline(self, load_mma_V_mbar_ptr, cluster_layout_vmnk):
+        """Create and initialize barrier for load mma Q."""
+        load_mma_V_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, len([self.load_warp_id])
+        )
+        load_mma_V_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, len([self.mma_warp_id])
+        )
+        return pipeline.PipelineTmaUmma.create(
+            barrier_storage=load_mma_V_mbar_ptr,
+            num_stages=self.load_mma_V_stage,
+            producer_group=load_mma_V_producer_group,
+            consumer_group=load_mma_V_consumer_group,
+            tx_count=self.tma_copy_V_bytes,
+            cta_layout_vmnk=cluster_layout_vmnk,
+        )
+
+    def make_and_init_load_mma_Q_pipeline(self, load_mma_Q_mbar_ptr, cluster_layout_vmnk):
+        """Create and initialize barrier for load mma Q."""
+        load_mma_Q_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, len([self.load_warp_id])
+        )
+        load_mma_Q_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, len([self.mma_warp_id])
+        )
+        return pipeline.PipelineTmaUmma.create(
+            barrier_storage=load_mma_Q_mbar_ptr,
+            num_stages=self.load_mma_Q_stage,
+            producer_group=load_mma_Q_producer_group,
+            consumer_group=load_mma_Q_consumer_group,
+            tx_count=self.tma_copy_Q_bytes,
+            cta_layout_vmnk=cluster_layout_vmnk,
+        )
+
+    def make_and_init_load_mma_QT_pipeline(self, load_mma_QT_mbar_ptr, cluster_layout_vmnk):
+        """Create and initialize barrier for load mma QT."""
+        load_mma_QT_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, len([self.load_warp_id])
+        )
+        load_mma_QT_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, len([self.mma_warp_id])
+        )
+        return pipeline.PipelineTmaUmma.create(
+            barrier_storage=load_mma_QT_mbar_ptr,
+            num_stages=self.load_mma_QT_stage,
+            producer_group=load_mma_QT_producer_group,
+            consumer_group=load_mma_QT_consumer_group,
+            tx_count=self.tma_copy_Q_bytes,
+            cta_layout_vmnk=cluster_layout_vmnk,
+        )
+
+    def make_and_init_load_mma_dO_pipeline(self, load_mma_dO_mbar_ptr, cluster_layout_vmnk):
+        """Create and initialize barrier for load mma dO."""
+        load_mma_dO_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, len([self.load_warp_id])
+        )
+        load_mma_dO_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, len([self.mma_warp_id])
+        )
+        return pipeline.PipelineTmaUmma.create(
+            barrier_storage=load_mma_dO_mbar_ptr,
+            num_stages=self.load_mma_dO_stage,
+            producer_group=load_mma_dO_producer_group,
+            consumer_group=load_mma_dO_consumer_group,
+            tx_count=self.tma_copy_dO_bytes,
+            cta_layout_vmnk=cluster_layout_vmnk,
+        )
+
+    def make_and_init_load_compute_LSE_pipeline(self, load_compute_lse_mbar_ptr):
+        """Create and initialize barrier for load compute lse."""
+        load_compute_lse_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.threads_per_warp,
+            # self.threads_per_warp,
+        )
+        load_compute_lse_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.threads_per_warp * self.num_compute_warps,
+            # self.threads_per_warp * self.num_compute_warps,
+        )
+        return pipeline.PipelineCpAsync.create(
+            barrier_storage=load_compute_lse_mbar_ptr,
+            num_stages=self.load_compute_LSE_stage,
+            producer_group=load_compute_lse_producer_group,
+            consumer_group=load_compute_lse_consumer_group,
+        )
+
+    def make_and_init_load_compute_sum_OdO_pipeline(self, load_compute_sum_OdO_mbar_ptr):
+        """Create and initialize barrier for load sum OdO."""
+        load_compute_sum_OdO_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.threads_per_warp,
+            # self.threads_per_warp,
+        )
+        load_compute_sum_OdO_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.threads_per_warp * self.num_compute_warps,
+            # self.threads_per_warp * self.num_compute_warps,
+        )
+        return pipeline.PipelineCpAsync.create(
+            barrier_storage=load_compute_sum_OdO_mbar_ptr,
+            num_stages=self.load_compute_sum_OdO_stage,
+            producer_group=load_compute_sum_OdO_producer_group,
+            consumer_group=load_compute_sum_OdO_consumer_group,
+        )
+
+    def make_and_init_mma_compute_S_pipeline(self, mma_compute_S_mbar_ptr, cluster_layout_vmnk):
+        """Create and initialize barrier for mma S."""
+        mma_compute_S_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            len([self.mma_warp_id]),
+        )
+        mma_compute_S_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.num_compute_warps * self.threads_per_warp * cluster_layout_vmnk.shape[0][0],
+        )
+        return pipeline.PipelineUmmaAsync.create(
+            barrier_storage=mma_compute_S_mbar_ptr,
+            num_stages=self.mma_compute_S_stage,
+            producer_group=mma_compute_S_producer_group,
+            consumer_group=mma_compute_S_consumer_group,
+            cta_layout_vmnk=cluster_layout_vmnk,
+        )
+
+    #  Barrier to between dP = v * dO and consume of dP in compute()
+    def make_and_init_mma_compute_dP_pipeline(self, mma_compute_dP_mbar_ptr, cluster_layout_vmnk):
+        """Create and initialize barrier for mma Q."""
+        mma_compute_dP_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            len([self.mma_warp_id]),
+        )
+        mma_compute_dP_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.num_compute_warps * self.threads_per_warp * cluster_layout_vmnk.shape[0][0],
+        )
+        return pipeline.PipelineUmmaAsync.create(
+            barrier_storage=mma_compute_dP_mbar_ptr,
+            num_stages=self.mma_compute_dP_stage,
+            producer_group=mma_compute_dP_producer_group,
+            consumer_group=mma_compute_dP_consumer_group,
+            cta_layout_vmnk=cluster_layout_vmnk,
+        )
+
+    def make_and_init_compute_mma_P_pipeline(self, compute_mma_P_mbar_ptr, cluster_layout_vmnk):
+        """Create and initialize barrier for mma P."""
+        compute_mma_P_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.num_compute_warps * self.threads_per_warp * cluster_layout_vmnk.shape[0][0],
+            # self.num_compute_warps * self.threads_per_warp,
+        )
+        compute_mma_P_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            len([self.mma_warp_id]),
+        )
+        return pipeline.PipelineAsyncUmma.create(
+            barrier_storage=compute_mma_P_mbar_ptr,
+            num_stages=self.compute_mma_P_stage,
+            producer_group=compute_mma_P_producer_group,
+            consumer_group=compute_mma_P_consumer_group,
+            cta_layout_vmnk=cluster_layout_vmnk,
+        )
+
+    def make_and_init_compute_mma_dS_pipeline(self, compute_mma_dS_mbar_ptr, cluster_layout_vmnk):
+        """Create and initialize barrier for mma dS."""
+
+        compute_mma_dS_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.num_compute_warps * self.threads_per_warp * cluster_layout_vmnk.shape[0][0],
+            # self.num_compute_warps * self.threads_per_warp,
+        )
+        compute_mma_dS_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            len([self.mma_warp_id]),
+        )
+
+        return pipeline.PipelineAsyncUmma.create(
+            barrier_storage=compute_mma_dS_mbar_ptr,
+            num_stages=self.compute_mma_dS_stage,
+            producer_group=compute_mma_dS_producer_group,
+            consumer_group=compute_mma_dS_consumer_group,
+            cta_layout_vmnk=cluster_layout_vmnk,
+        )
+
+    def make_and_init_mma_compute_dKdV_pipeline(
+        self, mma_compute_dKdV_mbar_ptr, cluster_layout_vmnk
+    ):
+        """Create and initialize barrier for mma dKdV."""
+        mma_compute_dKdV_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            len([self.mma_warp_id]),
+        )
+        mma_compute_dKdV_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.num_compute_warps * self.threads_per_warp * cluster_layout_vmnk.shape[0][0],
+            # self.num_compute_warps * self.threads_per_warp,
+        )
+        return pipeline.PipelineUmmaAsync.create(
+            barrier_storage=mma_compute_dKdV_mbar_ptr,
+            num_stages=self.mma_compute_dKdV_stage,
+            producer_group=mma_compute_dKdV_producer_group,
+            consumer_group=mma_compute_dKdV_consumer_group,
+            cta_layout_vmnk=cluster_layout_vmnk,
+        )

--- a/flashmask/flash_mask/flash_attn_v4/sm100_hd256_2cta_fmha_backward_dqkernel.py
+++ b/flashmask/flash_mask/flash_attn_v4/sm100_hd256_2cta_fmha_backward_dqkernel.py
@@ -1,0 +1,2145 @@
+# Copyright (c) 2025, Siyu Wang, Shengbin Di, Yuxi Chi, Linfeng Zheng, Haoyan Huang, Lanbo Li, Yun Zhong, Man Yuan, Minmin Sun, Yong Li, Wei Lin.
+
+from typing import Type, Tuple, Optional
+
+import cuda.bindings.driver as cuda
+
+import math
+import cutlass
+import cutlass.cute as cute
+import cutlass.cute.nvgpu.tcgen05 as tcgen05
+from cutlass.cute.nvgpu import cpasync
+import cutlass.utils as utils
+import cutlass.pipeline as pipeline
+import cutlass.utils.blackwell_helpers as sm100_utils
+from cutlass.cute.typing import Int32, Int64, Float32
+
+from cutlass.utils import ClcDynamicPersistentTileScheduler
+from flash_mask.flash_attn_v4.tile_scheduler import (
+    ClcState,
+    compute_sm100_fmha_grid as compute_grid,
+    compute_sm100_fmha_grid_clc as compute_grid_clc,
+    make_sm100_thread_cooperative_group as make_thread_cooperative_group,
+    Sm100FmhaStaticTileScheduler as FmhaStaticTileScheduler,
+    Sm100FmhaStaticTileSchedulerParams as FmhaStaticTileSchedulerParams,
+    Sm100FmhaClcDynamicTileScheduler as FmhaClcDynamicTileScheduler,
+    Sm100FmhaClcDynamicTileSchedulerParams as FmhaClcDynamicTileSchedulerParams,
+)
+from flash_mask.flash_attn_v4.mask import (
+    Sm100FusedMask as FusedMask,
+)
+from flash_mask.flash_attn_v4.tile_scheduler import SM100_TMEM_CAPACITY_COLUMNS
+
+
+class BlackwellFusedMultiHeadAttentionBackwardDQKernel:
+    def __init__(
+        self,
+        acc_dtype: Type[cutlass.Numeric],
+        mma_tiler: Tuple[int, int, int],
+        is_causal: bool,
+        window_size_left: int | None,
+        window_size_right: int | None,
+        is_persistent: bool,
+        split_head: bool,
+        use_clc_scheduler: bool = False,
+    ):
+        self.acc_dtype = acc_dtype
+        self.mma_tiler = mma_tiler
+        self.is_causal = is_causal
+        self.window_size_left = window_size_left
+        # Keep original behavior (known-good in this repo)
+        window_size_left = (
+            None
+            if (window_size_left is None or window_size_left < 0)
+            else cutlass.Int32(window_size_left)
+        )
+        window_size_right = (
+            None
+            if (window_size_right is None or window_size_right < 0)
+            else cutlass.Int32(window_size_right)
+        )
+        self.window_size_left = None if self.is_causal else window_size_left
+        self.window_size_right = cutlass.Int32(0) if self.is_causal else window_size_right
+        self.is_local = (not self.is_causal) and (
+            self.window_size_left is not None or self.window_size_right is not None
+        )
+        assert mma_tiler[0] == 128 and mma_tiler[1] == 128, "Only 128x128 tile impl is supported"
+        assert mma_tiler[2] == 256, "Only 256 is supported for 128x128 tile impl"
+        self.cta_tiler = (
+            mma_tiler[0],
+            mma_tiler[1],
+            mma_tiler[2],
+        )
+        self.qk_mma_tiler = (
+            2 * mma_tiler[0],
+            mma_tiler[1],
+            min(self.cta_tiler[2], 128) if split_head else self.cta_tiler[2],
+        )
+        self.dov_mma_tiler = self.qk_mma_tiler
+        self.dsk_mma_tiler = (
+            2 * mma_tiler[0],
+            min(self.cta_tiler[2], 128) if split_head else self.cta_tiler[2],
+            mma_tiler[1],
+        )
+
+        self.dsk_block_tiler = (
+            self.dsk_mma_tiler[0] // 2,
+            self.dsk_mma_tiler[1],
+            self.dsk_mma_tiler[2],
+        )
+        self.iterations_qk = self.cta_tiler[2] // self.qk_mma_tiler[2]
+        self.iterations_dov = self.cta_tiler[2] // self.dov_mma_tiler[2]
+        self.iterations_dsk = self.cta_tiler[2] // self.dsk_mma_tiler[1]
+        self.cluster_shape_mn = (2, 1)
+        self.tmem_warp_shape_mn = (4, 1)
+        self.is_persistent = is_persistent
+        self.use_clc_scheduler = use_clc_scheduler
+        self.use_semantic_trip_range = self.is_causal or self.is_local
+
+        self.compute_warp_ids = (0, 1, 2, 3)
+        self.epilogue_warp_ids = (4, 5, 6, 7)
+        self.mma_warp_id = 8
+        self.load_warp_id = 9
+        self.empty_warp_id = (10, 11)
+        self.sched_warp_id = self.empty_warp_id[0] if use_clc_scheduler else None
+        self.tmem_alloc_cols = SM100_TMEM_CAPACITY_COLUMNS
+        self.num_compute_warps = len(self.compute_warp_ids)
+
+        self.cta_sync_bar_id = 0
+        self.tmem_alloc_sync_bar_id = 1
+        self.compute_sync_bar_id = 2
+
+        self.threads_per_warp = 32
+        self.threads_per_cta = self.threads_per_warp * len(
+            (
+                *self.compute_warp_ids,  # this is to get a round num threads
+                *self.epilogue_warp_ids,
+                self.mma_warp_id,
+                self.load_warp_id,
+                *self.empty_warp_id,
+            )
+        )
+
+        self.tmem_alloc_barrier = pipeline.NamedBarrier(
+            barrier_id=1,
+            num_threads=self.threads_per_cta,
+        )
+
+        self.tmem_s_offset = 0
+        self.tmem_dp_offset = 128
+        self.tmem_dq_offset = 256
+
+        self.num_regs_compute = 256
+        self.num_regs_epilogue = 160
+        self.num_regs_other = 32
+
+        self.buffer_align_bytes = 1024
+
+    def _setup_attributes(self):
+        self.q_stage = self.iterations_qk
+        self.k_stage = self.iterations_qk
+        self.do_stage = self.iterations_dov
+        self.v_stage = self.iterations_dov
+        self.kt_stage = 1
+        self.qk_acc_stage = 1
+        self.dov_acc_stage = 1
+        self.dsk_acc_stage = 1
+        self.epi_stage = 1
+        self.load_compute_LSE_stage = 1
+        self.load_compute_sum_OdO_stage = 1
+        if cutlass.const_expr(self.use_clc_scheduler):
+            self.num_clc_stage = 1
+            self.num_clc_response_bytes = 16
+
+    @cute.jit
+    def __call__(
+        self,
+        q_tensor: cute.Tensor,
+        k_tensor: cute.Tensor,
+        v_tensor: cute.Tensor,
+        dq_tensor: cute.Tensor,
+        do_tensor: cute.Tensor,
+        lse_tensor: cute.Tensor,
+        sum_odo_tensor: cute.Tensor,
+        cum_seqlen_q: Optional[cute.Tensor],
+        cum_seqlen_k: Optional[cute.Tensor],
+        scale_softmax: cutlass.Float32,
+        stream: cuda.CUstream,
+    ):
+        varlen = cum_seqlen_q is not None or cum_seqlen_k is not None
+        # Infer shape metadata from normalized 5D tensors (B, S, H_k, H_r, D),
+        # similar to the dedicated hd256 forward path.
+        s_q = q_tensor.shape[1]
+        s_k = k_tensor.shape[1]
+        d = q_tensor.shape[4]
+        h_k = q_tensor.shape[2]
+        h_r = q_tensor.shape[3]
+        if cutlass.const_expr(cum_seqlen_q is not None):
+            b = cum_seqlen_q.shape[0] - 1
+        elif cutlass.const_expr(cum_seqlen_k is not None):
+            b = cum_seqlen_k.shape[0] - 1
+        else:
+            b = q_tensor.shape[0]
+        # `lse_tensor` / `sum_odo_tensor` are preallocated FP32 buffers (lse_log2 / dpsum)
+        # whose sequence dimension is padded (rounded up) by the caller.
+        # Use their leading dimension as the LSE length to ensure correct batch strides.
+        s_lse = lse_tensor.shape[0]
+        s_q64 = Int64(s_q)
+        s_k64 = Int64(s_k)
+        s_lse64 = Int64(s_lse)
+        d64 = cute.assume(Int64(d), divby=128)
+        h_r64 = Int64(h_r)
+        h_k64 = Int64(h_k)
+        b64 = Int64(b)
+        # Packed-varlen representation uses batch-dim = 1 and sequence-dim = total_{q,k}.
+        # Keep the *physical* sequence extent in the tensor layouts so that applying
+        # `cuseqlen_*` offsets stays within the tensor domain.
+        s_q_total = q_tensor.shape[1] if cum_seqlen_q is not None else s_q64
+        s_k_total = k_tensor.shape[1] if cum_seqlen_k is not None else s_k64
+        stride_b_qo = h_r64 * h_k64 * s_q64 * d64 if cum_seqlen_q is None else 0
+        stride_b_kv = h_k64 * s_k64 * d64 if cum_seqlen_k is None else 0
+        b_lse = b64 if cum_seqlen_q is None else 1
+        stride_b_lse = h_r64 * h_k64 * s_lse64 if cum_seqlen_q is None else 0
+
+        # (s, d, ((h_r, h_k), b))
+        q_layout = cute.make_layout(
+            (s_q_total, d, ((h_r, h_k), b)),
+            stride=(d64 * h_r64 * h_k64, 1, ((d64, d64 * h_r64), stride_b_qo)),
+        )
+        q = cute.make_tensor(q_tensor.iterator, q_layout)
+        # (s, d, ((h_r, h_k), b))
+        do_layout = cute.make_layout(
+            (s_q_total, d, ((h_r, h_k), b)),
+            stride=(d64 * h_r64 * h_k64, 1, ((d64, d64 * h_r64), stride_b_qo)),
+        )
+        do = cute.make_tensor(do_tensor.iterator, do_layout)
+        # (s, d, ((h_r, h_k), b)), 0-stride for h_r to broadcast
+        k_layout = cute.make_layout(
+            (s_k_total, d, ((h_r, h_k), b)),
+            stride=(d64 * h_k64, 1, ((0, d64), stride_b_kv)),
+        )
+        k = cute.make_tensor(k_tensor.iterator, k_layout)
+        # (d, s, ((h_r, h_k), b)), 0-stride for h_r to broadcast
+        kt_layout = cute.make_layout(
+            (d, s_k_total, ((h_r, h_k), b)),
+            stride=(1, d64 * h_k64, ((0, d64), stride_b_kv)),
+        )
+        kt = cute.make_tensor(k_tensor.iterator, kt_layout)
+        # (s, d, ((h_r, h_k), b)), 0-stride for h_r to broadcast
+        v_layout = cute.make_layout(
+            (s_k_total, d, ((h_r, h_k), b)),
+            stride=(d64 * h_k64, 1, ((0, d64), stride_b_kv)),
+        )
+        v = cute.make_tensor(v_tensor.iterator, v_layout)
+        # (s, ((h_r, h_k), b))
+        lse = cute.make_tensor(lse_tensor.iterator, lse_tensor.layout)
+        # (s, ((h_r, h_k), b))
+        sum_odo_layout = cute.make_layout(
+            (s_lse64, ((h_r, h_k), b_lse)),
+            stride=(1, ((s_lse64, h_r64 * s_lse64), stride_b_lse)),
+        )
+        sum_odo = cute.make_tensor(sum_odo_tensor.iterator, sum_odo_layout)
+        # (s, d, ((h_r, h_k), b))
+        dq_layout = cute.make_layout(
+            (s_q_total, d, ((h_r, h_k), b)),
+            stride=(d64 * h_r64 * h_k64, 1, ((d64, d64 * h_r64), stride_b_qo)),
+        )
+        dq = cute.make_tensor(dq_tensor.iterator, dq_layout)
+
+        # setup static attributes before smem/grid/tma computation
+        self.q_dtype = q.element_type
+        self.k_dtype = k.element_type
+        self.v_dtype = v.element_type
+        self.do_dtype = do.element_type
+        self.dq_dtype = dq.element_type
+        self.tilePlikeFP32 = self.qk_mma_tiler[1] // Float32.width * self.q_dtype.width
+
+        if cutlass.const_expr(self.use_clc_scheduler):
+            self.tile_sched_params, grid = compute_grid_clc(
+                (s_q, dq.shape[1], dq.shape[2]) if cum_seqlen_q is not None else dq.shape,
+                self.cta_tiler,
+                (*self.cluster_shape_mn, 1),
+            )
+        else:
+            self.tile_sched_params, grid = compute_grid(
+                (s_q, dq.shape[1], dq.shape[2]) if cum_seqlen_q is not None else dq.shape,
+                self.cta_tiler,
+                self.is_persistent,
+            )
+
+        self.q_major_mode = utils.LayoutEnum.from_tensor(q).mma_major_mode()
+        self.do_major_mode = utils.LayoutEnum.from_tensor(do).mma_major_mode()
+        self.k_major_mode = utils.LayoutEnum.from_tensor(k).mma_major_mode()
+        self.v_major_mode = utils.LayoutEnum.from_tensor(v).mma_major_mode()
+        self.dq_layout = utils.LayoutEnum.from_tensor(dq)
+
+        if cutlass.const_expr(self.q_major_mode != tcgen05.OperandMajorMode.K):
+            raise RuntimeError("The layout of q is not supported")
+        if cutlass.const_expr(self.k_major_mode != tcgen05.OperandMajorMode.K):
+            raise RuntimeError("The layout of k is not supported")
+        if cutlass.const_expr(self.v_major_mode != tcgen05.OperandMajorMode.K):
+            raise RuntimeError("The layout of v is not supported")
+        if cutlass.const_expr(self.do_major_mode != tcgen05.OperandMajorMode.K):
+            raise RuntimeError("The layout of v is not supported")
+
+        # check type consistency
+        if cutlass.const_expr(self.q_dtype != self.k_dtype):
+            raise TypeError(f"Type mismatch: {self.q_dtype} != {self.k_dtype}")
+        if cutlass.const_expr(self.q_dtype != self.v_dtype):
+            raise TypeError(f"Type mismatch: {self.q_dtype} != {self.v_dtype}")
+        if cutlass.const_expr(self.q_dtype != self.do_dtype):
+            raise TypeError(f"Type mismatch: {self.q_dtype} != {self.do_dtype}")
+
+        self._setup_attributes()
+
+        cta_group = tcgen05.CtaGroup.TWO
+        # the intermediate tensor p is from tmem & k-major
+        ds_source = tcgen05.OperandSource.TMEM
+        ds_major_mode = tcgen05.OperandMajorMode.K
+        k_trans_major_mode = tcgen05.OperandMajorMode.MN
+        qk_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            self.q_dtype,
+            self.q_major_mode,
+            self.k_major_mode,
+            self.acc_dtype,
+            cta_group,
+            self.qk_mma_tiler[:2],
+        )
+        dov_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            self.do_dtype,
+            self.do_major_mode,
+            self.v_major_mode,
+            self.acc_dtype,
+            cta_group,
+            self.dov_mma_tiler[:2],
+        )
+        dsk_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            self.q_dtype,
+            ds_major_mode,
+            k_trans_major_mode,
+            self.acc_dtype,
+            cta_group,
+            self.dsk_mma_tiler[:2],
+            ds_source,
+        )
+
+        self.cluster_shape_mnk = (*self.cluster_shape_mn, 1)
+        self.cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout(self.cluster_shape_mnk),
+            (qk_tiled_mma.thr_id.shape,),
+        )
+
+        self.epi_tile = self.dsk_block_tiler[:2]
+
+        q_smem_layout_staged = sm100_utils.make_smem_layout_a(
+            qk_tiled_mma,
+            self.qk_mma_tiler,
+            self.q_dtype,
+            self.q_stage,
+        )
+        k_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            qk_tiled_mma,
+            self.qk_mma_tiler,
+            self.k_dtype,
+            self.k_stage,
+        )
+        do_smem_layout_staged = sm100_utils.make_smem_layout_a(
+            dov_tiled_mma,
+            self.dov_mma_tiler,
+            self.do_dtype,
+            self.do_stage,
+        )
+        v_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            dov_tiled_mma,
+            self.dov_mma_tiler,
+            self.v_dtype,
+            self.v_stage,
+        )
+        ds_tmem_layout_staged = sm100_utils.make_smem_layout_a(
+            dsk_tiled_mma,
+            self.dsk_mma_tiler,
+            self.q_dtype,
+            self.qk_acc_stage,
+        )
+        ds_tmem_layout = cute.select(ds_tmem_layout_staged, mode=[0, 1, 2])
+        kt_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            dsk_tiled_mma,
+            self.dsk_mma_tiler,
+            self.k_dtype,
+            self.dsk_acc_stage,
+        )
+
+        # TMA load for Q
+        tma_load_op = cute.nvgpu.cpasync.CopyBulkTensorTileG2SOp(cta_group)
+
+        q_smem_layout = cute.select(q_smem_layout_staged, mode=[0, 1, 2])
+        tma_atom_q, tma_tensor_q = cute.nvgpu.make_tiled_tma_atom_A(
+            tma_load_op,
+            q,
+            q_smem_layout,
+            self.qk_mma_tiler,
+            qk_tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+        # TMA load for K
+        k_smem_layout = cute.select(k_smem_layout_staged, mode=[0, 1, 2])
+        tma_atom_k, tma_tensor_k = cute.nvgpu.make_tiled_tma_atom_B(
+            tma_load_op,
+            k,
+            k_smem_layout,
+            self.qk_mma_tiler,
+            qk_tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+        # TMA load for dO
+        do_smem_layout = cute.select(do_smem_layout_staged, mode=[0, 1, 2])
+        tma_atom_do, tma_tensor_do = cute.nvgpu.make_tiled_tma_atom_A(
+            tma_load_op,
+            do,
+            do_smem_layout,
+            self.dov_mma_tiler,
+            dov_tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+        # TMA load for V
+        v_smem_layout = cute.select(v_smem_layout_staged, mode=[0, 1, 2])
+        tma_atom_v, tma_tensor_v = cute.nvgpu.make_tiled_tma_atom_B(
+            tma_load_op,
+            v,
+            v_smem_layout,
+            self.dov_mma_tiler,
+            dov_tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+        # TMA load for KT
+        kt_smem_layout = cute.select(kt_smem_layout_staged, mode=[0, 1, 2])
+        tma_atom_kt, tma_tensor_kt = cute.nvgpu.make_tiled_tma_atom_B(
+            tma_load_op,
+            kt,
+            kt_smem_layout,
+            self.dsk_mma_tiler,
+            dsk_tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+        lse_smem_layout = cute.make_layout((self.cta_tiler[0], self.load_compute_LSE_stage))
+        sum_odo_smem_layout = cute.make_layout((self.cta_tiler[0], self.load_compute_sum_OdO_stage))
+
+        q_copy_size = cute.size_in_bytes(self.q_dtype, q_smem_layout)
+        k_copy_size = cute.size_in_bytes(self.k_dtype, k_smem_layout)
+        do_copy_size = cute.size_in_bytes(self.do_dtype, do_smem_layout)
+        v_copy_size = cute.size_in_bytes(self.v_dtype, v_smem_layout)
+        kt_copy_size = cute.size_in_bytes(self.k_dtype, kt_smem_layout)
+        self.tma_copy_q_bytes = q_copy_size * cute.size(qk_tiled_mma.thr_id.shape)
+        self.tma_copy_k_bytes = k_copy_size * cute.size(qk_tiled_mma.thr_id.shape)
+        self.tma_copy_do_bytes = do_copy_size * cute.size(qk_tiled_mma.thr_id.shape)
+        self.tma_copy_v_bytes = v_copy_size * cute.size(qk_tiled_mma.thr_id.shape)
+        self.tma_copy_kt_bytes = kt_copy_size * cute.size(qk_tiled_mma.thr_id.shape)
+
+        @cute.struct
+        class SharedStorage:
+            # TMA G2S load barriers: LOAD warp (producer) -> MMA warp (consumer)
+            load_q_mbar_ptr: cute.struct.MemRange[
+                Int64, self.q_stage * 2
+            ]  # load_q_{producer,consumer}
+            load_do_mbar_ptr: cute.struct.MemRange[
+                Int64, self.do_stage * 2
+            ]  # load_do_{producer,consumer}
+            load_k_mbar_ptr: cute.struct.MemRange[
+                Int64, self.k_stage * 2
+            ]  # load_k_{producer,consumer}
+            load_kt_mbar_ptr: cute.struct.MemRange[
+                Int64, self.kt_stage * 2
+            ]  # load_kt_{producer,consumer}
+            load_v_mbar_ptr: cute.struct.MemRange[
+                Int64, self.v_stage * 2
+            ]  # load_v_{producer,consumer}
+            mma_s_mbar_ptr: cute.struct.MemRange[Int64, self.qk_acc_stage * 2]
+            mma_dp_mbar_ptr: cute.struct.MemRange[Int64, self.dov_acc_stage * 2]
+            mma_dq_mbar_ptr: cute.struct.MemRange[Int64, self.epi_stage * 2]
+            ds_mma_mbar_ptr: cute.struct.MemRange[Int64, self.dsk_acc_stage * 2]
+            lse_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.load_compute_LSE_stage * 2]
+            sum_odo_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.load_compute_sum_OdO_stage * 2
+            ]
+            # A CTA-wide "TMEM lifetime" barrier used to safely deallocate TMEM after all users finish.
+            tmem_dealloc_mbar_ptr: Int64
+            # Tmem holding buffer
+            tmem_holding_buf: Int32
+            # CLC pipeline barriers and response buffer
+            clc_mbar_ptr: cute.struct.MemRange[Int64, 2]
+            clc_response: cute.struct.MemRange[Int32, 4]
+
+        self.shared_storage = SharedStorage
+
+        grid = cute.round_up(grid, self.cluster_shape_mnk)
+        # Launch the kernel synchronously
+        self.kernel(
+            qk_tiled_mma,
+            dov_tiled_mma,
+            dsk_tiled_mma,
+            tma_atom_q,
+            tma_tensor_q,
+            tma_atom_k,
+            tma_tensor_k,
+            tma_atom_v,
+            tma_tensor_v,
+            tma_atom_do,
+            tma_tensor_do,
+            tma_atom_kt,
+            tma_tensor_kt,
+            lse,
+            sum_odo,
+            dq,
+            cum_seqlen_q,
+            cum_seqlen_k,
+            scale_softmax,
+            self.window_size_left,
+            self.window_size_right,
+            self.cluster_layout_vmnk,
+            q_smem_layout_staged,
+            k_smem_layout_staged,
+            v_smem_layout_staged,
+            do_smem_layout_staged,
+            kt_smem_layout_staged,
+            ds_tmem_layout,
+            lse_smem_layout,
+            sum_odo_smem_layout,
+            self.tile_sched_params,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=self.cluster_shape_mnk,
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+
+    #  GPU device kernel
+    @cute.kernel
+    def kernel(
+        self,
+        qk_tiled_mma: cute.TiledMma,
+        dov_tiled_mma: cute.TiledMma,
+        dsk_tiled_mma: cute.TiledMma,
+        tma_atom_q: cute.CopyAtom,
+        mQ_qdl: cute.Tensor,
+        tma_atom_k: cute.CopyAtom,
+        mK_kdl: cute.Tensor,
+        tma_atom_v: cute.CopyAtom,
+        mV_dkl: cute.Tensor,
+        tma_atom_do: cute.CopyAtom,
+        mdO_qdl: cute.Tensor,
+        tma_atom_kt: cute.CopyAtom,
+        mK_dkl: cute.Tensor,
+        mLSE: cute.Tensor,
+        mSum_OdO: cute.Tensor,
+        mdQ_qdl: cute.Tensor,
+        cum_seqlen_q: Optional[cute.Tensor],
+        cum_seqlen_k: Optional[cute.Tensor],
+        scale_softmax: Float32,
+        window_size_left: Optional[Int32],
+        window_size_right: Optional[Int32],
+        cluster_layout_vmnk: cute.Layout,
+        q_smem_layout_staged: cute.ComposedLayout,
+        k_smem_layout_staged: cute.ComposedLayout,
+        v_smem_layout_staged: cute.ComposedLayout,
+        do_smem_layout_staged: cute.ComposedLayout,
+        kt_smem_layout_staged: cute.ComposedLayout,
+        ds_tmem_layout_staged: cute.ComposedLayout,
+        lse_smem_layout: cute.Layout,
+        sum_odo_smem_layout: cute.Layout,
+        tile_sched_params: FmhaStaticTileSchedulerParams | FmhaClcDynamicTileSchedulerParams,
+    ):
+        # llvm.inline_asm(
+        #     None,
+        #     [],
+        #     '.pragma "global knob CommonIntoMultiBlockLoop=1";',
+        #     "",
+        #     has_side_effects=True,
+        #     is_align_stack=False,
+        #     asm_dialect=llvm.AsmDialect.AD_ATT,
+        # )
+
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        #
+        # Prefetch tma desc
+        #
+        if warp_idx == self.load_warp_id:
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_q)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_k)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_v)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_do)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_kt)
+
+        bidx, bidy, bidz = cute.arch.block_idx()
+        tidx, _, _ = cute.arch.thread_idx()
+        varlen = cum_seqlen_q is not None or cum_seqlen_k is not None
+        mma_tile_coord_v = bidx % cute.size(qk_tiled_mma.thr_id.shape)
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+        block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(cta_rank_in_cluster)
+
+        # Alloc
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+
+        load_q_producer, load_q_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=self.q_stage,
+            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            tx_count=self.tma_copy_q_bytes,
+            barrier_storage=storage.load_q_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+        load_k_producer, load_k_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=self.k_stage,
+            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            tx_count=self.tma_copy_k_bytes,
+            barrier_storage=storage.load_k_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+        load_v_producer, load_v_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=self.v_stage,
+            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            tx_count=self.tma_copy_v_bytes,
+            barrier_storage=storage.load_v_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+        load_do_producer, load_do_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=self.do_stage,
+            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            tx_count=self.tma_copy_do_bytes,
+            barrier_storage=storage.load_do_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+        load_kt_producer, load_kt_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=self.kt_stage,
+            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            tx_count=self.tma_copy_kt_bytes,
+            barrier_storage=storage.load_kt_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+        mma_s_producer, mma_s_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=self.qk_acc_stage,
+            producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            consumer_group=make_thread_cooperative_group(
+                len(self.compute_warp_ids) * self.threads_per_warp * self.cluster_shape_mnk[0],
+            ),
+            barrier_storage=storage.mma_s_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+        mma_dp_producer, mma_dp_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=self.dov_acc_stage,
+            producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            consumer_group=make_thread_cooperative_group(
+                len(self.compute_warp_ids) * self.threads_per_warp * self.cluster_shape_mnk[0],
+            ),
+            barrier_storage=storage.mma_dp_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+        ds_mma_producer, ds_mma_consumer = pipeline.PipelineAsyncUmma.create(
+            num_stages=self.dsk_acc_stage,
+            producer_group=make_thread_cooperative_group(
+                len(self.compute_warp_ids) * self.threads_per_warp * self.cluster_shape_mnk[0],
+            ),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            barrier_storage=storage.ds_mma_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+        mma_dq_producer, mma_dq_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=self.epi_stage,
+            producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            consumer_group=make_thread_cooperative_group(
+                len(self.epilogue_warp_ids) * self.threads_per_warp * self.cluster_shape_mnk[0],
+            ),
+            barrier_storage=storage.mma_dq_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+
+        load_lse_producer, load_lse_consumer = pipeline.PipelineCpAsync.create(
+            num_stages=self.load_compute_LSE_stage,
+            producer_group=make_thread_cooperative_group(self.threads_per_warp),
+            consumer_group=make_thread_cooperative_group(
+                self.threads_per_warp * self.num_compute_warps
+            ),
+            barrier_storage=storage.lse_mbar_ptr.data_ptr(),
+        ).make_participants()
+        load_sum_odo_producer, load_sum_odo_consumer = pipeline.PipelineCpAsync.create(
+            num_stages=self.load_compute_sum_OdO_stage,
+            producer_group=make_thread_cooperative_group(self.threads_per_warp),
+            consumer_group=make_thread_cooperative_group(
+                self.threads_per_warp * self.num_compute_warps
+            ),
+            barrier_storage=storage.sum_odo_mbar_ptr.data_ptr(),
+        ).make_participants()
+
+        # Tensor memory dealloc barrier init
+        tmem = utils.TmemAllocator(
+            storage.tmem_holding_buf,
+            barrier_for_retrieve=self.tmem_alloc_barrier,
+            allocator_warp_id=self.epilogue_warp_ids[0],
+            is_two_cta=True,
+            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar_ptr,
+        )
+        tmem.allocate(self.tmem_alloc_cols)
+        tmem.wait_for_alloc()
+        tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+
+        # Initialize CLC state if using dynamic scheduler
+        if cutlass.const_expr(self.use_clc_scheduler):
+            clc_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+            cluster_size = cute.size(self.cluster_shape_mnk)
+            num_clc_consumer_threads = self.threads_per_warp * (
+                1  # sched_warp (CTA 0 only)
+                + cluster_size
+                * (
+                    len(self.compute_warp_ids)
+                    + len(self.epilogue_warp_ids)
+                    + 1  # mma_warp
+                    + 1  # load_warp
+                )
+            )
+            clc_pipeline_consumer_group = pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, num_clc_consumer_threads
+            )
+            clc_response_ptr = storage.clc_response.data_ptr()
+            clc = ClcState.create(
+                hw_scheduler=ClcDynamicPersistentTileScheduler.create(
+                    self.tile_sched_params.clc_hw_params(),
+                    cute.arch.block_idx(),
+                    cute.arch.grid_dim(),
+                    clc_response_ptr,
+                ),
+                pipeline=pipeline.PipelineClcFetchAsync.create(
+                    barrier_storage=storage.clc_mbar_ptr.data_ptr(),
+                    num_stages=self.num_clc_stage,
+                    producer_group=clc_pipeline_producer_group,
+                    consumer_group=clc_pipeline_consumer_group,
+                    tx_count=self.num_clc_response_bytes,
+                    cta_layout_vmnk=cluster_layout_vmnk,
+                    defer_sync=True,
+                ),
+                consumer_state=pipeline.make_pipeline_state(
+                    pipeline.PipelineUserType.Consumer, self.num_clc_stage
+                ),
+                producer_state=pipeline.make_pipeline_state(
+                    pipeline.PipelineUserType.Producer, self.num_clc_stage
+                ),
+            )
+        else:
+            clc = None
+            clc_response_ptr = None
+
+        # Cluster arrive after barrier init
+        pipeline.pipeline_init_arrive(cluster_shape_mn=cluster_layout_vmnk, is_relaxed=True)
+
+        sQ = smem.allocate_tensor(
+            element_type=self.q_dtype,
+            layout=q_smem_layout_staged.outer,
+            swizzle=q_smem_layout_staged.inner,
+            byte_alignment=128,
+        )
+        sK = smem.allocate_tensor(
+            element_type=self.k_dtype,
+            layout=k_smem_layout_staged.outer,
+            swizzle=k_smem_layout_staged.inner,
+            byte_alignment=128,
+        )
+        # K and V now use separate memory since we removed the transform stage
+        sV = smem.allocate_tensor(
+            element_type=self.v_dtype,
+            layout=v_smem_layout_staged.outer,
+            swizzle=v_smem_layout_staged.inner,
+            byte_alignment=128,
+        )
+        sdO = smem.allocate_tensor(
+            element_type=self.do_dtype,
+            layout=do_smem_layout_staged.outer,
+            swizzle=do_smem_layout_staged.inner,
+            byte_alignment=128,
+        )
+        sKT = smem.allocate_tensor(
+            element_type=self.k_dtype,
+            layout=kt_smem_layout_staged.outer,
+            swizzle=kt_smem_layout_staged.inner,
+            byte_alignment=128,
+        )
+        sLSE = smem.allocate_tensor(
+            element_type=self.acc_dtype,
+            layout=lse_smem_layout,
+            byte_alignment=128,
+        )
+        sSum_OdO = smem.allocate_tensor(
+            element_type=self.acc_dtype,
+            layout=sum_odo_smem_layout,
+            byte_alignment=128,
+        )
+        qk_thr_mma = qk_tiled_mma.get_slice(mma_tile_coord_v)  # default 1sm
+        dov_thr_mma = dov_tiled_mma.get_slice(mma_tile_coord_v)  # default 1sm
+        dsk_thr_mma = dsk_tiled_mma.get_slice(mma_tile_coord_v)  # default 1sm
+        tSrQ = qk_thr_mma.make_fragment_A(sQ)
+        tSrK = qk_thr_mma.make_fragment_B(sK)
+        tdPrdO = dov_thr_mma.make_fragment_A(sdO)
+        tdPrV = dov_thr_mma.make_fragment_B(sV)
+        tdQrKT = dsk_thr_mma.make_fragment_B(sKT)
+        qk_acc_shape = qk_thr_mma.partition_shape_C((self.qk_mma_tiler[0], self.qk_mma_tiler[1]))
+        tStS = qk_thr_mma.make_fragment_C(cute.append(qk_acc_shape, self.qk_acc_stage))
+        dov_acc_shape = dov_thr_mma.partition_shape_C(
+            (self.dov_mma_tiler[0], self.dov_mma_tiler[1])
+        )
+        tdPtdP = dov_thr_mma.make_fragment_C(cute.append(dov_acc_shape, self.dov_acc_stage))
+        dsk_acc_shape = dsk_thr_mma.partition_shape_C(
+            (self.dsk_mma_tiler[0], self.dsk_mma_tiler[1])
+        )
+        tdQtdQ = dsk_thr_mma.make_fragment_C(dsk_acc_shape)
+        tdQtdQ_layout = cute.append(
+            tdQtdQ.layout,
+            cute.make_layout(
+                self.iterations_dsk,
+                stride=self.dsk_mma_tiler[1] // self.tmem_warp_shape_mn[1],
+            ),
+        )
+        tStS = cute.make_tensor(tStS.iterator + self.tmem_s_offset, tStS.layout)
+        tdPtdP = cute.make_tensor(tdPtdP.iterator + self.tmem_dp_offset, tdPtdP.layout)
+        tdQtdQ_staged = cute.make_tensor(tdQtdQ.iterator + self.tmem_dq_offset, tdQtdQ_layout)
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  EMPTY
+        # ///////////////////////////////////////////////////////////////////////////////
+        for _i in cutlass.range_constexpr(len(self.empty_warp_id)):
+            if warp_idx == self.empty_warp_id[_i]:
+                cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
+
+        if cutlass.const_expr(self.use_clc_scheduler):
+            tile_sched = FmhaClcDynamicTileScheduler.create(
+                tile_sched_params,
+                cute.arch.block_idx(),
+                cute.arch.grid_dim(),
+                clc_response_ptr,
+                clc,
+            )
+        else:
+            blk_idx = cute.arch.block_idx()
+            tile_sched = FmhaStaticTileScheduler(
+                tile_sched_params, blk_idx[0], blk_idx, cute.arch.grid_dim()
+            )
+        work_tile = tile_sched.initial_work_tile_info()
+
+        # Cluster wait
+        pipeline.pipeline_init_wait(cluster_shape_mn=cluster_layout_vmnk)
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  LOAD
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx == self.load_warp_id:
+            cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
+
+            while work_tile.is_valid_tile:
+                curr_block_coord = work_tile.tile_idx
+                mma_block_coord = (
+                    curr_block_coord[0] // cute.size(qk_tiled_mma.thr_id.shape),
+                    curr_block_coord[1],
+                    curr_block_coord[2],
+                )
+                continue_cond = False
+                batch_coord = curr_block_coord[2][1]
+                seqlen_q = mQ_qdl.shape[0]
+                seqlen_k = mK_kdl.shape[0]
+                cuseqlen_q = Int32(0)
+                cuseqlen_k = Int32(0)
+                block_offset = (
+                    Int32(0),
+                    Int32(0),
+                    Int32(0),
+                    ((Int32(0), Int32(0)), Int32(0)),
+                )
+                if cutlass.const_expr(cum_seqlen_q is not None):
+                    cuseqlen_q = cum_seqlen_q[batch_coord]
+                    seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
+                    if cutlass.const_expr(cum_seqlen_k is not None):
+                        cuseqlen_k = cum_seqlen_k[batch_coord]
+                        seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
+                    block_offset = (
+                        cuseqlen_q,
+                        cuseqlen_k,
+                        Int32(0),
+                        ((Int32(0), Int32(0)), Int32(0)),
+                    )
+                    continue_cond = not FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
+                        self.qk_mma_tiler[0],
+                        mma_block_coord[0],
+                        seqlen_q,
+                    )
+                if not continue_cond:
+                    mQ_qdl_ = cute.domain_offset(cute.select(block_offset, mode=[0, 2, 3]), mQ_qdl)
+                    mK_kdl_ = cute.domain_offset(cute.select(block_offset, mode=[1, 2, 3]), mK_kdl)
+                    mdO_qdl_ = cute.domain_offset(
+                        cute.select(block_offset, mode=[0, 2, 3]), mdO_qdl
+                    )
+                    mV_dkl_ = cute.domain_offset(cute.select(block_offset, mode=[1, 2, 3]), mV_dkl)
+                    mK_dkl_ = cute.domain_offset(cute.select(block_offset, mode=[2, 1, 3]), mK_dkl)
+                    block_offset_stats = block_offset
+                    if cutlass.const_expr(cum_seqlen_q is not None):
+                        cuseqlen_q_stats = cute.assume(
+                            (cuseqlen_q + batch_coord * self.cta_tiler[0])
+                            // self.cta_tiler[0]
+                            * self.cta_tiler[0],
+                            divby=self.cta_tiler[0],
+                        )
+                        block_offset_stats = (
+                            cuseqlen_q_stats,
+                            block_offset[1],
+                            block_offset[2],
+                            block_offset[3],
+                        )
+                    LSE = cute.domain_offset(cute.select(block_offset_stats, mode=[0, 3]), mLSE)
+                    sum_OdO = cute.domain_offset(
+                        cute.select(block_offset_stats, mode=[0, 3]), mSum_OdO
+                    )
+
+                    # Local tile partition global tensors
+                    q_cta_layout = cute.make_layout(
+                        cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape
+                    )
+                    # (bM, bK, loopM, loopK, loopL)
+                    gQ_qdl = cute.flat_divide(mQ_qdl_, cute.select(self.qk_mma_tiler, mode=[0, 2]))
+                    tSgQ_qdl = qk_thr_mma.partition_A(gQ_qdl)
+                    tQsQ, tQgQ_qdl = cute.nvgpu.cpasync.tma_partition(
+                        tma_atom_q,
+                        block_in_cluster_coord_vmnk[2],
+                        q_cta_layout,
+                        cute.group_modes(sQ, 0, 3),
+                        cute.group_modes(tSgQ_qdl, 0, 3),
+                    )
+                    k_cta_layout = cute.make_layout(
+                        cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape
+                    )
+                    gK_kdl = cute.flat_divide(mK_kdl_, cute.select(self.qk_mma_tiler, mode=[1, 2]))
+                    tSgK_kdl = qk_thr_mma.partition_B(gK_kdl)
+                    tKsK, tKgK_kdl = cute.nvgpu.cpasync.tma_partition(
+                        tma_atom_k,
+                        block_in_cluster_coord_vmnk[1],
+                        k_cta_layout,
+                        cute.group_modes(sK, 0, 3),
+                        cute.group_modes(tSgK_kdl, 0, 3),
+                    )
+                    do_cta_layout = cute.make_layout(
+                        cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape
+                    )
+                    # (bM, bK, loopM, loopK, loopL)
+                    gdO_qdl = cute.flat_divide(
+                        mdO_qdl_, cute.select(self.dov_mma_tiler, mode=[0, 2])
+                    )
+                    tdPgdO_qdl = dov_thr_mma.partition_A(gdO_qdl)
+                    tdOsdO, tdOgdO_qdl = cute.nvgpu.cpasync.tma_partition(
+                        tma_atom_do,
+                        block_in_cluster_coord_vmnk[2],
+                        do_cta_layout,
+                        cute.group_modes(sdO, 0, 3),
+                        cute.group_modes(tdPgdO_qdl, 0, 3),
+                    )
+                    v_cta_layout = cute.make_layout(
+                        cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape
+                    )
+                    gV_dkl = cute.flat_divide(mV_dkl_, cute.select(self.dov_mma_tiler, mode=[1, 2]))
+                    tSgV_dkl = dov_thr_mma.partition_B(gV_dkl)
+                    tVsV, tVgV_dkl = cute.nvgpu.cpasync.tma_partition(
+                        tma_atom_v,
+                        block_in_cluster_coord_vmnk[1],
+                        v_cta_layout,
+                        cute.group_modes(sV, 0, 3),
+                        cute.group_modes(tSgV_dkl, 0, 3),
+                    )
+                    # kt layout
+                    kt_cta_layout = cute.make_layout(
+                        cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape
+                    )
+                    gK_dkl = cute.flat_divide(mK_dkl_, cute.select(self.dsk_mma_tiler, mode=[1, 2]))
+                    tdQgK_dkl = dsk_thr_mma.partition_B(gK_dkl)
+                    tKTsKT, tKgK_dkl = cute.nvgpu.cpasync.tma_partition(
+                        tma_atom_kt,
+                        block_in_cluster_coord_vmnk[1],
+                        kt_cta_layout,
+                        cute.group_modes(sKT, 0, 3),
+                        cute.group_modes(tdQgK_dkl, 0, 3),
+                    )
+                    # ((atom_v, rest_v), RestK)
+                    tQgQ = tQgQ_qdl[None, mma_block_coord[0], None, mma_block_coord[2]]
+                    # ((atom_v, rest_v), RestK)
+                    tdOgdO = tdOgdO_qdl[None, mma_block_coord[0], None, mma_block_coord[2]]
+                    # ((atom_v, rest_v), RestN, RestK)
+                    tKgK = tKgK_kdl[None, None, None, mma_block_coord[2]]
+                    # ((atom_v, rest_v), RestN, RestK)
+                    tVgV = tVgV_dkl[None, None, None, mma_block_coord[2]]
+                    # ((atom_v, rest_v), RestN, RestK)
+                    tKTgKT = tKgK_dkl[None, None, None, mma_block_coord[2]]
+
+                    seqlen_kv_loop_start, seqlen_kv_loop_steps = (
+                        FusedMask.get_trip_start_count_via_block_info(
+                            mma_block_coord,
+                            self.qk_mma_tiler,
+                            seqlen_q,
+                            seqlen_k,
+                            self.is_causal,
+                            self.is_local,
+                            window_size_left,
+                            window_size_right,
+                        )
+                    )
+                    # LSE
+                    lse_handle = load_lse_producer.acquire_and_advance()
+                    # 32 threads loading 128 values of 32b each
+                    # so 4*32b = 128b
+                    thread_idx = tidx % self.threads_per_warp
+                    async_copy_num_elts = sLSE.shape[0] // self.threads_per_warp
+                    atom_async_copy = cute.make_copy_atom(
+                        cpasync.CopyG2SOp(cache_mode=cpasync.LoadCacheMode.ALWAYS),
+                        self.acc_dtype,
+                        num_bits_per_copy=self.acc_dtype.width,
+                    )
+                    sLSE_for_copy = cute.flat_divide(sLSE, (1,))
+                    LSE_for_copy = cute.flat_divide(LSE, (1,))
+                    for i in cutlass.range_constexpr(async_copy_num_elts):
+                        LSE_idx = (
+                            self.cta_tiler[0] * curr_block_coord[0]
+                            + thread_idx * async_copy_num_elts
+                        )
+                        if cute.elem_less(LSE_idx + i, seqlen_q):
+                            cute.copy(
+                                atom_async_copy,
+                                LSE_for_copy[None, LSE_idx + i, curr_block_coord[2]],
+                                sLSE_for_copy[
+                                    None,
+                                    thread_idx * async_copy_num_elts + i,
+                                    lse_handle.index,
+                                ],
+                            )
+                        else:
+                            sLSE_for_copy[
+                                None,
+                                thread_idx * async_copy_num_elts + i,
+                                lse_handle.index,
+                            ].fill(0.0)
+                    lse_handle.commit()
+
+                    sum_odo_handle = load_sum_odo_producer.acquire_and_advance()
+                    sSum_OdO_for_copy = cute.flat_divide(sSum_OdO, (1,))
+                    sum_OdO_for_copy = cute.flat_divide(sum_OdO, (1,))
+                    for i in cutlass.range_constexpr(async_copy_num_elts):
+                        sum_OdO_idx = (
+                            self.cta_tiler[0] * curr_block_coord[0]
+                            + thread_idx * async_copy_num_elts
+                        )
+                        if cute.elem_less(sum_OdO_idx + i, seqlen_q):
+                            cute.copy(
+                                atom_async_copy,
+                                sum_OdO_for_copy[None, sum_OdO_idx + i, curr_block_coord[2]],
+                                sSum_OdO_for_copy[
+                                    None,
+                                    thread_idx * async_copy_num_elts + i,
+                                    sum_odo_handle.index,
+                                ],
+                            )
+                        else:
+                            sSum_OdO_for_copy[
+                                None,
+                                thread_idx * async_copy_num_elts + i,
+                                sum_odo_handle.index,
+                            ].fill(0.0)
+                    sum_odo_handle.commit()
+
+                    # Q
+                    for iter in cutlass.range(self.iterations_qk, unroll=1):
+                        q_handle = load_q_producer.acquire_and_advance()
+                        cute.copy(
+                            tma_atom_q,
+                            tQgQ[None, iter],
+                            tQsQ[None, q_handle.index],
+                            tma_bar_ptr=q_handle.barrier,
+                        )
+                    # dO
+                    for iter in cutlass.range(self.iterations_dov, unroll=1):
+                        do_handle = load_do_producer.acquire_and_advance()
+                        cute.copy(
+                            tma_atom_do,
+                            tdOgdO[None, iter],
+                            tdOsdO[None, do_handle.index],
+                            tma_bar_ptr=do_handle.barrier,
+                        )
+
+                    kv_coord = seqlen_kv_loop_start
+                    for i in cutlass.range(0, seqlen_kv_loop_steps, 1, unroll=1):
+                        # Ki
+                        for iter in cutlass.range(self.iterations_qk, unroll=1):
+                            k_handle = load_k_producer.acquire_and_advance()
+                            cute.copy(
+                                tma_atom_k,
+                                tKgK[None, kv_coord, iter],
+                                tKsK[None, k_handle.index],
+                                tma_bar_ptr=k_handle.barrier,
+                            )
+                        # Vi
+                        for iter in cutlass.range(self.iterations_dov, unroll=1):
+                            v_handle = load_v_producer.acquire_and_advance()
+                            cute.copy(
+                                tma_atom_v,
+                                tVgV[None, kv_coord, iter],
+                                tVsV[None, v_handle.index],
+                                tma_bar_ptr=v_handle.barrier,
+                            )
+                        # KTi
+                        for iter in cutlass.range(self.iterations_dsk, unroll=1):
+                            kt_handle = load_kt_producer.acquire_and_advance()
+                            cute.copy(
+                                tma_atom_kt,
+                                tKTgKT[None, iter, kv_coord],
+                                tKTsKT[None, kt_handle.index],
+                                tma_bar_ptr=kt_handle.barrier,
+                            )
+                        kv_coord += 1
+
+                work_tile = tile_sched.advance_to_next_work()
+                # End of persistent scheduler loop
+            load_k_producer.tail()
+            load_v_producer.tail()
+            load_kt_producer.tail()
+            load_q_producer.tail()
+            load_do_producer.tail()
+            load_lse_producer.tail()
+            load_sum_odo_producer.tail()
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  MMA
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx == self.mma_warp_id:
+            cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
+
+            while work_tile.is_valid_tile:
+                curr_block_coord = work_tile.tile_idx
+                mma_block_coord = (
+                    curr_block_coord[0] // cute.size(qk_tiled_mma.thr_id.shape),
+                    curr_block_coord[1],
+                    curr_block_coord[2],
+                )
+                continue_cond = False
+                seqlen_q = mQ_qdl.shape[0]
+                seqlen_k = mK_kdl.shape[0]
+                batch_coord = curr_block_coord[2][1]
+                if cutlass.const_expr(cum_seqlen_q is not None):
+                    cuseqlen_q = cum_seqlen_q[batch_coord]
+                    seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
+                    continue_cond = not FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
+                        self.qk_mma_tiler[0],
+                        mma_block_coord[0],
+                        seqlen_q,
+                    )
+
+                if not continue_cond:
+                    if cutlass.const_expr(cum_seqlen_k is not None):
+                        cuseqlen_k = cum_seqlen_k[batch_coord]
+                        seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
+
+                    seqlen_kv_loop_start, seqlen_kv_loop_steps = (
+                        FusedMask.get_trip_start_count_via_block_info(
+                            mma_block_coord,
+                            self.qk_mma_tiler,
+                            seqlen_q,
+                            seqlen_k,
+                            self.is_causal,
+                            self.is_local,
+                            window_size_left,
+                            window_size_right,
+                        )
+                    )
+
+                    cta_rank_in_cluster = cute.arch.make_warp_uniform(
+                        cute.arch.block_idx_in_cluster()
+                    )
+                    is_leader_cta = cta_rank_in_cluster % 2 == 0
+                    # dq_handle = mma_dq_producer.acquire_and_advance()
+                    load_q_releaser = load_q_consumer.clone()
+                    load_do_releaser = load_do_consumer.clone()
+                    dsk_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+
+                    num_innerloop = 8
+
+                    if is_leader_cta:
+                        dq_handle = mma_dq_producer.acquire_and_advance()
+                        if seqlen_kv_loop_steps > 1:
+                            # QK0
+                            s_handle = mma_s_producer.acquire_and_advance()
+                            tStS_slice = tStS[None, None, None, s_handle.index]
+                            qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+                            for iter in cutlass.range(self.iterations_qk, unroll=1):
+                                load_q_consumer.wait_and_advance()
+                                tSrQ_slice = tSrQ[None, None, None, iter]
+
+                                k_handle = load_k_consumer.wait_and_advance()
+                                tSrK_trans_slice = tSrK[None, None, None, k_handle.index]
+                                num_kphases = cute.size(tSrQ_slice, mode=[2])
+                                if cutlass.const_expr(num_kphases % num_innerloop == 0):
+                                    num_outer_iter = num_kphases // num_innerloop
+                                    for outer_iter in cutlass.range(num_outer_iter, unroll=1):
+                                        for kphase_idx in cutlass.range(
+                                            num_innerloop, unroll_full=True
+                                        ):
+                                            kphase_coord = (
+                                                None,
+                                                None,
+                                                outer_iter * num_innerloop + kphase_idx,
+                                            )
+                                            cute.gemm(
+                                                qk_tiled_mma,
+                                                tStS_slice,
+                                                tSrQ_slice[kphase_coord],
+                                                tSrK_trans_slice[kphase_coord],
+                                                tStS_slice,
+                                            )
+                                            qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                                else:
+                                    for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+                                        kphase_coord = (None, None, kphase_idx)
+                                        cute.gemm(
+                                            qk_tiled_mma,
+                                            tStS_slice,
+                                            tSrQ_slice[kphase_coord],
+                                            tSrK_trans_slice[kphase_coord],
+                                            tStS_slice,
+                                        )
+                                        qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                                k_handle.release()
+                            cute.arch.fence_view_async_tmem_store()
+                            s_handle.commit()
+
+                            # dOV0
+                            dp_handle = mma_dp_producer.acquire_and_advance()
+                            tdPtdP_slice = tdPtdP[None, None, None, dp_handle.index]
+                            dov_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+                            for iter in cutlass.range(self.iterations_dov, unroll=1):
+                                load_do_consumer.wait_and_advance()
+                                tdPrdO_slice = tdPrdO[None, None, None, iter]
+                                v_handle = load_v_consumer.wait_and_advance()
+                                tdPrV_trans_slice = tdPrV[None, None, None, v_handle.index]
+                                num_kphases = cute.size(tdPrdO_slice, mode=[2])
+                                if cutlass.const_expr(num_kphases % num_innerloop == 0):
+                                    num_outer_iter = num_kphases // num_innerloop
+                                    for outer_iter in cutlass.range(num_outer_iter, unroll=1):
+                                        for kphase_idx in cutlass.range(
+                                            num_innerloop, unroll_full=True
+                                        ):
+                                            kphase_coord = (
+                                                None,
+                                                None,
+                                                outer_iter * num_innerloop + kphase_idx,
+                                            )
+                                            cute.gemm(
+                                                dov_tiled_mma,
+                                                tdPtdP_slice,
+                                                tdPrdO_slice[kphase_coord],
+                                                tdPrV_trans_slice[kphase_coord],
+                                                tdPtdP_slice,
+                                            )
+                                            dov_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                                else:
+                                    for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+                                        kphase_coord = (None, None, kphase_idx)
+                                        cute.gemm(
+                                            dov_tiled_mma,
+                                            tdPtdP_slice,
+                                            tdPrdO_slice[kphase_coord],
+                                            tdPrV_trans_slice[kphase_coord],
+                                            tdPtdP_slice,
+                                        )
+                                        dov_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                                v_handle.release()
+                            cute.arch.fence_view_async_tmem_store()
+                            dp_handle.commit()
+
+                            for i in cutlass.range(1, seqlen_kv_loop_steps - 1, 1, unroll=1):
+                                # QKi
+                                s_handle = mma_s_producer.acquire_and_advance()
+
+                                tStS_slice = tStS[None, None, None, s_handle.index]
+                                qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+                                for iter in cutlass.range(self.iterations_qk, unroll=1):
+                                    tSrQ_slice = tSrQ[None, None, None, iter]
+                                    k_handle = load_k_consumer.wait_and_advance()
+                                    tSrK_trans_slice = tSrK[None, None, None, k_handle.index]
+                                    num_kphases = cute.size(tSrQ_slice, mode=[2])
+                                    if cutlass.const_expr(num_kphases % num_innerloop == 0):
+                                        num_outer_iter = num_kphases // num_innerloop
+                                        for outer_iter in cutlass.range(num_outer_iter, unroll=1):
+                                            for kphase_idx in cutlass.range(
+                                                num_innerloop, unroll_full=True
+                                            ):
+                                                kphase_coord = (
+                                                    None,
+                                                    None,
+                                                    outer_iter * num_innerloop + kphase_idx,
+                                                )
+                                                cute.gemm(
+                                                    qk_tiled_mma,
+                                                    tStS_slice,
+                                                    tSrQ_slice[kphase_coord],
+                                                    tSrK_trans_slice[kphase_coord],
+                                                    tStS_slice,
+                                                )
+                                                qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                                    else:
+                                        for kphase_idx in cutlass.range(
+                                            num_kphases, unroll_full=True
+                                        ):
+                                            kphase_coord = (None, None, kphase_idx)
+                                            cute.gemm(
+                                                qk_tiled_mma,
+                                                tStS_slice,
+                                                tSrQ_slice[kphase_coord],
+                                                tSrK_trans_slice[kphase_coord],
+                                                tStS_slice,
+                                            )
+                                            qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                                    k_handle.release()
+                                s_handle.commit()
+
+                                # dSKTi
+                                ds_handle = ds_mma_consumer.wait_and_advance()
+                                dsk_whether_acc = dsk_tiled_mma.get(tcgen05.Field.ACCUMULATE)
+                                for iter in cutlass.range(self.iterations_dsk, unroll=1):
+                                    kt_handle = load_kt_consumer.wait_and_advance()
+                                    dsk_tiled_mma.set(tcgen05.Field.ACCUMULATE, dsk_whether_acc)
+                                    tdQtdQ_slice = tdQtdQ_staged[None, None, None, iter]
+                                    tdStdS_slice = tdPtdP[None, None, None, ds_handle.index]
+                                    tdS = cute.make_tensor(
+                                        tdStdS_slice.iterator, ds_tmem_layout_staged.outer
+                                    )
+                                    tdQrdS = dsk_thr_mma.make_fragment_A(tdS)
+                                    tdQrdS_slice = cute.make_tensor(
+                                        cute.recast_ptr(tdStdS_slice.iterator, dtype=self.q_dtype),
+                                        tdQrdS.layout,
+                                    )
+
+                                    tdQrKT_slice = tdQrKT[None, None, None, kt_handle.index]
+                                    num_kphases = cute.size(tdQrKT_slice, mode=[2])
+                                    if cutlass.const_expr(num_kphases % num_innerloop == 0):
+                                        num_outer_iter = num_kphases // num_innerloop
+                                        for outer_iter in cutlass.range(num_outer_iter, unroll=1):
+                                            for kphase_idx in cutlass.range(
+                                                num_innerloop, unroll_full=True
+                                            ):
+                                                kphase_coord = (
+                                                    None,
+                                                    None,
+                                                    outer_iter * num_innerloop + kphase_idx,
+                                                )
+                                                cute.gemm(
+                                                    dsk_tiled_mma,
+                                                    tdQtdQ_slice,
+                                                    tdQrdS_slice[kphase_coord],
+                                                    tdQrKT_slice[kphase_coord],
+                                                    tdQtdQ_slice,
+                                                )
+                                                dsk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                                    else:
+                                        for kphase_idx in cutlass.range(
+                                            num_kphases, unroll_full=True
+                                        ):
+                                            kphase_coord = (None, None, kphase_idx)
+                                            cute.gemm(
+                                                dsk_tiled_mma,
+                                                tdQtdQ_slice,
+                                                tdQrdS_slice[kphase_coord],
+                                                tdQrKT_slice[kphase_coord],
+                                                tdQtdQ_slice,
+                                            )
+                                            dsk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                                    kt_handle.release()
+                                ds_handle.release()
+
+                                # dOVi
+                                dp_handle = mma_dp_producer.acquire_and_advance()
+                                tdPtdP_slice = tdPtdP[None, None, None, dp_handle.index]
+                                dov_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+                                for iter in cutlass.range(self.iterations_dov, unroll=1):
+                                    tdPrdO_slice = tdPrdO[None, None, None, iter]
+                                    v_handle = load_v_consumer.wait_and_advance()
+                                    tdPrV_trans_slice = tdPrV[None, None, None, v_handle.index]
+                                    num_kphases = cute.size(tdPrdO_slice, mode=[2])
+                                    if cutlass.const_expr(num_kphases % num_innerloop == 0):
+                                        num_outer_iter = num_kphases // num_innerloop
+                                        for outer_iter in cutlass.range(num_outer_iter, unroll=1):
+                                            for kphase_idx in cutlass.range(
+                                                num_innerloop, unroll_full=True
+                                            ):
+                                                kphase_coord = (
+                                                    None,
+                                                    None,
+                                                    outer_iter * num_innerloop + kphase_idx,
+                                                )
+                                                cute.gemm(
+                                                    dov_tiled_mma,
+                                                    tdPtdP_slice,
+                                                    tdPrdO_slice[kphase_coord],
+                                                    tdPrV_trans_slice[kphase_coord],
+                                                    tdPtdP_slice,
+                                                )
+                                                dov_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                                    else:
+                                        for kphase_idx in cutlass.range(
+                                            num_kphases, unroll_full=True
+                                        ):
+                                            kphase_coord = (None, None, kphase_idx)
+                                            cute.gemm(
+                                                dov_tiled_mma,
+                                                tdPtdP_slice,
+                                                tdPrdO_slice[kphase_coord],
+                                                tdPrV_trans_slice[kphase_coord],
+                                                tdPtdP_slice,
+                                            )
+                                            dov_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                                    v_handle.release()
+                                dp_handle.commit()
+
+                            # QKend
+                            s_handle = mma_s_producer.acquire_and_advance()
+                            tStS_slice = tStS[None, None, None, s_handle.index]
+                            qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+                            for iter in cutlass.range(self.iterations_qk, unroll=1):
+                                tSrQ_slice = tSrQ[None, None, None, iter]
+                                k_handle = load_k_consumer.wait_and_advance()
+
+                                tSrK_trans_slice = tSrK[None, None, None, k_handle.index]
+
+                                num_kphases = cute.size(tSrQ_slice, mode=[2])
+                                if cutlass.const_expr(num_kphases % num_innerloop == 0):
+                                    num_outer_iter = num_kphases // num_innerloop
+                                    for outer_iter in cutlass.range(num_outer_iter, unroll=1):
+                                        for kphase_idx in cutlass.range(
+                                            num_innerloop, unroll_full=True
+                                        ):
+                                            kphase_coord = (
+                                                None,
+                                                None,
+                                                outer_iter * num_innerloop + kphase_idx,
+                                            )
+                                            cute.gemm(
+                                                qk_tiled_mma,
+                                                tStS_slice,
+                                                tSrQ_slice[kphase_coord],
+                                                tSrK_trans_slice[kphase_coord],
+                                                tStS_slice,
+                                            )
+                                            qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                                else:
+                                    for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+                                        kphase_coord = (None, None, kphase_idx)
+                                        cute.gemm(
+                                            qk_tiled_mma,
+                                            tStS_slice,
+                                            tSrQ_slice[kphase_coord],
+                                            tSrK_trans_slice[kphase_coord],
+                                            tStS_slice,
+                                        )
+                                        qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                                k_handle.release()
+                                load_q_releaser.release()
+                                load_q_releaser.advance()
+                            s_handle.commit()
+
+                            # dSKTend - 1
+                            ds_handle = ds_mma_consumer.wait_and_advance()
+                            dsk_whether_acc = dsk_tiled_mma.get(tcgen05.Field.ACCUMULATE)
+                            for iter in cutlass.range(self.iterations_dsk, unroll=1):
+                                kt_handle = load_kt_consumer.wait_and_advance()
+                                dsk_tiled_mma.set(tcgen05.Field.ACCUMULATE, dsk_whether_acc)
+                                tdQtdQ_slice = tdQtdQ_staged[None, None, None, iter]
+                                tdStdS_slice = tdPtdP[None, None, None, ds_handle.index]
+                                tdS = cute.make_tensor(
+                                    tdStdS_slice.iterator, ds_tmem_layout_staged.outer
+                                )
+                                tdQrdS = dsk_thr_mma.make_fragment_A(tdS)
+                                tdQrdS_slice = cute.make_tensor(
+                                    cute.recast_ptr(tdStdS_slice.iterator, dtype=self.q_dtype),
+                                    tdQrdS.layout,
+                                )
+
+                                tdQrKT_slice = tdQrKT[None, None, None, kt_handle.index]
+                                num_kphases = cute.size(tdQrKT_slice, mode=[2])
+                                if cutlass.const_expr(num_kphases % num_innerloop == 0):
+                                    num_outer_iter = num_kphases // num_innerloop
+                                    for outer_iter in cutlass.range(num_outer_iter, unroll=1):
+                                        for kphase_idx in cutlass.range(
+                                            num_innerloop, unroll_full=True
+                                        ):
+                                            kphase_coord = (
+                                                None,
+                                                None,
+                                                outer_iter * num_innerloop + kphase_idx,
+                                            )
+                                            cute.gemm(
+                                                dsk_tiled_mma,
+                                                tdQtdQ_slice,
+                                                tdQrdS_slice[kphase_coord],
+                                                tdQrKT_slice[kphase_coord],
+                                                tdQtdQ_slice,
+                                            )
+                                            dsk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                                else:
+                                    for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+                                        kphase_coord = (None, None, kphase_idx)
+                                        cute.gemm(
+                                            dsk_tiled_mma,
+                                            tdQtdQ_slice,
+                                            tdQrdS_slice[kphase_coord],
+                                            tdQrKT_slice[kphase_coord],
+                                            tdQtdQ_slice,
+                                        )
+                                        dsk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                                kt_handle.release()
+                            ds_handle.release()
+
+                            # dOVend
+                            dp_handle = mma_dp_producer.acquire_and_advance()
+                            tdPtdP_slice = tdPtdP[None, None, None, dp_handle.index]
+                            dov_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+                            for iter in cutlass.range(self.iterations_dov, unroll=1):
+                                tdPrdO_slice = tdPrdO[None, None, None, iter]
+                                v_handle = load_v_consumer.wait_and_advance()
+                                tdPrV_trans_slice = tdPrV[None, None, None, v_handle.index]
+                                num_kphases = cute.size(tdPrdO_slice, mode=[2])
+                                if cutlass.const_expr(num_kphases % num_innerloop == 0):
+                                    num_outer_iter = num_kphases // num_innerloop
+                                    for outer_iter in cutlass.range(num_outer_iter, unroll=1):
+                                        for kphase_idx in cutlass.range(
+                                            num_innerloop, unroll_full=True
+                                        ):
+                                            kphase_coord = (
+                                                None,
+                                                None,
+                                                outer_iter * num_innerloop + kphase_idx,
+                                            )
+                                            cute.gemm(
+                                                dov_tiled_mma,
+                                                tdPtdP_slice,
+                                                tdPrdO_slice[kphase_coord],
+                                                tdPrV_trans_slice[kphase_coord],
+                                                tdPtdP_slice,
+                                            )
+                                            dov_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                                else:
+                                    for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+                                        kphase_coord = (None, None, kphase_idx)
+                                        cute.gemm(
+                                            dov_tiled_mma,
+                                            tdPtdP_slice,
+                                            tdPrdO_slice[kphase_coord],
+                                            tdPrV_trans_slice[kphase_coord],
+                                            tdPtdP_slice,
+                                        )
+                                        dov_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                                v_handle.release()
+                                load_do_releaser.release()
+                                load_do_releaser.advance()
+                            dp_handle.commit()
+                            # dSKTend
+                            ds_handle = ds_mma_consumer.wait_and_advance()
+                            dsk_whether_acc = dsk_tiled_mma.get(tcgen05.Field.ACCUMULATE)
+                            for iter in cutlass.range(self.iterations_dsk, unroll=1):
+                                kt_handle = load_kt_consumer.wait_and_advance()
+                                dsk_tiled_mma.set(tcgen05.Field.ACCUMULATE, dsk_whether_acc)
+                                tdQtdQ_slice = tdQtdQ_staged[None, None, None, iter]
+                                tdStdS_slice = tdPtdP[None, None, None, ds_handle.index]
+                                tdS = cute.make_tensor(
+                                    tdStdS_slice.iterator, ds_tmem_layout_staged.outer
+                                )
+                                tdQrdS = dsk_thr_mma.make_fragment_A(tdS)
+                                tdQrdS_slice = cute.make_tensor(
+                                    cute.recast_ptr(tdStdS_slice.iterator, dtype=self.q_dtype),
+                                    tdQrdS.layout,
+                                )
+
+                                tdQrKT_slice = tdQrKT[None, None, None, kt_handle.index]
+                                num_kphases = cute.size(tdQrKT_slice, mode=[2])
+                                if cutlass.const_expr(num_kphases % num_innerloop == 0):
+                                    num_outer_iter = num_kphases // num_innerloop
+                                    for outer_iter in cutlass.range(num_outer_iter, unroll=1):
+                                        for kphase_idx in cutlass.range(
+                                            num_innerloop, unroll_full=True
+                                        ):
+                                            kphase_coord = (
+                                                None,
+                                                None,
+                                                outer_iter * num_innerloop + kphase_idx,
+                                            )
+                                            cute.gemm(
+                                                dsk_tiled_mma,
+                                                tdQtdQ_slice,
+                                                tdQrdS_slice[kphase_coord],
+                                                tdQrKT_slice[kphase_coord],
+                                                tdQtdQ_slice,
+                                            )
+                                            dsk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                                else:
+                                    for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+                                        kphase_coord = (None, None, kphase_idx)
+                                        cute.gemm(
+                                            dsk_tiled_mma,
+                                            tdQtdQ_slice,
+                                            tdQrdS_slice[kphase_coord],
+                                            tdQrKT_slice[kphase_coord],
+                                            tdQtdQ_slice,
+                                        )
+                                        dsk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                                kt_handle.release()
+                            ds_handle.release()
+                        else:
+                            # QK0
+                            s_handle = mma_s_producer.acquire_and_advance()
+                            tStS_slice = tStS[None, None, None, s_handle.index]
+                            qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+
+                            for iter in cutlass.range(self.iterations_qk, unroll=1):
+                                load_q_consumer.wait_and_advance()
+                                tSrQ_slice = tSrQ[None, None, None, iter]
+                                k_handle = load_k_consumer.wait_and_advance()
+                                tSrK_trans_slice = tSrK[None, None, None, k_handle.index]
+                                num_kphases = cute.size(tSrQ_slice, mode=[2])
+                                if cutlass.const_expr(num_kphases % num_innerloop == 0):
+                                    num_outer_iter = num_kphases // num_innerloop
+                                    for outer_iter in cutlass.range(num_outer_iter, unroll=1):
+                                        for kphase_idx in cutlass.range(
+                                            num_innerloop, unroll_full=True
+                                        ):
+                                            kphase_coord = (
+                                                None,
+                                                None,
+                                                outer_iter * num_innerloop + kphase_idx,
+                                            )
+                                            cute.gemm(
+                                                qk_tiled_mma,
+                                                tStS_slice,
+                                                tSrQ_slice[kphase_coord],
+                                                tSrK_trans_slice[kphase_coord],
+                                                tStS_slice,
+                                            )
+                                            qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                                else:
+                                    for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+                                        kphase_coord = (None, None, kphase_idx)
+                                        cute.gemm(
+                                            qk_tiled_mma,
+                                            tStS_slice,
+                                            tSrQ_slice[kphase_coord],
+                                            tSrK_trans_slice[kphase_coord],
+                                            tStS_slice,
+                                        )
+                                        qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                                k_handle.release()
+                                load_q_releaser.release()
+                                load_q_releaser.advance()
+                            s_handle.commit()
+
+                            # dOV0
+                            dp_handle = mma_dp_producer.acquire_and_advance()
+                            tdPtdP_slice = tdPtdP[None, None, None, dp_handle.index]
+                            dov_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+                            for iter in cutlass.range(self.iterations_dov, unroll=1):
+                                load_do_consumer.wait_and_advance()
+                                tdPrdO_slice = tdPrdO[None, None, None, iter]
+                                v_handle = load_v_consumer.wait_and_advance()
+                                tdPrV_trans_slice = tdPrV[None, None, None, v_handle.index]
+                                num_kphases = cute.size(tdPrdO_slice, mode=[2])
+                                if cutlass.const_expr(num_kphases % num_innerloop == 0):
+                                    num_outer_iter = num_kphases // num_innerloop
+                                    for outer_iter in cutlass.range(num_outer_iter, unroll=1):
+                                        for kphase_idx in cutlass.range(
+                                            num_innerloop, unroll_full=True
+                                        ):
+                                            kphase_coord = (
+                                                None,
+                                                None,
+                                                outer_iter * num_innerloop + kphase_idx,
+                                            )
+                                            cute.gemm(
+                                                dov_tiled_mma,
+                                                tdPtdP_slice,
+                                                tdPrdO_slice[kphase_coord],
+                                                tdPrV_trans_slice[kphase_coord],
+                                                tdPtdP_slice,
+                                            )
+                                            dov_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                                else:
+                                    for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+                                        kphase_coord = (None, None, kphase_idx)
+                                        cute.gemm(
+                                            dov_tiled_mma,
+                                            tdPtdP_slice,
+                                            tdPrdO_slice[kphase_coord],
+                                            tdPrV_trans_slice[kphase_coord],
+                                            tdPtdP_slice,
+                                        )
+                                        dov_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                                v_handle.release()
+                                load_do_releaser.release()
+                                load_do_releaser.advance()
+                            dp_handle.commit()
+
+                            # dSKT0
+                            ds_handle = ds_mma_consumer.wait_and_advance()
+                            dsk_whether_acc = dsk_tiled_mma.get(tcgen05.Field.ACCUMULATE)
+                            for iter in cutlass.range(self.iterations_dsk, unroll=1):
+                                kt_handle = load_kt_consumer.wait_and_advance()
+                                dsk_tiled_mma.set(tcgen05.Field.ACCUMULATE, dsk_whether_acc)
+                                tdQtdQ_slice = tdQtdQ_staged[None, None, None, iter]
+                                tdStdS_slice = tdPtdP[None, None, None, ds_handle.index]
+                                tdS = cute.make_tensor(
+                                    tdStdS_slice.iterator, ds_tmem_layout_staged.outer
+                                )
+                                tdQrdS = dsk_thr_mma.make_fragment_A(tdS)
+                                tdQrdS_slice = cute.make_tensor(
+                                    cute.recast_ptr(tdStdS_slice.iterator, dtype=self.q_dtype),
+                                    tdQrdS.layout,
+                                )
+
+                                tdQrKT_slice = tdQrKT[None, None, None, kt_handle.index]
+                                num_kphases = cute.size(tdQrKT_slice, mode=[2])
+                                if cutlass.const_expr(num_kphases % num_innerloop == 0):
+                                    num_outer_iter = num_kphases // num_innerloop
+                                    for outer_iter in cutlass.range(num_outer_iter, unroll=1):
+                                        for kphase_idx in cutlass.range(
+                                            num_innerloop, unroll_full=True
+                                        ):
+                                            kphase_coord = (
+                                                None,
+                                                None,
+                                                outer_iter * num_innerloop + kphase_idx,
+                                            )
+                                            cute.gemm(
+                                                dsk_tiled_mma,
+                                                tdQtdQ_slice,
+                                                tdQrdS_slice[kphase_coord],
+                                                tdQrKT_slice[kphase_coord],
+                                                tdQtdQ_slice,
+                                            )
+                                            dsk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                                else:
+                                    for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+                                        kphase_coord = (None, None, kphase_idx)
+                                        cute.gemm(
+                                            dsk_tiled_mma,
+                                            tdQtdQ_slice,
+                                            tdQrdS_slice[kphase_coord],
+                                            tdQrKT_slice[kphase_coord],
+                                            tdQtdQ_slice,
+                                        )
+                                        dsk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                                kt_handle.release()
+                            ds_handle.release()
+                        dq_handle.commit()
+                work_tile = tile_sched.advance_to_next_work()
+            # End of persistent scheduler loop
+            mma_s_producer.tail()
+            mma_dp_producer.tail()
+            mma_dq_producer.tail()
+
+        # Softmax and dSoftmax warp
+        if warp_idx >= self.compute_warp_ids[0] and warp_idx <= self.compute_warp_ids[-1]:
+            # increase register after decreasing
+            cute.arch.warpgroup_reg_alloc(self.num_regs_compute)
+            while work_tile.is_valid_tile:
+                curr_block_coord = work_tile.tile_idx
+                mma_block_coord = (
+                    curr_block_coord[0] // cute.size(qk_tiled_mma.thr_id.shape),
+                    curr_block_coord[1],
+                    curr_block_coord[2],
+                )
+                batch_coord = curr_block_coord[2][1]
+                continue_cond = False
+                seqlen_q = mQ_qdl.shape[0]
+                seqlen_k = mK_kdl.shape[0]
+                cuseqlen_q = Int32(0)
+                if cutlass.const_expr(cum_seqlen_q is not None):
+                    cuseqlen_q = cum_seqlen_q[batch_coord]
+                    seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
+                    continue_cond = not FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
+                        self.qk_mma_tiler[0],
+                        mma_block_coord[0],
+                        seqlen_q,
+                    )
+                if not continue_cond:
+                    if cutlass.const_expr(cum_seqlen_k is not None):
+                        cuseqlen_k = cum_seqlen_k[batch_coord]
+                        seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
+
+                    start_count, trip_count = FusedMask.get_trip_start_count_via_block_info(
+                        mma_block_coord,
+                        self.qk_mma_tiler,
+                        seqlen_q,
+                        seqlen_k,
+                        self.is_causal,
+                        self.is_local,
+                        window_size_left,
+                        window_size_right,
+                    )
+                    end_count = start_count + trip_count
+                    if cutlass.const_expr(self.use_semantic_trip_range):
+                        n_block_min_causal_local_mask, n_block_min_before_local_mask = (
+                            FusedMask.get_trip_mask_bounds_via_block_info(
+                                mma_block_coord,
+                                self.qk_mma_tiler,
+                                seqlen_q,
+                                seqlen_k,
+                                self.is_causal,
+                                self.is_local,
+                                window_size_left,
+                                window_size_right,
+                            )
+                        )
+
+                    cS_base = cute.make_identity_tensor(
+                        (self.qk_mma_tiler[0], self.qk_mma_tiler[1])
+                    )
+                    cS = cute.domain_offset((mma_block_coord[0] * self.qk_mma_tiler[0], 0), cS_base)
+                    tScS = qk_thr_mma.partition_C(cS)
+
+                    cdP_base = cute.make_identity_tensor(
+                        (self.dov_mma_tiler[0], self.dov_mma_tiler[1])
+                    )
+                    cdP = cute.domain_offset(
+                        (mma_block_coord[0] * self.dov_mma_tiler[0], 0), cdP_base
+                    )
+                    tdPcdP = dov_thr_mma.partition_C(cdP)
+
+                    lse_handle = load_lse_consumer.wait_and_advance()
+                    sum_odo_handle = load_sum_odo_consumer.wait_and_advance()
+                    for step in cutlass.range(start_count, end_count, 1, unroll=1):
+                        cS_iter = cute.domain_offset((0, step * self.qk_mma_tiler[1]), cS)
+                        tScS_iter = qk_thr_mma.partition_C(cS_iter)
+
+                        cdP_iter = cute.domain_offset((0, step * self.dov_mma_tiler[1]), cdP)
+
+                        tdPcdP_iter = dov_thr_mma.partition_C(cdP_iter)
+
+                        # Si, dPi -> dSi
+                        if cutlass.const_expr(self.use_semantic_trip_range):
+                            need_apply_mask = (
+                                step >= n_block_min_causal_local_mask
+                                or step < n_block_min_before_local_mask
+                            )
+                        else:
+                            need_apply_mask = step == end_count - 1
+                        mma_s_consumer, mma_dp_consumer, ds_mma_producer = self.compute_step(
+                            (need_apply_mask, window_size_left, window_size_right),
+                            (
+                                seqlen_q,
+                                seqlen_k,
+                                scale_softmax,
+                                batch_coord,
+                                curr_block_coord[0],
+                                varlen,
+                            ),
+                            (tStS, tScS_iter, tdPtdP, tdPcdP_iter, sLSE, sSum_OdO),
+                            (
+                                mma_s_consumer,
+                                mma_dp_consumer,
+                                ds_mma_producer,
+                                lse_handle,
+                                sum_odo_handle,
+                            ),
+                            step,
+                        )
+                    lse_handle.release()
+                    sum_odo_handle.release()
+                work_tile = tile_sched.advance_to_next_work()
+            ds_mma_producer.tail()
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Epilogue
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx >= self.epilogue_warp_ids[0] and warp_idx <= self.epilogue_warp_ids[-1]:
+            cute.arch.warpgroup_reg_dealloc(self.num_regs_epilogue)
+
+            while work_tile.is_valid_tile:
+                curr_block_coord = work_tile.tile_idx
+                mma_block_coord = (
+                    curr_block_coord[0] // cute.size(qk_tiled_mma.thr_id.shape),
+                    curr_block_coord[1],
+                    curr_block_coord[2],
+                )
+                batch_coord = curr_block_coord[2][1]
+                # cute.printf("batch_coord={}", batch_coord)
+                seqlen_q = mQ_qdl.shape[0]
+                seqlen_k = mK_kdl.shape[0]
+                continue_cond = False
+                cuseqlen_q = Int32(0)
+                if cutlass.const_expr(cum_seqlen_q is not None):
+                    cuseqlen_q = cum_seqlen_q[batch_coord]
+                    seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
+                    continue_cond = not FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
+                        self.qk_mma_tiler[0],
+                        mma_block_coord[0],
+                        seqlen_q,
+                    )
+
+                if not continue_cond:
+                    if cutlass.const_expr(cum_seqlen_k is not None):
+                        cuseqlen_k = cum_seqlen_k[batch_coord]
+                        seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
+
+                    mdQ_qdl_eff = mdQ_qdl
+                    if cutlass.const_expr(cum_seqlen_q is not None):
+                        block_offset_dQ = (
+                            cuseqlen_q,
+                            Int32(0),
+                            Int32(0),
+                            ((Int32(0), Int32(0)), Int32(0)),
+                        )
+                        mdQ_qdl_eff = cute.domain_offset(
+                            cute.select(block_offset_dQ, mode=[0, 2, 3]), mdQ_qdl
+                        )
+
+                    # (bM, bN, loopM, loopN, loopL)
+                    gdQ_qdl = cute.flat_divide(
+                        mdQ_qdl_eff, cute.select(self.dsk_block_tiler, mode=[0, 1])
+                    )
+                    cdQ_qdl = cute.flat_divide(
+                        cute.make_identity_tensor(mdQ_qdl_eff.shape),
+                        cute.select(self.dsk_block_tiler, mode=[0, 1]),
+                    )
+
+                    gdQ_staged = gdQ_qdl[None, None, curr_block_coord[0], None, curr_block_coord[2]]
+                    cdQ_staged = cdQ_qdl[None, None, curr_block_coord[0], None, curr_block_coord[2]]
+
+                    # dQ TMEM to GMEM
+                    mma_dq_consumer = self.dQ_epilogue(
+                        (seqlen_q, cuseqlen_q, mQ_qdl.shape[0], batch_coord),
+                        (mma_dq_consumer, gdQ_staged, cdQ_staged, tdQtdQ_staged),
+                        self.epi_tile,
+                    )
+                work_tile = tile_sched.advance_to_next_work()
+            # NOTE: tmem.free() moved to kernel end to enable cluster-wide sync
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Scheduler Warp (only for CLC dynamic scheduler)
+        # ///////////////////////////////////////////////////////////////////////////////
+        if cutlass.const_expr(self.use_clc_scheduler):
+            is_first_cta_in_cluster = cta_rank_in_cluster == 0
+
+            if warp_idx == self.sched_warp_id and is_first_cta_in_cluster:
+                cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
+                while work_tile.is_valid_tile:
+                    tile_sched.prefetch_next_work()
+                    work_tile = tile_sched.advance_to_next_work()
+                tile_sched.producer_tail()
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Empty warps reg dealloc
+        # ///////////////////////////////////////////////////////////////////////////////
+        if cutlass.const_expr(self.use_clc_scheduler):
+            if warp_idx > self.load_warp_id:
+                if not (warp_idx == self.sched_warp_id and is_first_cta_in_cluster):
+                    cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
+        else:
+            if warp_idx > self.load_warp_id:
+                cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Cooperative TMEM Deallocation (2CTA)
+        # ///////////////////////////////////////////////////////////////////////////////
+        # All warps (including scheduler) have finished by this point.
+        # Cluster-wide sync ensures both CTAs reach here before dealloc.
+        cute.arch.cluster_arrive()
+        cute.arch.cluster_wait()
+        tmem.relinquish_alloc_permit()
+        tmem.free(tmem_ptr)
+
+        return
+
+    @cute.jit
+    def compute_step(
+        self,
+        mask_args: Tuple,
+        value_args: Tuple,
+        tensor_args: Tuple,
+        pipeline_args: Tuple,
+        step: Int32,
+    ) -> Tuple[Float32, Float32, pipeline.PipelineConsumer, pipeline.PipelineProducer]:
+        need_apply_mask, window_size_left, window_size_right = mask_args
+        seqlen_q, seqlen_k, scale_softmax, batch_coord, block_m_idx, varlen = value_args
+        tStS, tScS, tdPtdP, tdPcdP, sLSE, sSum_OdO = tensor_args
+        mma_s_consumer, mma_dp_consumer, ds_mma_producer, lse_handle, sum_odo_handle = pipeline_args
+
+        bidx = block_m_idx
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx % (self.threads_per_warp * len(self.compute_warp_ids))
+        s_handle = mma_s_consumer.wait_and_advance()
+        tStS_slice = tStS[(None, None), 0, 0, s_handle.index]
+        tScS_slice = tScS[(None, None), 0, 0]
+        tmem_load_atom = cute.make_copy_atom(
+            tcgen05.Ld32x32bOp(tcgen05.Repetition(16)), self.acc_dtype
+        )
+        tmem_tiled_load = tcgen05.make_tmem_copy(tmem_load_atom, tStS_slice)
+        thr_load = tmem_tiled_load.get_slice(thread_idx)
+        tTMEM_LOADtS = thr_load.partition_S(tStS_slice)
+        tTMEM_LOADcS = thr_load.partition_D(tScS_slice)
+        tTMEM_LOADrS = cute.make_rmem_tensor(tTMEM_LOADcS.shape, self.acc_dtype)
+        cute.copy(tmem_tiled_load, tTMEM_LOADtS, tTMEM_LOADrS)
+        cute.arch.fence_view_async_tmem_load()
+        s_handle.release()
+        if need_apply_mask:
+            FusedMask.apply_mask_via_causal_local(
+                tTMEM_LOADrS,
+                tTMEM_LOADcS,
+                seqlen_q,
+                seqlen_k,
+                self.use_semantic_trip_range,
+                self.is_causal,
+                self.is_local,
+                window_size_left,
+                window_size_right,
+            )
+
+        log2_e = cutlass.Float32(math.log2(math.e))
+        softmax_scale_log2_e = scale_softmax * log2_e
+        tTMEM_STORErP = cute.make_rmem_tensor(tTMEM_LOADrS.shape, self.q_dtype)
+        for k in cutlass.range(0, cute.size(tTMEM_LOADrS), 2, unroll_full=True):
+            lse = (
+                -sLSE[
+                    cute.get(tTMEM_LOADcS[k], mode=[0]) - bidx * self.cta_tiler[0],
+                    lse_handle.index,
+                ],
+                -sLSE[
+                    cute.get(tTMEM_LOADcS[k + 1], mode=[0]) - bidx * self.cta_tiler[0],
+                    lse_handle.index,
+                ],
+            )
+            tTMEM_LOADrS[k], tTMEM_LOADrS[k + 1] = cute.arch.fma_packed_f32x2(
+                (tTMEM_LOADrS[k], tTMEM_LOADrS[k + 1]),
+                (softmax_scale_log2_e, softmax_scale_log2_e),
+                lse,
+            )
+            tTMEM_LOADrS[k] = cute.math.exp2(tTMEM_LOADrS[k], fastmath=True)
+            tTMEM_LOADrS[k + 1] = cute.math.exp2(tTMEM_LOADrS[k + 1], fastmath=True)
+
+        dp_handle = mma_dp_consumer.wait_and_advance()
+        tdPtdP_slice = tdPtdP[(None, None), 0, 0, dp_handle.index]
+        tdPcdP_slice = tdPcdP[(None, None), 0, 0]
+        thr_load = tmem_tiled_load.get_slice(thread_idx)
+        tTMEM_LOADtdP = thr_load.partition_S(tdPtdP_slice)
+        tTMEM_LOADcdP = thr_load.partition_D(tdPcdP_slice)
+        tTMEM_LOADrdP = cute.make_rmem_tensor(tTMEM_LOADcdP.shape, self.acc_dtype)
+        cute.copy(tmem_tiled_load, tTMEM_LOADtdP, tTMEM_LOADrdP)
+        cute.arch.fence_view_async_tmem_load()
+        dp_handle.release()
+        tTMEM_STORErdP = cute.make_rmem_tensor(tTMEM_LOADrdP.shape, self.q_dtype)
+
+        for k in cutlass.range(0, cute.size(tTMEM_LOADrdP), 2, unroll_full=True):
+            dpsum_0 = -sSum_OdO[
+                cute.get(tTMEM_LOADcdP[k], mode=[0]) - bidx * self.cta_tiler[0],
+                sum_odo_handle.index,
+            ]
+            dpsum_1 = -sSum_OdO[
+                cute.get(tTMEM_LOADcdP[k + 1], mode=[0]) - bidx * self.cta_tiler[0],
+                sum_odo_handle.index,
+            ]
+            if cutlass.const_expr(varlen):
+                if not cute.elem_less(cute.get(tTMEM_LOADcdP[k], mode=[0]), seqlen_q):
+                    dpsum_0 = 0.0
+                if not cute.elem_less(cute.get(tTMEM_LOADcdP[k + 1], mode=[0]), seqlen_q):
+                    dpsum_1 = 0.0
+            tTMEM_LOADrdP[k], tTMEM_LOADrdP[k + 1] = cute.arch.add_packed_f32x2(
+                (tTMEM_LOADrdP[k], tTMEM_LOADrdP[k + 1]),
+                (dpsum_0, dpsum_1),
+            )
+            tTMEM_LOADrdP[k], tTMEM_LOADrdP[k + 1] = cute.arch.mul_packed_f32x2(
+                (tTMEM_LOADrdP[k], tTMEM_LOADrdP[k + 1]), (tTMEM_LOADrS[k], tTMEM_LOADrS[k + 1])
+            )
+            tTMEM_LOADrdP[k], tTMEM_LOADrdP[k + 1] = cute.arch.mul_packed_f32x2(
+                (tTMEM_LOADrdP[k], tTMEM_LOADrdP[k + 1]), (scale_softmax, scale_softmax)
+            )
+        dp_vec = tTMEM_LOADrdP.load()
+        tTMEM_STORErdP.store(dp_vec.to(self.q_dtype))
+
+        ds_handle = ds_mma_producer.acquire_and_advance()
+        tmem_store_atom = cute.make_copy_atom(
+            tcgen05.St32x32bOp(tcgen05.Repetition(32)), self.acc_dtype
+        )
+        tilePlikeFP32 = tdPtdP_slice.shape[1] // Float32.width * self.q_dtype.width
+        tdPtdP_dS_layout = cute.composition(
+            tdPtdP_slice.layout, cute.make_layout((tdPtdP_slice.shape[0], tilePlikeFP32))
+        )
+        tdPtdP_dS = cute.make_tensor(tdPtdP_slice.iterator, tdPtdP_dS_layout)
+        tdPcdP_dS_layout = cute.composition(
+            tdPcdP_slice.layout, cute.make_layout((tdPcdP_slice.shape[0], tilePlikeFP32))
+        )
+        tdPcdP_dS = cute.make_tensor(tdPcdP_slice.iterator, tdPcdP_dS_layout)
+        tmem_tiled_store = tcgen05.make_tmem_copy(tmem_store_atom, tdPtdP_dS)
+
+        thr_store = tmem_tiled_store.get_slice(thread_idx)
+        tTMEM_STOREtdS = thr_store.partition_D(tdPtdP_dS)
+        tTMEM_STOREcdP = thr_store.partition_S(tdPcdP_dS)
+        tTMEM_STORErdS_ = cute.make_tensor(
+            cute.recast_ptr(tTMEM_STORErdP.iterator, dtype=self.acc_dtype),
+            tTMEM_STOREcdP.shape,
+        )
+        cute.copy(tmem_tiled_store, tTMEM_STORErdS_, tTMEM_STOREtdS)
+        cute.arch.fence_view_async_tmem_store()
+        ds_handle.commit()
+        return mma_s_consumer, mma_dp_consumer, ds_mma_producer
+
+    @cute.jit
+    def dQ_epilogue(
+        self,
+        value_args: Tuple,
+        dq_args: Tuple,
+        epi_tile: cute.Tile,
+    ) -> Tuple[pipeline.PipelineConsumer, pipeline.PipelineProducer]:
+        seqlen_q, cuseqlen_q, total_q, batch_coord = value_args
+        (mma_dq_consumer, gdQ_staged, cdQ_staged, tdQtdQ_staged) = dq_args
+        dq_handle = mma_dq_consumer.wait_and_advance()
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, bidy, bidz = cute.arch.block_idx()
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+        cute.arch.fence_view_async_shared()
+
+        for iter in cutlass.range(self.iterations_dsk):
+            gdQ = gdQ_staged[None, None, iter]
+            cdQ = cdQ_staged[None, None, iter]
+            tdQtdQ = tdQtdQ_staged[(None, None), 0, 0, iter]
+            tdQtdQ_epi = cute.zipped_divide(tdQtdQ, epi_tile)
+            cdQ_epi = cute.zipped_divide(cdQ, epi_tile)
+            gdQ_epi = cute.zipped_divide(gdQ, epi_tile)
+            tidx, _, _ = cute.arch.thread_idx()
+            thread_idx = tidx % (self.threads_per_warp * len(self.epilogue_warp_ids))
+            tmem_copy_atom = cute.make_copy_atom(
+                tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32)), self.acc_dtype
+            )
+            tiled_tmem_load = tcgen05.make_tmem_copy(tmem_copy_atom, tdQtdQ_epi)
+            thr_tmem_load = tiled_tmem_load.get_slice(thread_idx)
+            tTMEM_LOADtdQ = thr_tmem_load.partition_S(tdQtdQ_epi)
+            tTMEM_LOADgdQ = thr_tmem_load.partition_D(gdQ_epi)
+            tTMEM_LOADcdQ = thr_tmem_load.partition_D(cdQ_epi)
+
+            for i in cutlass.range(cute.size(tTMEM_LOADtdQ, mode=[1]), unroll_full=True):
+                tTMEM_LOADtdQ_i = tTMEM_LOADtdQ[None, i, 0]
+                tTMEM_LOADgdQ_i = tTMEM_LOADgdQ[None, i, 0]
+                tTMEM_LOADcdQ_i = tTMEM_LOADcdQ[None, i, 0]
+                tTMrdQ = cute.make_rmem_tensor(tTMEM_LOADcdQ[None, 0, i].shape, self.acc_dtype)
+                cute.copy(tiled_tmem_load, tTMEM_LOADtdQ_i, tTMrdQ)
+                tSMrdQ = cute.make_rmem_tensor(tTMrdQ.shape, self.q_dtype)
+                dq_vec = tTMrdQ.load()
+                tSMrdQ.store(dq_vec.to(self.q_dtype))
+                if cute.elem_less(tTMEM_LOADcdQ_i[0][0], seqlen_q):
+                    cute.autovec_copy(tSMrdQ, tTMEM_LOADgdQ_i)
+        dq_handle.release()
+        return mma_dq_consumer

--- a/flashmask/flash_mask/flash_attn_v4/sm100_hd256_2cta_fmha_forward.py
+++ b/flashmask/flash_mask/flash_attn_v4/sm100_hd256_2cta_fmha_forward.py
@@ -1,0 +1,1730 @@
+# Copyright (c) 2025, Siyu Wang, Shengbin Di, Yuxi Chi, Linfeng Zheng, Haoyan Huang, Lanbo Li, Yun Zhong, Man Yuan, Minmin Sun, Yong Li, Wei Lin.
+
+import math
+from typing import Tuple, Optional
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.cute.nvgpu.tcgen05 as tcgen05
+import cutlass.utils as utils
+import cutlass.pipeline as pipeline
+import cutlass.utils.blackwell_helpers as sm100_utils
+from cutlass.cute.typing import Int32, Int64, Float32
+
+from cutlass.utils import ClcDynamicPersistentTileScheduler
+from flash_mask.flash_attn_v4.tile_scheduler import (
+    ClcState,
+    compute_sm100_fmha_grid as compute_grid,
+    compute_sm100_fmha_grid_clc as compute_grid_clc,
+    make_sm100_thread_cooperative_group as make_thread_cooperative_group,
+    Sm100FmhaStaticTileScheduler as FmhaStaticTileScheduler,
+    Sm100FmhaStaticTileSchedulerParams as FmhaStaticTileSchedulerParams,
+    Sm100FmhaClcDynamicTileScheduler as FmhaClcDynamicTileScheduler,
+    Sm100FmhaClcDynamicTileSchedulerParams as FmhaClcDynamicTileSchedulerParams,
+)
+from flash_mask.flash_attn_v4.mask import (
+    Sm100FusedMask as FusedMask,
+)
+from flash_mask.flash_attn_v4.tile_scheduler import SM100_TMEM_CAPACITY_COLUMNS
+
+
+class BlackwellFusedMultiHeadAttentionForward:
+    def __init__(
+        self,
+        head_dim: int,
+        head_dim_v: Optional[int] = None,
+        qhead_per_kvhead: int = 1,
+        is_causal: bool = False,
+        is_local: bool = False,
+        is_split_kv: bool = False,
+        pack_gqa: bool = False,
+        q_subtile_factor: int | None = None,
+        m_block_size: int = 128,
+        n_block_size: int = 128,
+        q_stage: int = 2,
+        is_persistent: bool = True,
+        score_mod=None,
+        mask_mod=None,
+        has_aux_tensors: bool = False,
+        paged_kv_non_tma: bool = False,
+        is_varlen_q: bool = False,
+        use_2cta_instrs: bool = False,
+        use_clc_scheduler: bool = False,
+    ):
+        head_dim_v = head_dim if head_dim_v is None else head_dim_v
+        assert head_dim == 256 and head_dim_v == 256, (
+            "SM100 dedicated kernel only supports (head_dim, head_dim_v) = (256, 256)"
+        )
+        assert score_mod is None, "SM100 forward with head_dim=256 does not support score_mod"
+        assert mask_mod is None, "SM100 forward with head_dim=256 does not support mask_mod"
+        assert not has_aux_tensors, "SM100 forward with head_dim=256 does not support aux tensors"
+        assert not paged_kv_non_tma, "SM100 forward with head_dim=256 does not support paged KV"
+        assert not pack_gqa, "SM100 forward with head_dim=256 does not support pack_gqa"
+        assert not is_split_kv, "SM100 forward with head_dim=256 does not support SplitKV"
+        assert q_subtile_factor is None, (
+            "SM100 forward with head_dim=256 does not support q_subtile_factor"
+        )
+        assert m_block_size == 128 and n_block_size == 128, (
+            "SM100 dedicated kernel only supports tile_m=128 and tile_n=128"
+        )
+        # q_stage / persistence / scheduler knobs are accepted for interface parity,
+        # but this dedicated kernel uses fixed internal settings.
+
+        qk_acc_dtype = cutlass.Float32
+        pv_acc_dtype = cutlass.Float32
+        mma_tiler = (128, 128, head_dim)
+        self.qk_acc_dtype = qk_acc_dtype
+        self.pv_acc_dtype = pv_acc_dtype
+        self.mma_tiler = mma_tiler
+        assert mma_tiler[0] == 128 and mma_tiler[1] == 128, "Only 128x128 tile impl is supported"
+        assert mma_tiler[2] == 256, "Only 256 is supported for 128x128 tile impl"
+        self.cta_tiler = (
+            mma_tiler[0],
+            mma_tiler[1],
+            mma_tiler[2],
+        )
+        self.qk_mma_tiler = (
+            2 * mma_tiler[0],
+            mma_tiler[1],
+            min(self.cta_tiler[2], 128),
+        )
+        self.pv_mma_tiler = self.qk_mma_tiler
+        self.pv_block_tiler = (
+            self.pv_mma_tiler[0] // 2,
+            self.pv_mma_tiler[1],
+            self.pv_mma_tiler[2],
+        )
+        self.iterations_qk = self.cta_tiler[2] // self.qk_mma_tiler[2]
+        self.iterations_pv = self.cta_tiler[2] // self.pv_mma_tiler[1]
+        self.cluster_shape_mn = (2, 1)
+        self.tmem_warp_shape_mn = (4, 1)
+        # Dedicated hd256 kernel uses fixed scheduling policy.
+        self.is_persistent = False
+        self.is_causal = is_causal
+        self.is_local = is_local
+        self.use_semantic_trip_range = is_causal or is_local
+        self.use_clc_scheduler = False
+
+        self.softmax_warp_ids = (0, 1, 2, 3)
+        self.correction_warp_ids = (4, 5, 6, 7)
+        self.mma_warp_id = 8
+        self.load_warp_id = 9
+        self.empty_warp_id = (10, 11)
+        self.sched_warp_id = self.empty_warp_id[0] if use_clc_scheduler else None
+        self.tmem_alloc_cols = SM100_TMEM_CAPACITY_COLUMNS
+
+        self.threads_per_warp = 32
+        self.threads_per_cta = self.threads_per_warp * len(
+            (
+                *self.softmax_warp_ids,  # this is to get a round num threads
+                *self.correction_warp_ids,
+                self.mma_warp_id,
+                self.load_warp_id,
+                *self.empty_warp_id,
+            )
+        )
+
+        self.tmem_alloc_barrier = pipeline.NamedBarrier(
+            barrier_id=1,
+            num_threads=self.threads_per_cta,
+        )
+
+        self.tmem_s_offset = 0
+        self.tmem_o_offset = 256
+        self.tmem_p_offset = self.tmem_s_offset
+
+        self.num_regs_softmax = 256
+        self.num_regs_correction = 160
+        self.num_regs_other = 32
+
+        self.buffer_align_bytes = 1024
+
+    def _setup_attributes(self):
+        self.q_stage = self.iterations_qk
+        self.kv_stage = 4
+        self.qk_acc_stage = 2
+        self.mma_corr_stage = 1
+        if cutlass.const_expr(self.use_clc_scheduler):
+            self.num_clc_stage = 1
+            self.num_clc_response_bytes = 16
+
+    @cute.jit
+    def __call__(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        mO: cute.Tensor,
+        mLSE: Optional[cute.Tensor],
+        softmax_scale: Float32,
+        mCuSeqlensQ: Optional[cute.Tensor] = None,
+        mCuSeqlensK: Optional[cute.Tensor] = None,
+        mSeqUsedQ: Optional[cute.Tensor] = None,
+        mSeqUsedK: Optional[cute.Tensor] = None,
+        mPageTable: Optional[cute.Tensor] = None,
+        window_size_left: Int32 | int | None = None,
+        window_size_right: Int32 | int | None = None,
+        learnable_sink: Optional[cute.Tensor] = None,
+        blocksparse_tensors: Optional[cute.Tensor] = None,
+        aux_tensors: Optional[list] = None,
+        stream: cuda.CUstream = None,
+    ):
+        # Keep parity with FlashAttentionForwardSm100.__call__ interface.
+        # (TODO@wangsiyu) Implement these features.
+        assert mSeqUsedQ is None and mSeqUsedK is None, (
+            "SM100 forward with head_dim=256 does not support seqused_q/seqused_k"
+        )
+        assert mPageTable is None, "SM100 forward with head_dim=256 does not support paged KV"
+        assert learnable_sink is None, (
+            "SM100 forward with head_dim=256 does not support learnable_sink"
+        )
+        assert blocksparse_tensors is None, (
+            "SM100 forward with head_dim=256 does not support block sparsity"
+        )
+        assert aux_tensors is None, "SM100 forward with head_dim=256 does not support aux_tensors"
+        assert not self.is_local, (
+            "SM100 forward with head_dim=256 does not support local attention yet"
+        )
+        assert window_size_left is None and window_size_right is None, (
+            "SM100 forward with head_dim=256 does not support runtime window_size overrides"
+        )
+
+        q_tensor, k_tensor, v_tensor, o_tensor = mQ, mK, mV, mO
+        lse_tensor = mLSE
+        cum_seqlen_q = mCuSeqlensQ
+        cum_seqlen_k = mCuSeqlensK
+
+        q_rank = len(mQ.shape)
+        k_rank = len(mK.shape)
+        if cutlass.const_expr(cum_seqlen_q is not None):
+            # Varlen path accepts either legacy 5D tensors or standard 3D tensors.
+            if cutlass.const_expr(q_rank == 5):
+                s_q = mQ.shape[1]
+                h_q = mQ.shape[2] * mQ.shape[3]
+                d = mQ.shape[4]
+            elif cutlass.const_expr(q_rank == 3):
+                s_q = mQ.shape[0]
+                h_q = mQ.shape[1]
+                d = mQ.shape[2]
+            else:
+                raise RuntimeError(f"hd256 forward varlen expects q rank 3 or 5, got rank {q_rank}")
+        else:
+            # Non-varlen path accepts either legacy 5D tensors or standard 4D tensors.
+            if cutlass.const_expr(q_rank == 5):
+                s_q = mQ.shape[1]
+                h_q = mQ.shape[2] * mQ.shape[3]
+                d = mQ.shape[4]
+            elif cutlass.const_expr(q_rank == 4):
+                s_q = mQ.shape[1]
+                h_q = mQ.shape[2]
+                d = mQ.shape[3]
+            else:
+                raise RuntimeError(
+                    f"hd256 forward non-varlen expects q rank 4 or 5, got rank {q_rank}"
+                )
+
+        if cutlass.const_expr(cum_seqlen_k is not None):
+            if cutlass.const_expr(k_rank == 5):
+                s_k = mK.shape[1]
+                h_k = mK.shape[2]
+            elif cutlass.const_expr(k_rank == 3):
+                s_k = mK.shape[0]
+                h_k = mK.shape[1]
+            else:
+                raise RuntimeError(f"hd256 forward varlen expects k rank 3 or 5, got rank {k_rank}")
+        else:
+            if cutlass.const_expr(k_rank == 5):
+                s_k = mK.shape[1]
+                h_k = mK.shape[2]
+            elif cutlass.const_expr(k_rank == 4):
+                s_k = mK.shape[1]
+                h_k = mK.shape[2]
+            else:
+                raise RuntimeError(
+                    f"hd256 forward non-varlen expects k rank 4 or 5, got rank {k_rank}"
+                )
+        if cutlass.const_expr(cum_seqlen_q is not None):
+            b = mCuSeqlensQ.shape[0] - 1
+        elif cutlass.const_expr(cum_seqlen_k is not None):
+            b = mCuSeqlensK.shape[0] - 1
+        else:
+            b = mQ.shape[0]
+
+        scale_softmax = softmax_scale
+        scale_softmax_log2 = softmax_scale * math.log2(math.exp(1.0))
+        scale_output = 1.0
+        s_lse = s_q
+        h_r = h_q // h_k
+        s_q64 = Int64(s_q)
+        s_k64 = Int64(s_k)
+        s_lse64 = Int64(s_lse)
+        d64 = cute.assume(Int64(d), divby=128)
+        h_r64 = Int64(h_r)
+        h_k64 = Int64(h_k)
+        b64 = Int64(b)
+        s_q_total = (
+            q_tensor.shape[1]
+            if cum_seqlen_q is not None and q_rank == 5
+            else (q_tensor.shape[0] if cum_seqlen_q is not None else s_q64)
+        )
+        s_k_total = (
+            k_tensor.shape[1]
+            if cum_seqlen_k is not None and k_rank == 5
+            else (k_tensor.shape[0] if cum_seqlen_k is not None else s_k64)
+        )
+        stride_b_qo = h_r64 * h_k64 * s_q64 * d64 if cum_seqlen_q is None else 0
+        stride_b_kv = h_k64 * s_k64 * d64 if cum_seqlen_k is None else 0
+        b_lse = b64 if cum_seqlen_q is None else 1
+        stride_b_lse = h_r64 * h_k64 * s_lse64 if cum_seqlen_q is None else 0
+
+        # (s, d, ((h_r, h_k), b))
+        q_layout = cute.make_layout(
+            (s_q_total, d, ((h_r, h_k), b)),
+            stride=(d64 * h_r64 * h_k64, 1, ((d64, d64 * h_r64), stride_b_qo)),
+        )
+        q = cute.make_tensor(q_tensor.iterator, q_layout)
+        # (s, d, ((h_r, h_k), b)), 0-stride for h_r to broadcast
+        k_layout = cute.make_layout(
+            (s_k_total, d, ((h_r, h_k), b)),
+            stride=(d64 * h_k64, 1, ((0, d64), stride_b_kv)),
+        )
+        k = cute.make_tensor(k_tensor.iterator, k_layout)
+        # (d, s, ((h_r, h_k), b)), 0-stride for h_r to broadcast
+        v_layout = cute.make_layout(
+            (d, s_k_total, ((h_r, h_k), b)),
+            stride=(1, d64 * h_k64, ((0, d64), stride_b_kv)),
+        )
+        v = cute.make_tensor(v_tensor.iterator, v_layout)
+        # (s, d, ((h_r, h_k), b))
+        o_layout = cute.make_layout(
+            (s_q_total, d, ((h_r, h_k), b)),
+            stride=(d64 * h_r64 * h_k64, 1, ((d64, d64 * h_r64), stride_b_qo)),
+        )
+        o = cute.make_tensor(o_tensor.iterator, o_layout)
+        if cutlass.const_expr(lse_tensor is not None):
+            # (s, ((h_r, h_k), b))
+            lse_layout = cute.make_layout(
+                (s_lse64, ((h_r, h_k), b_lse)),
+                stride=(1, ((s_lse64, h_r64 * s_lse64), stride_b_lse)),
+            )
+            lse = cute.make_tensor(lse_tensor.iterator, lse_layout)
+        else:
+            lse = None
+
+        # setup static attributes before smem/grid/tma computation
+        self.q_dtype = q.element_type
+        self.k_dtype = k.element_type
+        self.v_dtype = v.element_type
+        self.o_dtype = o.element_type
+        self.tilePlikeFP32 = self.qk_mma_tiler[1] // Float32.width * self.q_dtype.width
+
+        if cutlass.const_expr(self.use_clc_scheduler):
+            self.tile_sched_params, grid = compute_grid_clc(
+                (s_q, o.shape[1], o.shape[2]) if cum_seqlen_q is not None else o.shape,
+                self.cta_tiler,
+                (*self.cluster_shape_mn, 1),
+            )
+        else:
+            self.tile_sched_params, grid = compute_grid(
+                (s_q, o.shape[1], o.shape[2]) if cum_seqlen_q is not None else o.shape,
+                self.cta_tiler,
+                self.is_persistent,
+            )
+
+        self.q_major_mode = utils.LayoutEnum.from_tensor(q).mma_major_mode()
+        self.k_major_mode = utils.LayoutEnum.from_tensor(k).mma_major_mode()
+        self.v_major_mode = utils.LayoutEnum.from_tensor(v).mma_major_mode()
+        self.o_layout = utils.LayoutEnum.from_tensor(o)
+
+        if cutlass.const_expr(self.q_major_mode != tcgen05.OperandMajorMode.K):
+            raise RuntimeError("The layout of q is not supported")
+        if cutlass.const_expr(self.k_major_mode != tcgen05.OperandMajorMode.K):
+            raise RuntimeError("The layout of k is not supported")
+        if cutlass.const_expr(self.v_major_mode != tcgen05.OperandMajorMode.MN):
+            raise RuntimeError("The layout of v is not supported")
+
+        # check type consistency
+        if cutlass.const_expr(self.q_dtype != self.k_dtype):
+            raise TypeError(f"Type mismatch: {self.q_dtype} != {self.k_dtype}")
+        if cutlass.const_expr(self.q_dtype != self.v_dtype):
+            raise TypeError(f"Type mismatch: {self.q_dtype} != {self.v_dtype}")
+        self._setup_attributes()
+
+        cta_group = tcgen05.CtaGroup.TWO
+        # the intermediate tensor p is from tmem & k-major
+        p_source = tcgen05.OperandSource.TMEM
+        p_major_mode = tcgen05.OperandMajorMode.K
+        qk_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            self.q_dtype,
+            self.q_major_mode,
+            self.k_major_mode,
+            self.qk_acc_dtype,
+            cta_group,
+            self.qk_mma_tiler[:2],
+        )
+        pv_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            self.v_dtype,
+            p_major_mode,
+            self.v_major_mode,
+            self.pv_acc_dtype,
+            cta_group,
+            self.pv_mma_tiler[:2],
+            p_source,
+        )
+
+        self.cluster_shape_mnk = (*self.cluster_shape_mn, 1)
+        self.cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout(self.cluster_shape_mnk),
+            (qk_tiled_mma.thr_id.shape,),
+        )
+
+        self.epi_tile = self.pv_block_tiler[:2]
+
+        q_smem_layout_staged = sm100_utils.make_smem_layout_a(
+            qk_tiled_mma,
+            self.qk_mma_tiler,
+            self.q_dtype,
+            self.q_stage,
+        )
+        k_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            qk_tiled_mma,
+            self.qk_mma_tiler,
+            self.k_dtype,
+            self.kv_stage,
+        )
+        p_tmem_layout_staged = sm100_utils.make_smem_layout_a(
+            pv_tiled_mma,
+            self.pv_mma_tiler,
+            self.q_dtype,
+            self.qk_acc_stage,
+        )
+        p_tmem_layout = cute.select(p_tmem_layout_staged, mode=[0, 1, 2])
+        v_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            pv_tiled_mma,
+            self.pv_mma_tiler,
+            self.v_dtype,
+            self.kv_stage,
+        )
+        # TMA load for Q
+        tma_load_op = cute.nvgpu.cpasync.CopyBulkTensorTileG2SOp(cta_group)
+
+        q_smem_layout = cute.select(q_smem_layout_staged, mode=[0, 1, 2])
+        tma_atom_q, tma_tensor_q = cute.nvgpu.make_tiled_tma_atom_A(
+            tma_load_op,
+            q,
+            q_smem_layout,
+            self.qk_mma_tiler,
+            qk_tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        # TMA load for K
+        k_smem_layout = cute.select(k_smem_layout_staged, mode=[0, 1, 2])
+        tma_atom_k, tma_tensor_k = cute.nvgpu.make_tiled_tma_atom_B(
+            tma_load_op,
+            k,
+            k_smem_layout,
+            self.qk_mma_tiler,
+            qk_tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+        # TMA load for V
+        v_smem_layout = cute.select(v_smem_layout_staged, mode=[0, 1, 2])
+        tma_atom_v, tma_tensor_v = cute.nvgpu.make_tiled_tma_atom_B(
+            tma_load_op,
+            v,
+            v_smem_layout,
+            self.pv_mma_tiler,
+            pv_tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        q_copy_size = cute.size_in_bytes(self.q_dtype, q_smem_layout)
+        k_copy_size = cute.size_in_bytes(self.k_dtype, k_smem_layout)
+        self.tma_copy_q_bytes = q_copy_size * cute.size(qk_tiled_mma.thr_id.shape)
+        self.tma_copy_kv_bytes = k_copy_size * cute.size(qk_tiled_mma.thr_id.shape)
+
+        @cute.struct
+        class SharedStorage:
+            # TMA G2S load barriers: LOAD warp (producer) -> MMA warp (consumer)
+            load_q_mbar_ptr: cute.struct.MemRange[
+                Int64, self.q_stage * 2
+            ]  # load_q_{producer,consumer}
+            load_kv_mbar_ptr: cute.struct.MemRange[
+                Int64, self.kv_stage * 2
+            ]  # load_kv_{producer,consumer}
+            mma_s_mbar_ptr: cute.struct.MemRange[Int64, self.qk_acc_stage * 2]
+            p_mma_mbar_ptr: cute.struct.MemRange[Int64, self.qk_acc_stage * 2]
+            # Softmax -> Correction signaling barriers (row_max/row_sum vec ready)
+            s_corr_mbar_ptr: cute.struct.MemRange[
+                Int64, self.qk_acc_stage * 2
+            ]  # s_corr_{producer,consumer}
+            sum_mbar_ptr: cute.struct.MemRange[Int64, 2]
+            # MMA -> Correction ownership barriers for O_partial tokens (online rescale/finalize)
+            mma_corr_mbar_ptr: cute.struct.MemRange[
+                Int64, self.mma_corr_stage * 2
+            ]  # mma_corr_{producer,consumer}
+            # A CTA-wide "TMEM lifetime" barrier used to safely deallocate TMEM after all users finish.
+            tmem_dealloc_mbar_ptr: Int64
+            # Tmem holding buffer
+            tmem_holding_buf: Int32
+            # CLC pipeline barriers and response buffer
+            clc_mbar_ptr: cute.struct.MemRange[Int64, 2]
+            clc_response: cute.struct.MemRange[Int32, 4]
+
+        self.shared_storage = SharedStorage
+
+        grid = cute.round_up(grid, self.cluster_shape_mnk)
+        # Launch the kernel synchronously
+        self.kernel(
+            qk_tiled_mma,
+            pv_tiled_mma,
+            tma_atom_q,
+            tma_tensor_q,
+            tma_atom_k,
+            tma_tensor_k,
+            tma_atom_v,
+            tma_tensor_v,
+            o,
+            cum_seqlen_q,
+            cum_seqlen_k,
+            lse,
+            scale_softmax_log2,
+            scale_softmax,
+            scale_output,
+            window_size_left,
+            window_size_right,
+            self.cluster_layout_vmnk,
+            q_smem_layout_staged,
+            k_smem_layout_staged,
+            p_tmem_layout,
+            v_smem_layout_staged,
+            self.tile_sched_params,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=self.cluster_shape_mnk,
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+
+    #  GPU device kernel
+    @cute.kernel
+    def kernel(
+        self,
+        qk_tiled_mma: cute.TiledMma,
+        pv_tiled_mma: cute.TiledMma,
+        tma_atom_q: cute.CopyAtom,
+        mQ_qdl: cute.Tensor,
+        tma_atom_k: cute.CopyAtom,
+        mK_kdl: cute.Tensor,
+        tma_atom_v: cute.CopyAtom,
+        mV_dkl: cute.Tensor,
+        mO_qdl: cute.Tensor,
+        cum_seqlen_q: Optional[cute.Tensor],
+        cum_seqlen_k: Optional[cute.Tensor],
+        mLSE: Optional[cute.Tensor],
+        scale_softmax_log2: Float32,
+        scale_softmax: Float32,
+        scale_output: Float32,
+        window_size_left: Optional[Int32],
+        window_size_right: Optional[Int32],
+        cluster_layout_vmnk: cute.Layout,
+        q_smem_layout_staged: cute.ComposedLayout,
+        k_smem_layout_staged: cute.ComposedLayout,
+        p_tmem_layout_staged: cute.ComposedLayout,
+        v_smem_layout_staged: cute.ComposedLayout,
+        tile_sched_params: FmhaStaticTileSchedulerParams | FmhaClcDynamicTileSchedulerParams,
+    ):
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+
+        #
+        # Prefetch tma desc
+        #
+        if warp_idx == self.load_warp_id:
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_q)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_k)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_v)
+
+        bidx, _, _ = cute.arch.block_idx()
+        mma_tile_coord_v = bidx % cute.size(qk_tiled_mma.thr_id.shape)
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+        block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(cta_rank_in_cluster)
+
+        # Alloc
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+
+        load_q_producer, load_q_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=self.q_stage,
+            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            tx_count=self.tma_copy_q_bytes,
+            barrier_storage=storage.load_q_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+        load_kv_producer, load_kv_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=self.kv_stage,
+            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            tx_count=self.tma_copy_kv_bytes,
+            barrier_storage=storage.load_kv_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+        mma_s_producer, mma_s_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=self.qk_acc_stage,
+            producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            consumer_group=make_thread_cooperative_group(
+                len(self.softmax_warp_ids) * self.threads_per_warp * self.cluster_shape_mnk[0],
+            ),
+            barrier_storage=storage.mma_s_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+        p_mma_producer, p_mma_consumer = pipeline.PipelineAsyncUmma.create(
+            num_stages=self.qk_acc_stage,
+            producer_group=make_thread_cooperative_group(
+                len(self.softmax_warp_ids) * self.threads_per_warp * self.cluster_shape_mnk[0],
+            ),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            barrier_storage=storage.p_mma_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+        s_corr_producer, s_corr_consumer = pipeline.PipelineAsync.create(
+            num_stages=self.qk_acc_stage,
+            producer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.softmax_warp_ids)
+            ),
+            consumer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.correction_warp_ids)
+            ),
+            barrier_storage=storage.s_corr_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        sum_producer, sum_consumer = pipeline.PipelineAsync.create(
+            num_stages=1,
+            producer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.softmax_warp_ids)
+            ),
+            consumer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.correction_warp_ids)
+            ),
+            barrier_storage=storage.sum_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        mma_corr_producer, mma_corr_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=self.mma_corr_stage,
+            producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            consumer_group=make_thread_cooperative_group(
+                len(self.correction_warp_ids) * self.threads_per_warp * self.cluster_shape_mnk[0],
+            ),
+            barrier_storage=storage.mma_corr_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+        # Tensor memory dealloc barrier init
+        tmem = utils.TmemAllocator(
+            storage.tmem_holding_buf,
+            barrier_for_retrieve=self.tmem_alloc_barrier,
+            allocator_warp_id=self.correction_warp_ids[0],
+            is_two_cta=True,
+            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar_ptr,
+        )
+        tmem.allocate(self.tmem_alloc_cols)
+        tmem.wait_for_alloc()
+        tmem_ptr = tmem.retrieve_ptr(self.qk_acc_dtype)
+        # Initialize CLC state if using dynamic scheduler
+        if cutlass.const_expr(self.use_clc_scheduler):
+            clc_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+            cluster_size = cute.size(self.cluster_shape_mnk)
+            num_clc_consumer_threads = self.threads_per_warp * (
+                1  # sched_warp (CTA 0 only)
+                + cluster_size
+                * (
+                    len(self.softmax_warp_ids)
+                    + len(self.correction_warp_ids)
+                    + 1  # mma_warp
+                    + 1  # load_warp
+                )
+            )
+            clc_pipeline_consumer_group = pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, num_clc_consumer_threads
+            )
+            clc_response_ptr = storage.clc_response.data_ptr()
+            clc = ClcState.create(
+                hw_scheduler=ClcDynamicPersistentTileScheduler.create(
+                    self.tile_sched_params.clc_hw_params(),
+                    cute.arch.block_idx(),
+                    cute.arch.grid_dim(),
+                    clc_response_ptr,
+                ),
+                pipeline=pipeline.PipelineClcFetchAsync.create(
+                    barrier_storage=storage.clc_mbar_ptr.data_ptr(),
+                    num_stages=self.num_clc_stage,
+                    producer_group=clc_pipeline_producer_group,
+                    consumer_group=clc_pipeline_consumer_group,
+                    tx_count=self.num_clc_response_bytes,
+                    cta_layout_vmnk=cluster_layout_vmnk,
+                    defer_sync=True,
+                ),
+                consumer_state=pipeline.make_pipeline_state(
+                    pipeline.PipelineUserType.Consumer, self.num_clc_stage
+                ),
+                producer_state=pipeline.make_pipeline_state(
+                    pipeline.PipelineUserType.Producer, self.num_clc_stage
+                ),
+            )
+        else:
+            clc = None
+            clc_response_ptr = None
+
+        # Cluster arrive after barrier init
+        pipeline.pipeline_init_arrive(cluster_shape_mn=cluster_layout_vmnk, is_relaxed=True)
+
+        sQ = smem.allocate_tensor(
+            element_type=self.q_dtype,
+            layout=q_smem_layout_staged.outer,
+            swizzle=q_smem_layout_staged.inner,
+            byte_alignment=128,
+        )
+        sK = smem.allocate_tensor(
+            element_type=self.k_dtype,
+            layout=k_smem_layout_staged.outer,
+            swizzle=k_smem_layout_staged.inner,
+            byte_alignment=128,
+        )
+        # K and V now use separate memory since we removed the transform stage
+        sV = smem.allocate_tensor(
+            element_type=self.v_dtype,
+            layout=v_smem_layout_staged.outer,
+            swizzle=v_smem_layout_staged.inner,
+            byte_alignment=128,
+        )
+
+        sSum = smem.allocate_tensor(
+            element_type=self.qk_acc_dtype,
+            layout=cute.make_layout(len(self.softmax_warp_ids) * self.threads_per_warp),
+            byte_alignment=128,
+        )
+        qk_thr_mma = qk_tiled_mma.get_slice(mma_tile_coord_v)  # default 1sm
+        pv_thr_mma = pv_tiled_mma.get_slice(mma_tile_coord_v)  # default 1sm
+        tSrQ = qk_thr_mma.make_fragment_A(sQ)
+        tSrK = qk_thr_mma.make_fragment_B(sK)
+        tOrV = pv_thr_mma.make_fragment_B(sV)
+        qk_acc_shape = qk_thr_mma.partition_shape_C((self.qk_mma_tiler[0], self.qk_mma_tiler[1]))
+        tStS = qk_thr_mma.make_fragment_C(cute.append(qk_acc_shape, self.qk_acc_stage))
+        pv_acc_shape = pv_thr_mma.partition_shape_C((self.pv_mma_tiler[0], self.pv_mma_tiler[1]))
+        tOtO = pv_thr_mma.make_fragment_C(pv_acc_shape)
+        tOtO_layout = cute.append(
+            tOtO.layout,
+            cute.make_layout(
+                self.iterations_pv,
+                stride=self.pv_mma_tiler[1] // self.tmem_warp_shape_mn[1],
+            ),
+        )
+        tStS = cute.make_tensor(tStS.iterator + self.tmem_s_offset, tStS.layout)
+        tOtO_staged = cute.make_tensor(tOtO.iterator + self.tmem_o_offset, tOtO_layout)
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  EMPTY
+        # ///////////////////////////////////////////////////////////////////////////////
+        for _i in cutlass.range_constexpr(len(self.empty_warp_id)):
+            if warp_idx == self.empty_warp_id[_i]:
+                cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
+
+        if cutlass.const_expr(self.use_clc_scheduler):
+            tile_sched = FmhaClcDynamicTileScheduler.create(
+                tile_sched_params,
+                cute.arch.block_idx(),
+                cute.arch.grid_dim(),
+                clc_response_ptr,
+                clc,
+            )
+        else:
+            blk_idx = cute.arch.block_idx()
+            tile_sched = FmhaStaticTileScheduler(
+                tile_sched_params, blk_idx[0], blk_idx, cute.arch.grid_dim()
+            )
+        work_tile = tile_sched.initial_work_tile_info()
+
+        # Cluster wait
+        pipeline.pipeline_init_wait(cluster_shape_mn=cluster_layout_vmnk)
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  LOAD
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx == self.load_warp_id:
+            cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
+            while work_tile.is_valid_tile:
+                curr_block_coord = work_tile.tile_idx  # (q_tile_idx, 0, (head_idx, batch_idx))
+                mma_block_coord = (
+                    curr_block_coord[0] // cute.size(qk_tiled_mma.thr_id.shape),
+                    curr_block_coord[1],
+                    curr_block_coord[2],
+                )
+                continue_cond = False
+                batch_coord = curr_block_coord[2][1]
+                seqlen_q = mQ_qdl.shape[0]
+                seqlen_k = mK_kdl.shape[0]
+                cuseqlen_q = Int32(0)
+                cuseqlen_k = Int32(0)
+                block_offset = (
+                    Int32(0),
+                    Int32(0),
+                    Int32(0),
+                    ((Int32(0), Int32(0)), Int32(0)),
+                )
+                if cutlass.const_expr(cum_seqlen_q is not None):
+                    cuseqlen_q = cum_seqlen_q[batch_coord]
+                    seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
+                    if cutlass.const_expr(cum_seqlen_k is not None):
+                        cuseqlen_k = cum_seqlen_k[batch_coord]
+                        seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
+                    block_offset = (
+                        cuseqlen_q,
+                        cuseqlen_k,
+                        Int32(0),
+                        ((Int32(0), Int32(0)), Int32(0)),
+                    )
+                    continue_cond = not FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
+                        self.qk_mma_tiler[0],
+                        mma_block_coord[0],
+                        seqlen_q,
+                    )
+                if not continue_cond:
+                    mQ_qdl_ = cute.domain_offset(cute.select(block_offset, mode=[0, 2, 3]), mQ_qdl)
+                    mK_kdl_ = cute.domain_offset(cute.select(block_offset, mode=[1, 2, 3]), mK_kdl)
+                    mV_dkl_ = cute.domain_offset(cute.select(block_offset, mode=[2, 1, 3]), mV_dkl)
+                    # Local tile partition global tensors
+                    q_cta_layout = cute.make_layout(
+                        cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape
+                    )
+                    # (bM, bK, loopM, loopK, loopL)
+                    gQ_qdl = cute.flat_divide(mQ_qdl_, cute.select(self.qk_mma_tiler, mode=[0, 2]))
+                    tSgQ_qdl = qk_thr_mma.partition_A(gQ_qdl)
+                    tQsQ, tQgQ_qdl = cute.nvgpu.cpasync.tma_partition(
+                        tma_atom_q,
+                        block_in_cluster_coord_vmnk[2],
+                        q_cta_layout,
+                        cute.group_modes(sQ, 0, 3),
+                        cute.group_modes(tSgQ_qdl, 0, 3),
+                    )
+                    kv_cta_layout = cute.make_layout(
+                        cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape
+                    )
+                    gK_kdl = cute.flat_divide(mK_kdl_, cute.select(self.qk_mma_tiler, mode=[1, 2]))
+                    tSgK_kdl = qk_thr_mma.partition_B(gK_kdl)
+                    tKsK, tKgK_kdl = cute.nvgpu.cpasync.tma_partition(
+                        tma_atom_k,
+                        block_in_cluster_coord_vmnk[1],
+                        kv_cta_layout,
+                        cute.group_modes(sK, 0, 3),
+                        cute.group_modes(tSgK_kdl, 0, 3),
+                    )
+
+                    gV_dkl = cute.flat_divide(mV_dkl_, cute.select(self.pv_mma_tiler, mode=[1, 2]))
+                    tSgV_dkl = pv_thr_mma.partition_B(gV_dkl)
+                    tVsV, tVgV_dkl = cute.nvgpu.cpasync.tma_partition(
+                        tma_atom_v,
+                        block_in_cluster_coord_vmnk[1],
+                        kv_cta_layout,
+                        cute.group_modes(sV, 0, 3),
+                        cute.group_modes(tSgV_dkl, 0, 3),
+                    )
+                    # ((atom_v, rest_v), RestK)
+                    tQgQ = tQgQ_qdl[None, mma_block_coord[0], None, mma_block_coord[2]]
+                    # ((atom_v, rest_v), RestN, RestK)
+                    tKgK = tKgK_kdl[None, None, None, mma_block_coord[2]]
+                    # ((atom_v, rest_v), RestN, RestK)
+                    tVgV = tVgV_dkl[None, None, None, mma_block_coord[2]]
+
+                    seqlen_kv_loop_start, seqlen_kv_loop_steps = (
+                        FusedMask.get_trip_start_count_via_block_info(
+                            mma_block_coord,
+                            self.qk_mma_tiler,
+                            seqlen_q,
+                            seqlen_k,
+                            self.is_causal,
+                            self.is_local,
+                            window_size_left,
+                            window_size_right,
+                        )
+                    )
+                    seqlen_kv_loop_end = seqlen_kv_loop_start + seqlen_kv_loop_steps
+                    # Q
+                    for iter in cutlass.range(self.iterations_qk, unroll=1):
+                        q_handle = load_q_producer.acquire_and_advance()
+                        cute.copy(
+                            tma_atom_q,
+                            tQgQ[None, iter],
+                            tQsQ[None, q_handle.index],
+                            tma_bar_ptr=q_handle.barrier,
+                        )
+
+                    # K0
+                    kv_coord = seqlen_kv_loop_start
+                    for iter in cutlass.range(self.iterations_qk, unroll=1):
+                        k_handle = load_kv_producer.acquire_and_advance()
+                        cute.copy(
+                            tma_atom_k,
+                            tKgK[None, kv_coord, iter],
+                            tKsK[None, k_handle.index],
+                            tma_bar_ptr=k_handle.barrier,
+                        )
+                    kv_coord += 1
+
+                    for i in cutlass.range(1, seqlen_kv_loop_steps, 1, unroll=1):
+                        # Ki
+                        for iter in cutlass.range(self.iterations_qk, unroll=1):
+                            k_handle = load_kv_producer.acquire_and_advance()
+                            cute.copy(
+                                tma_atom_k,
+                                tKgK[None, kv_coord, iter],
+                                tKsK[None, k_handle.index],
+                                tma_bar_ptr=k_handle.barrier,
+                            )
+                        # Vi-1
+                        for iter in cutlass.range(self.iterations_pv, unroll=1):
+                            v_handle = load_kv_producer.acquire_and_advance()
+                            cute.copy(
+                                tma_atom_v,
+                                tVgV[None, iter, kv_coord - 1],
+                                tVsV[None, v_handle.index],
+                                tma_bar_ptr=v_handle.barrier,
+                            )
+                        kv_coord += 1
+                    # Vend
+                    for iter in cutlass.range(self.iterations_pv, unroll=1):
+                        v_handle = load_kv_producer.acquire_and_advance()
+                        cute.copy(
+                            tma_atom_v,
+                            tVgV[None, iter, seqlen_kv_loop_end - 1],
+                            tVsV[None, v_handle.index],
+                            tma_bar_ptr=v_handle.barrier,
+                        )
+
+                work_tile = tile_sched.advance_to_next_work()
+                # End of persistent scheduler loop
+            load_kv_producer.tail()
+            load_q_producer.tail()
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  MMA
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx == self.mma_warp_id:
+            cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
+
+            while work_tile.is_valid_tile:
+                curr_block_coord = work_tile.tile_idx
+                mma_block_coord = (
+                    curr_block_coord[0] // cute.size(qk_tiled_mma.thr_id.shape),
+                    curr_block_coord[1],
+                    curr_block_coord[2],
+                )
+                continue_cond = False
+                seqlen_q = mQ_qdl.shape[0]
+                seqlen_k = mK_kdl.shape[0]
+                batch_coord = curr_block_coord[2][1]
+                if cutlass.const_expr(cum_seqlen_q is not None):
+                    cuseqlen_q = cum_seqlen_q[batch_coord]
+                    seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
+                    continue_cond = not FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
+                        self.qk_mma_tiler[0],
+                        mma_block_coord[0],
+                        seqlen_q,
+                    )
+
+                if not continue_cond:
+                    if cutlass.const_expr(cum_seqlen_k is not None):
+                        cuseqlen_k = cum_seqlen_k[batch_coord]
+                        seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
+
+                    seqlen_kv_loop_start, seqlen_kv_loop_steps = (
+                        FusedMask.get_trip_start_count_via_block_info(
+                            mma_block_coord,
+                            self.qk_mma_tiler,
+                            seqlen_q,
+                            seqlen_k,
+                            self.is_causal,
+                            self.is_local,
+                            window_size_left,
+                            window_size_right,
+                        )
+                    )
+                    seqlen_kv_loop_end = seqlen_kv_loop_start + seqlen_kv_loop_steps
+
+                    cta_rank_in_cluster = cute.arch.make_warp_uniform(
+                        cute.arch.block_idx_in_cluster()
+                    )
+                    is_leader_cta = cta_rank_in_cluster % 2 == 0
+                    load_q_releaser = load_q_consumer.clone()
+                    pv_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+                    if seqlen_kv_loop_steps > 1:
+                        # QK0
+                        if is_leader_cta:
+                            s_handle = mma_s_producer.acquire_and_advance()
+                            tStS_slice = tStS[None, None, None, s_handle.index]
+                            qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+                            for iter in cutlass.range(self.iterations_qk, unroll=1):
+                                load_q_consumer.wait_and_advance()
+                                tSrQ_slice = tSrQ[None, None, None, iter]
+                                k_handle = load_kv_consumer.wait_and_advance()
+                                tSrK_trans_slice = tSrK[None, None, None, k_handle.index]
+                                num_kphases = cute.size(tSrQ_slice, mode=[2])
+                                for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+                                    kphase_coord = (None, None, kphase_idx)
+                                    cute.gemm(
+                                        qk_tiled_mma,
+                                        tStS_slice,
+                                        tSrQ_slice[kphase_coord],
+                                        tSrK_trans_slice[kphase_coord],
+                                        tStS_slice,
+                                    )
+                                    qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                                k_handle.release()
+                            s_handle.commit()
+                        for i in cutlass.range(1, seqlen_kv_loop_steps - 1, 1, unroll=1):
+                            # QKi
+                            if is_leader_cta:
+                                s_handle = mma_s_producer.acquire_and_advance()
+                                tStS_slice = tStS[None, None, None, s_handle.index]
+                                qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+                                for iter in cutlass.range(self.iterations_qk, unroll=1):
+                                    tSrQ_slice = tSrQ[None, None, None, iter]
+                                    k_handle = load_kv_consumer.wait_and_advance()
+                                    tSrK_trans_slice = tSrK[None, None, None, k_handle.index]
+                                    num_kphases = cute.size(tSrQ_slice, mode=[2])
+                                    for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+                                        kphase_coord = (None, None, kphase_idx)
+                                        cute.gemm(
+                                            qk_tiled_mma,
+                                            tStS_slice,
+                                            tSrQ_slice[kphase_coord],
+                                            tSrK_trans_slice[kphase_coord],
+                                            tStS_slice,
+                                        )
+                                        qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                                    k_handle.release()
+                                s_handle.commit()
+
+                                # PVi-1
+                                p_handle = p_mma_consumer.wait_and_advance()
+                                o_handle = mma_corr_producer.acquire_and_advance()
+                                pv_whether_acc = pv_tiled_mma.get(tcgen05.Field.ACCUMULATE)
+                                for iter in cutlass.range(self.iterations_pv, unroll=1):
+                                    v_handle = load_kv_consumer.wait_and_advance()
+                                    pv_tiled_mma.set(tcgen05.Field.ACCUMULATE, pv_whether_acc)
+                                    tOtO_slice = tOtO_staged[None, None, None, iter]
+                                    tStS_slice = tStS[None, None, None, p_handle.index]
+                                    tP = cute.make_tensor(
+                                        tStS_slice.iterator, p_tmem_layout_staged.outer
+                                    )
+                                    tOrP = pv_thr_mma.make_fragment_A(tP)
+                                    tOrP_slice = cute.make_tensor(
+                                        cute.recast_ptr(tStS_slice.iterator, dtype=self.q_dtype),
+                                        tOrP.layout,
+                                    )
+                                    tOrV_slice = tOrV[None, None, None, v_handle.index]
+                                    num_kphases = cute.size(tOrV_slice, mode=[2])
+                                    for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+                                        kphase_coord = (None, None, kphase_idx)
+                                        cute.gemm(
+                                            pv_tiled_mma,
+                                            tOtO_slice,
+                                            tOrP_slice[kphase_coord],
+                                            tOrV_slice[kphase_coord],
+                                            tOtO_slice,
+                                        )
+                                        pv_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                                    v_handle.release()
+                                o_handle.commit()
+                                p_handle.release()
+                        if is_leader_cta:
+                            # QKend
+                            s_handle = mma_s_producer.acquire_and_advance()
+                            tStS_slice = tStS[None, None, None, s_handle.index]
+                            qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+                            for iter in cutlass.range(self.iterations_qk, unroll=1):
+                                tSrQ_slice = tSrQ[None, None, None, iter]
+                                k_handle = load_kv_consumer.wait_and_advance()
+                                tSrK_trans_slice = tSrK[None, None, None, k_handle.index]
+                                num_kphases = cute.size(tSrQ_slice, mode=[2])
+                                for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+                                    kphase_coord = (None, None, kphase_idx)
+                                    cute.gemm(
+                                        qk_tiled_mma,
+                                        tStS_slice,
+                                        tSrQ_slice[kphase_coord],
+                                        tSrK_trans_slice[kphase_coord],
+                                        tStS_slice,
+                                    )
+                                    qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                                k_handle.release()
+                                load_q_releaser.release()
+                                load_q_releaser.advance()
+                            s_handle.commit()
+
+                            # PVend-1
+                            p_handle = p_mma_consumer.wait_and_advance()
+                            o_handle = mma_corr_producer.acquire_and_advance()
+                            pv_whether_acc = pv_tiled_mma.get(tcgen05.Field.ACCUMULATE)
+                            for iter in cutlass.range(self.iterations_pv, unroll=1):
+                                v_handle = load_kv_consumer.wait_and_advance()
+                                pv_tiled_mma.set(tcgen05.Field.ACCUMULATE, pv_whether_acc)
+                                tOtO_slice = tOtO_staged[None, None, None, iter]
+                                tStS_slice = tStS[None, None, None, p_handle.index]
+                                tP = cute.make_tensor(
+                                    tStS_slice.iterator, p_tmem_layout_staged.outer
+                                )
+                                tOrP = pv_thr_mma.make_fragment_A(tP)
+                                tOrP_slice = cute.make_tensor(
+                                    cute.recast_ptr(tStS_slice.iterator, dtype=self.q_dtype),
+                                    tOrP.layout,
+                                )
+                                tOrV_slice = tOrV[None, None, None, v_handle.index]
+                                num_kphases = cute.size(tOrV_slice, mode=[2])
+                                for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+                                    kphase_coord = (None, None, kphase_idx)
+                                    cute.gemm(
+                                        pv_tiled_mma,
+                                        tOtO_slice,
+                                        tOrP_slice[kphase_coord],
+                                        tOrV_slice[kphase_coord],
+                                        tOtO_slice,
+                                    )
+                                    pv_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                                v_handle.release()
+                            o_handle.commit()
+                            p_handle.release()
+                    else:
+                        if is_leader_cta:
+                            # QK0
+                            s_handle = mma_s_producer.acquire_and_advance()
+                            tStS_slice = tStS[None, None, None, s_handle.index]
+                            qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+                            for iter in cutlass.range(self.iterations_qk, unroll=1):
+                                load_q_consumer.wait_and_advance()
+                                tSrQ_slice = tSrQ[None, None, None, iter]
+                                k_handle = load_kv_consumer.wait_and_advance()
+                                tSrK_trans_slice = tSrK[None, None, None, k_handle.index]
+                                num_kphases = cute.size(tSrQ_slice, mode=[2])
+                                for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+                                    kphase_coord = (None, None, kphase_idx)
+                                    cute.gemm(
+                                        qk_tiled_mma,
+                                        tStS_slice,
+                                        tSrQ_slice[kphase_coord],
+                                        tSrK_trans_slice[kphase_coord],
+                                        tStS_slice,
+                                    )
+                                    qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                                k_handle.release()
+                                load_q_releaser.release()
+                                load_q_releaser.advance()
+                            s_handle.commit()
+
+                    if is_leader_cta:
+                        # PVend
+                        p_handle = p_mma_consumer.wait_and_advance()
+                        o_handle = mma_corr_producer.acquire_and_advance()
+                        pv_whether_acc = pv_tiled_mma.get(tcgen05.Field.ACCUMULATE)
+                        for iter in cutlass.range(self.iterations_pv, unroll=1):
+                            v_handle = load_kv_consumer.wait_and_advance()
+                            pv_tiled_mma.set(tcgen05.Field.ACCUMULATE, pv_whether_acc)
+                            tOtO_slice = tOtO_staged[None, None, None, iter]
+                            tStS_slice = tStS[None, None, None, p_handle.index]
+                            tP = cute.make_tensor(tStS_slice.iterator, p_tmem_layout_staged.outer)
+                            tOrP = pv_thr_mma.make_fragment_A(tP)
+                            tOrP_slice = cute.make_tensor(
+                                cute.recast_ptr(tStS_slice.iterator, dtype=self.q_dtype),
+                                tOrP.layout,
+                            )
+                            tOrV_slice = tOrV[None, None, None, v_handle.index]
+                            num_kphases = cute.size(tOrV_slice, mode=[2])
+                            for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+                                kphase_coord = (None, None, kphase_idx)
+                                cute.gemm(
+                                    pv_tiled_mma,
+                                    tOtO_slice,
+                                    tOrP_slice[kphase_coord],
+                                    tOrV_slice[kphase_coord],
+                                    tOtO_slice,
+                                )
+                                pv_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                            v_handle.release()
+                        o_handle.commit()
+                        p_handle.release()
+                work_tile = tile_sched.advance_to_next_work()
+            # End of persistent scheduler loop
+            mma_s_producer.tail()
+            mma_corr_producer.tail()
+
+        if warp_idx < self.correction_warp_ids[0] and warp_idx >= self.softmax_warp_ids[0]:
+            # increase register after decreasing
+            cute.arch.warpgroup_reg_alloc(self.num_regs_softmax)
+
+            while work_tile.is_valid_tile:
+                curr_block_coord = work_tile.tile_idx
+                mma_block_coord = (
+                    curr_block_coord[0] // cute.size(qk_tiled_mma.thr_id.shape),
+                    curr_block_coord[1],
+                    curr_block_coord[2],
+                )
+                batch_coord = curr_block_coord[2][1]
+                continue_cond = False
+                seqlen_q = mQ_qdl.shape[0]
+                seqlen_k = mK_kdl.shape[0]
+                cuseqlen_q = Int32(0)
+                if cutlass.const_expr(cum_seqlen_q is not None):
+                    cuseqlen_q = cum_seqlen_q[batch_coord]
+                    seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
+                    continue_cond = not FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
+                        self.qk_mma_tiler[0],
+                        mma_block_coord[0],
+                        seqlen_q,
+                    )
+                if not continue_cond:
+                    if cutlass.const_expr(cum_seqlen_k is not None):
+                        cuseqlen_k = cum_seqlen_k[batch_coord]
+                        seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
+
+                    row_max = -Float32.inf
+                    row_max_prev = -Float32.inf
+                    row_sum = 0.0
+
+                    start_count, trip_count = FusedMask.get_trip_start_count_via_block_info(
+                        mma_block_coord,
+                        self.qk_mma_tiler,
+                        seqlen_q,
+                        seqlen_k,
+                        self.is_causal,
+                        self.is_local,
+                        window_size_left,
+                        window_size_right,
+                    )
+                    end_count = start_count + trip_count
+                    if cutlass.const_expr(self.use_semantic_trip_range):
+                        n_block_min_causal_local_mask, n_block_min_before_local_mask = (
+                            FusedMask.get_trip_mask_bounds_via_block_info(
+                                mma_block_coord,
+                                self.qk_mma_tiler,
+                                seqlen_q,
+                                seqlen_k,
+                                self.is_causal,
+                                self.is_local,
+                                window_size_left,
+                                window_size_right,
+                            )
+                        )
+                    cS_base = cute.make_identity_tensor(
+                        (self.qk_mma_tiler[0], self.qk_mma_tiler[1])
+                    )
+                    cS = cute.domain_offset((mma_block_coord[0] * self.qk_mma_tiler[0], 0), cS_base)
+                    tScS = qk_thr_mma.partition_C(cS)
+
+                    for step in cutlass.range(start_count, end_count, 1, unroll=1):
+                        cS_iter = cute.domain_offset((0, step * self.qk_mma_tiler[1]), cS)
+                        tScS_iter = qk_thr_mma.partition_C(cS_iter)
+                        if cutlass.const_expr(self.use_semantic_trip_range):
+                            need_apply_mask = (
+                                step >= n_block_min_causal_local_mask
+                                or step < n_block_min_before_local_mask
+                            )
+                        else:
+                            # Residual path only needs seqlen masking on the last K tile.
+                            need_apply_mask = step == end_count - 1
+                        # Si -> Pi
+                        (
+                            row_max,
+                            row_sum,
+                            mma_s_consumer,
+                            p_mma_producer,
+                            s_corr_producer,
+                        ) = self.softmax_step(
+                            (need_apply_mask, window_size_left, window_size_right),
+                            (
+                                row_max_prev,
+                                row_sum,
+                                seqlen_q,
+                                seqlen_k,
+                                scale_softmax_log2,
+                            ),
+                            (tStS, tScS_iter),
+                            (mma_s_consumer, p_mma_producer, s_corr_producer),
+                        )
+                        row_max_prev = row_max
+                    sum_producer = self.store_sum_max(
+                        row_max,
+                        mLSE,
+                        row_sum,
+                        sSum,
+                        sum_producer,
+                        curr_block_coord,
+                        seqlen_q,
+                        cum_seqlen_q,
+                        cuseqlen_q,
+                        scale_softmax,
+                    )
+                work_tile = tile_sched.advance_to_next_work()
+            p_mma_producer.tail()
+            s_corr_producer.tail()
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Correction
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx >= self.correction_warp_ids[0] and warp_idx < self.mma_warp_id:
+            cute.arch.warpgroup_reg_dealloc(self.num_regs_correction)
+
+            while work_tile.is_valid_tile:
+                curr_block_coord = work_tile.tile_idx
+                mma_block_coord = (
+                    curr_block_coord[0] // cute.size(qk_tiled_mma.thr_id.shape),
+                    curr_block_coord[1],
+                    curr_block_coord[2],
+                )
+                batch_coord = curr_block_coord[2][1]
+                seqlen_q = mQ_qdl.shape[0]
+                seqlen_k = mK_kdl.shape[0]
+                continue_cond = False
+                cuseqlen_q = Int32(0)
+                if cutlass.const_expr(cum_seqlen_q is not None):
+                    cuseqlen_q = cum_seqlen_q[batch_coord]
+                    seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
+                    continue_cond = not FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
+                        self.qk_mma_tiler[0],
+                        mma_block_coord[0],
+                        seqlen_q,
+                    )
+
+                if not continue_cond:
+                    if cutlass.const_expr(cum_seqlen_k is not None):
+                        cuseqlen_k = cum_seqlen_k[batch_coord]
+                        seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
+
+                    mO_qdl_eff = mO_qdl
+                    if cutlass.const_expr(cum_seqlen_q is not None):
+                        block_offset_o = (
+                            cuseqlen_q,
+                            Int32(0),
+                            Int32(0),
+                            ((Int32(0), Int32(0)), Int32(0)),
+                        )
+                        mO_qdl_eff = cute.domain_offset(
+                            cute.select(block_offset_o, mode=[0, 2, 3]), mO_qdl
+                        )
+
+                    # (bM, bN, loopM, loopN, loopL)
+                    gO_qdl = cute.flat_divide(
+                        mO_qdl_eff, cute.select(self.pv_block_tiler, mode=[0, 1])
+                    )
+                    cO_qdl = cute.flat_divide(
+                        cute.make_identity_tensor(mO_qdl_eff.shape),
+                        cute.select(self.pv_block_tiler, mode=[0, 1]),
+                    )
+
+                    _, seqlen_kv_loop_steps = FusedMask.get_trip_start_count_via_block_info(
+                        mma_block_coord,
+                        self.qk_mma_tiler,
+                        seqlen_q,
+                        seqlen_k,
+                        self.is_causal,
+                        self.is_local,
+                        window_size_left,
+                        window_size_right,
+                    )
+                    gO_staged = gO_qdl[None, None, curr_block_coord[0], None, curr_block_coord[2]]
+                    cO_staged = cO_qdl[None, None, curr_block_coord[0], None, curr_block_coord[2]]
+                    cS = cute.make_identity_tensor((self.qk_mma_tiler[0], self.qk_mma_tiler[1]))
+                    tScS = qk_thr_mma.partition_C(cS)
+
+                    # Empty step as the first step is no need for correction
+                    stats_handle = s_corr_consumer.wait_and_advance()
+                    stats_handle.release()
+                    for step in cutlass.range(1, seqlen_kv_loop_steps, 1, unroll=1):
+                        # Oi-1 -> Oi
+                        mma_corr_consumer, s_corr_consumer = self.correction_rescale(
+                            scale_softmax_log2,
+                            (s_corr_consumer, tStS, tScS),
+                            (mma_corr_consumer, tOtO_staged, cO_staged),
+                            self.epi_tile,
+                        )
+                    # O_partial -> O_final
+                    mma_corr_consumer, sum_consumer = self.correction_epilog(
+                        (seqlen_q, scale_output),
+                        (sum_consumer, sSum),
+                        (mma_corr_consumer, gO_staged, cO_staged, tOtO_staged),
+                        self.epi_tile,
+                    )
+                work_tile = tile_sched.advance_to_next_work()
+            # NOTE: tmem.free() moved to kernel end to enable cluster-wide sync
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Scheduler Warp (only for CLC dynamic scheduler)
+        # ///////////////////////////////////////////////////////////////////////////////
+        if cutlass.const_expr(self.use_clc_scheduler):
+            is_first_cta_in_cluster = cta_rank_in_cluster == 0
+
+            if warp_idx == self.sched_warp_id and is_first_cta_in_cluster:
+                cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
+                while work_tile.is_valid_tile:
+                    tile_sched.prefetch_next_work()
+                    work_tile = tile_sched.advance_to_next_work()
+                tile_sched.producer_tail()
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Empty warps reg dealloc
+        # ///////////////////////////////////////////////////////////////////////////////
+        if cutlass.const_expr(self.use_clc_scheduler):
+            if warp_idx > self.load_warp_id:
+                if not (warp_idx == self.sched_warp_id and is_first_cta_in_cluster):
+                    cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
+        else:
+            if warp_idx > self.load_warp_id:
+                cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Cooperative TMEM Deallocation (2CTA)
+        # ///////////////////////////////////////////////////////////////////////////////
+        # All warps (including scheduler) have finished by this point.
+        # Cluster-wide sync ensures both CTAs reach here before dealloc.
+        cute.arch.cluster_arrive()
+        cute.arch.cluster_wait()
+        tmem.relinquish_alloc_permit()
+        tmem.free(tmem_ptr)
+
+        return
+
+    @cute.jit
+    def softmax_step(
+        self,
+        mask_args: Tuple,
+        value_args: Tuple,
+        tensor_args: Tuple,
+        pipeline_args: Tuple,
+    ) -> Tuple[Float32, Float32, pipeline.PipelineConsumer, pipeline.PipelineProducer]:
+        need_apply_mask, window_size_left, window_size_right = mask_args
+        row_max, row_sum, seqlen_q, seqlen_k, scale_softmax_log2 = value_args
+        tStS, tScS = tensor_args
+        mma_s_consumer, p_mma_producer, s_corr_producer = pipeline_args
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx % (self.threads_per_warp * len(self.softmax_warp_ids))
+        s_handle = mma_s_consumer.wait_and_advance()
+        tStS_slice = tStS[(None, None), 0, 0, s_handle.index]
+        tScS_slice = tScS[(None, None), 0, 0]
+        tmem_load_atom = cute.make_copy_atom(
+            tcgen05.Ld32x32bOp(tcgen05.Repetition(32)), self.qk_acc_dtype
+        )
+        tmem_tiled_load = tcgen05.make_tmem_copy(tmem_load_atom, tStS_slice)
+        thr_load = tmem_tiled_load.get_slice(thread_idx)
+        tTMEM_LOADtS = thr_load.partition_S(tStS_slice)
+        tTMEM_LOADcS = thr_load.partition_D(tScS_slice)
+        tTMEM_LOADrS = cute.make_rmem_tensor(tTMEM_LOADcS.shape, self.qk_acc_dtype)
+        cute.copy(tmem_tiled_load, tTMEM_LOADtS, tTMEM_LOADrS)
+
+        cute.arch.fence_view_async_tmem_load()
+        s_handle.release()
+        if need_apply_mask:
+            FusedMask.apply_mask_via_causal_local(
+                tTMEM_LOADrS,
+                tTMEM_LOADcS,
+                seqlen_q,
+                seqlen_k,
+                self.use_semantic_trip_range,
+                self.is_causal,
+                self.is_local,
+                window_size_left,
+                window_size_right,
+            )
+        old_row_max = row_max
+        row_max = tTMEM_LOADrS.load().reduce(cute.ReductionOp.MAX, row_max, 0)
+        row_max_safe = row_max
+        if row_max == -cutlass.Float32.inf:
+            row_max_safe = 0.0
+
+        stats_handle = s_corr_producer.acquire_and_advance()
+        stats_layout = cute.composition(
+            tStS_slice.layout, cute.make_layout((tStS_slice.shape[0], 2))
+        )
+        stats_c_layout = cute.composition(
+            tScS_slice.layout, cute.make_layout((tScS_slice.shape[0], 2))
+        )
+        tOtStats = cute.make_tensor(tStS_slice.iterator + self.tilePlikeFP32, stats_layout)
+        tOcStats = cute.make_tensor(tScS_slice.iterator, stats_c_layout)
+        tmem_store_stats_atom = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(2)),
+            self.qk_acc_dtype,
+        )
+        tiled_tmem_store_stats = tcgen05.make_tmem_copy(tmem_store_stats_atom, tOtStats)
+        thr_tmem_store_stats = tiled_tmem_store_stats.get_slice(thread_idx)
+        tTMEM_STOREcStats = thr_tmem_store_stats.partition_S(tOcStats)
+        tTMEM_STORErStats = cute.make_rmem_tensor(tTMEM_STOREcStats.shape, self.qk_acc_dtype)
+        tTMEM_STORErStats[0] = old_row_max
+        tTMEM_STORErStats[1] = row_max_safe
+        tTMEM_STOREtStats = thr_tmem_store_stats.partition_D(tOtStats)
+        cute.copy(tiled_tmem_store_stats, tTMEM_STORErStats, tTMEM_STOREtStats)
+        cute.arch.fence_view_async_tmem_store()
+        stats_handle.commit()
+
+        scale = scale_softmax_log2
+        minus_row_max_scale = (0.0 - row_max_safe) * scale
+        tTMEM_STORErP = cute.make_rmem_tensor(tTMEM_LOADrS.shape, self.q_dtype)
+        for k in range(0, cute.size(tTMEM_LOADrS), 2):
+            tTMEM_LOADrS[k], tTMEM_LOADrS[k + 1] = cute.arch.fma_packed_f32x2(
+                (tTMEM_LOADrS[k], tTMEM_LOADrS[k + 1]),
+                (scale, scale),
+                (minus_row_max_scale, minus_row_max_scale),
+            )
+            tTMEM_LOADrS[k] = cute.math.exp2(tTMEM_LOADrS[k], fastmath=True)
+            tTMEM_LOADrS[k + 1] = cute.math.exp2(tTMEM_LOADrS[k + 1], fastmath=True)
+        s_vec = tTMEM_LOADrS.load()
+        tTMEM_STORErP.store(s_vec.to(self.q_dtype))
+
+        p_handle = p_mma_producer.acquire_and_advance()
+        tmem_store_atom = cute.make_copy_atom(
+            tcgen05.St32x32bOp(tcgen05.Repetition(32)), self.qk_acc_dtype
+        )
+        tilePlikeFP32 = tStS_slice.shape[1] // Float32.width * self.q_dtype.width
+        tStS_P_layout = cute.composition(
+            tStS_slice.layout, cute.make_layout((tStS_slice.shape[0], tilePlikeFP32))
+        )
+        tStS_P = cute.make_tensor(tStS_slice.iterator, tStS_P_layout)
+        tScS_P_layout = cute.composition(
+            tScS_slice.layout, cute.make_layout((tScS_slice.shape[0], tilePlikeFP32))
+        )
+        tScS_P = cute.make_tensor(tScS_slice.iterator, tScS_P_layout)
+        tmem_tiled_store = tcgen05.make_tmem_copy(tmem_store_atom, tStS_P)
+        thr_store = tmem_tiled_store.get_slice(thread_idx)
+        tTMEM_STOREtP = thr_store.partition_D(tStS_P)
+        tTMEM_STOREcS = thr_store.partition_S(tScS_P)
+        tTMEM_STORErP_ = cute.make_tensor(
+            cute.recast_ptr(tTMEM_STORErP.iterator, dtype=self.qk_acc_dtype),
+            tTMEM_STOREcS.shape,
+        )
+        cute.copy(tmem_tiled_store, tTMEM_STORErP_, tTMEM_STOREtP)
+        cute.arch.fence_view_async_tmem_store()
+
+        p_handle.commit()
+        acc_scale_ = scale * (old_row_max - row_max_safe)
+        acc_scale = cute.math.exp2(acc_scale_, fastmath=True) * 0.5
+        # TODO: calc row sum with TensorSSA
+        row_sum *= acc_scale
+        local_row_sum_0 = (row_sum, row_sum)
+        local_row_sum_1 = (0.0, 0.0)
+        local_row_sum_2 = (0.0, 0.0)
+        local_row_sum_3 = (0.0, 0.0)
+        reduction_unroll = 4
+        frg_tile = cute.size(tTMEM_LOADrS) // reduction_unroll
+        tTMEM_LOADrS_frg = cute.logical_divide(tTMEM_LOADrS, cute.make_layout(frg_tile))
+        for j in cutlass.range_constexpr(0, cute.size(tTMEM_LOADrS_frg, mode=[0]), 2):
+            local_row_sum_0 = cute.arch.add_packed_f32x2(
+                local_row_sum_0, (tTMEM_LOADrS_frg[j, 0], tTMEM_LOADrS_frg[j + 1, 0])
+            )
+            local_row_sum_1 = cute.arch.add_packed_f32x2(
+                local_row_sum_1, (tTMEM_LOADrS_frg[j, 1], tTMEM_LOADrS_frg[j + 1, 1])
+            )
+            local_row_sum_2 = cute.arch.add_packed_f32x2(
+                local_row_sum_2, (tTMEM_LOADrS_frg[j, 2], tTMEM_LOADrS_frg[j + 1, 2])
+            )
+            local_row_sum_3 = cute.arch.add_packed_f32x2(
+                local_row_sum_3, (tTMEM_LOADrS_frg[j, 3], tTMEM_LOADrS_frg[j + 1, 3])
+            )
+        local_row_sum_0 = cute.arch.add_packed_f32x2(local_row_sum_0, local_row_sum_1)
+        local_row_sum_2 = cute.arch.add_packed_f32x2(local_row_sum_2, local_row_sum_3)
+        local_row_sum_0 = cute.arch.add_packed_f32x2(local_row_sum_0, local_row_sum_2)
+        row_sum = local_row_sum_0[0] + local_row_sum_0[1]
+        return row_max, row_sum, mma_s_consumer, p_mma_producer, s_corr_producer
+
+    @cute.jit
+    def correction_rescale(
+        self,
+        scale_softmax_log2: Float32,
+        stats_args: tuple,
+        o_args: tuple,
+        epi_tile: cute.Tile,
+    ) -> pipeline.PipelineConsumer:
+        (s_corr_consumer, tStS, tScS) = stats_args
+        (mma_o_consumer, tOtO_staged, cO_staged) = o_args
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx % (self.threads_per_warp * len(self.softmax_warp_ids))
+
+        stats_handle = s_corr_consumer.wait_and_advance()
+        tStS_slice = tStS[(None, None), 0, 0, stats_handle.index]
+        tScS_slice = tScS[(None, None), 0, 0]
+        stats_layout = cute.composition(
+            tStS_slice.layout, cute.make_layout((tStS_slice.shape[0], 2))
+        )
+        stats_c_layout = cute.composition(
+            tScS_slice.layout, cute.make_layout((tScS_slice.shape[0], 2))
+        )
+        tOtStats = cute.make_tensor(tStS_slice.iterator + self.tilePlikeFP32, stats_layout)
+        tOcStats = cute.make_tensor(tScS_slice.iterator, stats_c_layout)
+        tmem_load_stats_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(2)),
+            self.qk_acc_dtype,
+        )
+        tiled_tmem_load_stats = tcgen05.make_tmem_copy(tmem_load_stats_atom, tOtStats)
+        thr_tmem_load_stats = tiled_tmem_load_stats.get_slice(thread_idx)
+        tTMEM_LOADtStats = thr_tmem_load_stats.partition_S(tOtStats)
+        tTMEM_LOADcStats = thr_tmem_load_stats.partition_D(tOcStats)
+        tTMEM_LOADrStats = cute.make_rmem_tensor(tTMEM_LOADcStats.shape, self.qk_acc_dtype)
+        cute.copy(tiled_tmem_load_stats, tTMEM_LOADtStats, tTMEM_LOADrStats)
+
+        scale = scale_softmax_log2 * (tTMEM_LOADrStats[0] - tTMEM_LOADrStats[1])
+        scale = cute.math.exp2(scale, fastmath=True)
+        stats_handle.release()
+        o_handle = mma_o_consumer.wait_and_advance()
+        for iter in cutlass.range(self.iterations_pv, unroll_full=True):
+            tOtO = tOtO_staged[(None, None), 0, 0, iter]
+            cO = cO_staged[None, None, iter]
+            tOtO_epi = cute.zipped_divide(tOtO, epi_tile)
+            cO_epi = cute.zipped_divide(cO, epi_tile)
+            tmem_load_atom = cute.make_copy_atom(
+                tcgen05.Ld32x32bOp(tcgen05.Repetition(16)),
+                self.pv_acc_dtype,
+            )
+            tmem_tiled_load = tcgen05.make_tmem_copy(tmem_load_atom, tOtO_epi)
+            thr_load = tmem_tiled_load.get_slice(thread_idx)
+            tmem_store_atom = cute.make_copy_atom(
+                tcgen05.St32x32bOp(tcgen05.Repetition(16)),
+                self.pv_acc_dtype,
+            )
+            tmem_store_atom = tcgen05.make_tmem_copy(tmem_store_atom, tOtO_epi)
+            thr_store = tmem_store_atom.get_slice(thread_idx)
+            tTMEM_LOADtO = thr_load.partition_S(tOtO_epi)
+            tTMEM_LOADcO = thr_load.partition_D(cO_epi)
+            tTMEM_STOREtO = thr_store.partition_D(tOtO_epi)
+            tTMrO = cute.make_rmem_tensor_like(
+                cute.append(
+                    cute.make_layout(tTMEM_LOADcO[None, 0, 0].shape),
+                    cute.make_layout(2, stride=cute.size(tTMEM_LOADcO[None, 0, 0].shape)),
+                ),
+                self.pv_acc_dtype,
+            )
+            tTMEM_LOADtO_0 = tTMEM_LOADtO[None, 0, 0]
+            cute.copy(tmem_tiled_load, tTMEM_LOADtO_0, tTMrO[None, 0])
+            iter_num = cute.size(tTMEM_LOADtO, mode=[1])
+            for i in cutlass.range(1, iter_num, unroll_full=True):
+                tTMEM_LOADtO_i = tTMEM_LOADtO[None, i, 0]
+                cute.copy(tmem_tiled_load, tTMEM_LOADtO_i, tTMrO[None, i % 2])
+                for j in cutlass.range(0, cute.size(tTMrO, mode=[0]), 2, unroll_full=True):
+                    tTMrO[j, (i - 1) % 2], tTMrO[j + 1, (i - 1) % 2] = cute.arch.mul_packed_f32x2(
+                        (tTMrO[j, (i - 1) % 2], tTMrO[j + 1, (i - 1) % 2]),
+                        (scale, scale),
+                    )
+                tTMEM_STOREtO_prev_i = tTMEM_STOREtO[None, i - 1, 0]
+                cute.copy(tmem_store_atom, tTMrO[None, (i - 1) % 2], tTMEM_STOREtO_prev_i)
+
+            for j in cutlass.range(0, cute.size(tTMrO, mode=[0]), 2, unroll_full=True):
+                tTMrO[j, (iter_num - 1) % 2], tTMrO[j + 1, (iter_num - 1) % 2] = (
+                    cute.arch.mul_packed_f32x2(
+                        (
+                            tTMrO[j, (iter_num - 1) % 2],
+                            tTMrO[j + 1, (iter_num - 1) % 2],
+                        ),
+                        (scale, scale),
+                    )
+                )
+            cute.copy(
+                tmem_store_atom,
+                tTMrO[None, (iter_num - 1) % 2],
+                tTMEM_STOREtO[None, iter_num - 1, 0],
+            )
+        cute.arch.fence_view_async_tmem_store()
+        o_handle.release()
+        return mma_o_consumer, s_corr_consumer
+
+    @cute.jit
+    def correction_epilog(
+        self,
+        value_args: Tuple,
+        sum_args: Tuple,
+        o_args: Tuple,
+        epi_tile: cute.Tile,
+    ) -> Tuple[pipeline.PipelineConsumer, pipeline.PipelineProducer]:
+        (seqlen_q, scale_output) = value_args
+        (sum_consumer, sSum) = sum_args
+        (mma_o_consumer, gO_staged, cO_staged, tOtO_staged) = o_args
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx % (self.threads_per_warp * len(self.softmax_warp_ids))
+        sum_handle = sum_consumer.wait_and_advance()
+        row_sum = sSum[thread_idx]
+        cute.arch.fence_view_async_shared()
+        sum_handle.release()
+        scale = scale_output / row_sum
+        o_handle = mma_o_consumer.wait_and_advance()
+        for iter in cutlass.range(self.iterations_pv):
+            gO = gO_staged[None, None, iter]
+            cO = cO_staged[None, None, iter]
+            tOtO = tOtO_staged[(None, None), 0, 0, iter]
+            tOtO_epi = cute.zipped_divide(tOtO, epi_tile)
+            cO_epi = cute.zipped_divide(cO, epi_tile)
+            gO_epi = cute.zipped_divide(gO, epi_tile)
+            tidx, _, _ = cute.arch.thread_idx()
+            thread_idx = tidx % (self.threads_per_warp * len(self.softmax_warp_ids))
+            tmem_copy_atom = cute.make_copy_atom(
+                tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32)), self.pv_acc_dtype
+            )
+            tiled_tmem_load = tcgen05.make_tmem_copy(tmem_copy_atom, tOtO_epi)
+            thr_tmem_load = tiled_tmem_load.get_slice(thread_idx)
+            tTMEM_LOADtO = thr_tmem_load.partition_S(tOtO_epi)
+            tTMEM_LOADgO = thr_tmem_load.partition_D(gO_epi)
+            tTMEM_LOADcO = thr_tmem_load.partition_D(cO_epi)
+            for i in cutlass.range(cute.size(tTMEM_LOADtO, mode=[1]), unroll_full=True):
+                tTMEM_LOADtO_i = tTMEM_LOADtO[None, i, 0]
+                tTMEM_LOADgO_i = tTMEM_LOADgO[None, i, 0]
+                tTMEM_LOADcO_i = tTMEM_LOADcO[None, i, 0]
+                tTMrO = cute.make_rmem_tensor(tTMEM_LOADcO[None, 0, i].shape, self.pv_acc_dtype)
+                cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMrO)
+                for j in cutlass.range(0, cute.size(tTMrO), 2, unroll_full=True):
+                    tTMrO[j], tTMrO[j + 1] = cute.arch.mul_packed_f32x2(
+                        (tTMrO[j], tTMrO[j + 1]),
+                        (scale, scale),
+                    )
+                tSMrO = cute.make_rmem_tensor(tTMrO.shape, self.o_dtype)
+                o_vec = tTMrO.load()
+                tSMrO.store(o_vec.to(self.o_dtype))
+                if cute.elem_less(tTMEM_LOADcO_i[0][0], seqlen_q):
+                    cute.autovec_copy(tSMrO, tTMEM_LOADgO_i)
+        o_handle.release()
+        return mma_o_consumer, sum_consumer
+
+    @cute.jit
+    def store_sum_max(
+        self,
+        row_max,
+        mLSE,
+        row_sum,
+        sSum,
+        sum_producer,
+        current_block_coord,
+        seqlen_q,
+        cum_seqlen_q,
+        cuseqlen_q,
+        scale_softmax,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx % (self.threads_per_warp * len(self.softmax_warp_ids))
+        sum_handle = sum_producer.acquire_and_advance()
+        sSum[thread_idx] = row_sum
+        cute.arch.fence_view_async_shared()
+        sum_handle.commit()
+
+        if cutlass.const_expr(mLSE is not None):
+            q_idx = current_block_coord[0] * self.cta_tiler[0] + tidx
+            hb_idx = (
+                (current_block_coord[2][0], Int32(0))
+                if cutlass.const_expr(cum_seqlen_q is not None)
+                else current_block_coord[2]
+            )
+            lse_value = scale_softmax * row_max + cute.math.log(row_sum, fastmath=True)
+            if cute.elem_less(q_idx, seqlen_q):
+                global_q_idx = (
+                    q_idx + cuseqlen_q if cutlass.const_expr(cum_seqlen_q is not None) else q_idx
+                )
+                mLSE[global_q_idx, hb_idx] = lse_value
+        return sum_producer

--- a/flashmask/flash_mask/flash_attn_v4/sm90_config_search.py
+++ b/flashmask/flash_mask/flash_attn_v4/sm90_config_search.py
@@ -5,9 +5,9 @@ Enumerates tile sizes, swap modes, atom layouts, and staging options.
 Checks GMMA divisibility, register budget, and shared memory budget.
 
 Usage:
-    python flash_attn/cute/sm90_config_search.py --headdim 128
-    python flash_attn/cute/sm90_config_search.py --mode fwd --headdim 192-128
-    python flash_attn/cute/sm90_config_search.py --mode bwd --headdim 192 --tile-n 64,96
+    python flash_mask/flash_attn_v4/sm90_config_search.py --headdim 128
+    python flash_mask/flash_attn_v4/sm90_config_search.py --mode fwd --headdim 192-128
+    python flash_mask/flash_attn_v4/sm90_config_search.py --mode bwd --headdim 192 --tile-n 64,96
 """
 
 import math

--- a/flashmask/flash_mask/flash_attn_v4/tile_scheduler.py
+++ b/flashmask/flash_mask/flash_attn_v4/tile_scheduler.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+# Copyright (c) 2025, Tri Dao, Siyu Wang, Shengbin Di, Yuxi Chi, Linfeng Zheng, Haoyan Huang, Lanbo Li, Yun Zhong, Man Yuan, Minmin Sun, Yong Li, Wei Lin.
 
 from enum import IntEnum, auto
 from typing import Optional, Tuple, Protocol, runtime_checkable
@@ -16,12 +16,17 @@ import cutlass.cute as cute
 from cutlass import Int32, const_expr
 from cutlass.cute import FastDivmodDivisor
 from cutlass.utils import ClcDynamicPersistentTileScheduler, ClcDynamicPersistentTileSchedulerParams
-
-from flash_mask.flash_attn_v4.cute_dsl_utils import ParamsBase
+from cutlass.cute.typing import Boolean
+from cutlass.cutlass_dsl import (
+    min as dsl_min,
+    extract_mlir_values,
+    new_from_mlir_values,
+)
+from cutlass.utils.hardware_info import HardwareInfo
 
 import flash_mask.flash_attn_v4.utils as utils
 from flash_mask.flash_attn_v4.fast_math import clz
-
+from flash_mask.flash_attn_v4.cute_dsl_utils import ParamsBase
 
 class SchedulingMode(IntEnum):
     NONE = auto()
@@ -1085,3 +1090,536 @@ class SingleTileVarlenScheduler:
             obj_list.append(cutlass.new_from_mlir_values(obj, values[:n_items]))
             values = values[n_items:]
         return self.__class__(*obj_list, loc=self._loc)
+
+
+# -----------------------------------------------------------------------------
+# SM100 FMHA-specific schedulers (kept separate from generic schedulers).
+# -----------------------------------------------------------------------------
+
+
+class Sm100FmhaStaticTileSchedulerParams:
+    """A class to represent parameters for the FMHA (Fused Multi-Head Attention) static tile scheduler.
+
+    This class holds the configuration parameters needed to initialize and configure
+    the tile scheduler for FMHA operations.
+
+    :ivar is_persistent: Whether to use persistent kernel mode.
+    :type is_persistent: bool
+    :ivar problem_shape_mbh: Problem shape in (M, B, H) format.
+    :type problem_shape_mbh: cute.Shape
+    """
+
+    def __init__(
+        self,
+        is_persistent: bool,
+        problem_shape_mbh: cute.Shape,
+        *,
+        loc=None,
+        ip=None,
+    ):
+        """
+        Initializes the Sm100FmhaStaticTileSchedulerParams with the given parameters.
+
+        :param is_persistent: Whether to use persistent kernel mode.
+        :type is_persistent: bool
+        :param problem_shape_mbh: Problem shape in (M, B, H) format.
+        :type problem_shape_mbh: cute.Shape
+        """
+        self.is_persistent = is_persistent
+        self.problem_shape_mbh = problem_shape_mbh
+        self._loc = loc
+        self._ip = ip
+
+    def __extract_mlir_values__(self):
+        values, self._values_pos = [], []
+        for obj in [self.problem_shape_mbh]:
+            obj_values = extract_mlir_values(obj)
+            values += obj_values
+            self._values_pos.append(len(obj_values))
+        return values
+
+    def __new_from_mlir_values__(self, values):
+        obj_list = []
+        for obj, n_items in zip([self.problem_shape_mbh], self._values_pos):
+            obj_list.append(new_from_mlir_values(obj, values[:n_items]))
+            values = values[n_items:]
+        return Sm100FmhaStaticTileSchedulerParams(
+            self.is_persistent, *(tuple(obj_list)), loc=self._loc
+        )
+
+
+class Sm100FmhaStaticTileScheduler:
+    """A static tile scheduler for FMHA (Fused Multi-Head Attention) operations.
+
+    This class manages the scheduling of work tiles for FMHA kernels, supporting
+    both persistent and non-persistent kernel modes. It tracks the current work
+    position and advances through the problem space efficiently.
+
+    :ivar _params: Scheduler parameters.
+    :type _params: Sm100FmhaStaticTileSchedulerParams
+    :ivar _blk_coord: Block coordinates.
+    :type _blk_coord: cute.Coord
+    :ivar _grid_shape: Grid shape for the kernel.
+    :type _grid_shape: cute.Shape
+    :ivar _is_persistent: Whether to use persistent kernel mode.
+    :type _is_persistent: bool
+    :ivar _current_work_linear_idx: Current linear work index.
+    :type _current_work_linear_idx: Int32
+    :ivar _problem_shape_mbh: Problem shape in (M, B, H) format.
+    :type _problem_shape_mbh: cute.Layout
+    :ivar _num_blocks: Number of blocks in the problem.
+    :type _num_blocks: Int32
+    :ivar _is_first_block: Whether this is the first block.
+    :type _is_first_block: bool
+    :ivar num_persistent_sm: Number of persistent SMs.
+    :type num_persistent_sm: Int32
+    """
+
+    def __init__(
+        self,
+        params: Sm100FmhaStaticTileSchedulerParams,
+        current_work_linear_idx: Int32,
+        blk_coord: cute.Coord,
+        grid_shape: cute.Shape,
+        *,
+        loc=None,
+        ip=None,
+    ):
+        """
+        Initializes the Sm100FmhaStaticTileScheduler with the given parameters.
+
+        :param params: Scheduler parameters.
+        :type params: Sm100FmhaStaticTileSchedulerParams
+        :param current_work_linear_idx: Current linear work index.
+        :type current_work_linear_idx: Int32
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param grid_shape: Grid shape for the kernel.
+        :type grid_shape: cute.Shape
+        """
+        self._params = params
+        self._blk_coord = blk_coord
+        self._grid_shape = grid_shape
+        self._is_persistent = params.is_persistent
+        self._current_work_linear_idx = current_work_linear_idx
+        self._problem_shape_mbh = cute.make_layout(params.problem_shape_mbh, loc=loc, ip=ip)
+        self._num_blocks = cute.size(self._problem_shape_mbh, loc=loc, ip=ip)
+        self._is_first_block = True
+        self.num_persistent_sm = cute.size(grid_shape, loc=loc, ip=ip)
+        self._loc = loc
+        self._ip = ip
+
+    # called by host
+    @staticmethod
+    def get_grid_shape(
+        params: Sm100FmhaStaticTileSchedulerParams,
+        *,
+        loc=None,
+        ip=None,
+    ) -> cute.Shape:
+        """
+        Determine the grid shape for the FMHA kernel.
+
+        For persistent kernels, the grid shape is limited by the number of SMs
+        (Streaming Multiprocessors) available on the device. For non-persistent
+        kernels, the grid shape matches the problem shape.
+
+        :param params: Scheduler parameters.
+        :type params: Sm100FmhaStaticTileSchedulerParams
+
+        :return: Grid shape as (M, B, H) tuple.
+        :rtype: cute.Shape
+        """
+        if params.is_persistent:
+            hardware_info = HardwareInfo()
+            sm_count = hardware_info.get_device_multiprocessor_count()
+            return (
+                dsl_min(sm_count, cute.size(params.problem_shape_mbh, loc=loc, ip=ip)),
+                1,
+                1,
+            )
+        else:
+            return params.problem_shape_mbh
+
+    @staticmethod
+    def check_valid_work_for_seqlen_q(
+        q_tiler: int,
+        current_idx: Int32,
+        seqlen_q: Int32,
+    ) -> Boolean:
+        """
+        Check if the current work index is valid for the given query sequence length.
+
+        This method verifies that the current work tile index multiplied by the
+        query tiler size is within the bounds of the query sequence length.
+
+        :param q_tiler: Query tiler size.
+        :type q_tiler: int
+        :param current_idx: Current work index.
+        :type current_idx: Int32
+        :param seqlen_q: Query sequence length.
+        :type seqlen_q: Int32
+
+        :return: True if the work is valid, False otherwise.
+        :rtype: Boolean
+        """
+        return current_idx * q_tiler < seqlen_q
+
+    def get_current_work(self, *, loc=None, ip=None) -> cutlass.utils.WorkTileInfo:
+        """
+        Get information about the current work tile.
+
+        Determines if the current work is valid and computes the tile coordinates
+        based on whether the kernel is persistent or non-persistent.
+
+        :return: WorkTileInfo containing tile coordinates and validity flag.
+        :rtype: WorkTileInfo
+        """
+        is_valid = (
+            self._current_work_linear_idx < self._num_blocks
+            if self._is_persistent
+            else self._is_first_block
+        )
+
+        blk_coord = (0, 0, 0)
+        if self._is_persistent:
+            blk_coord = self._problem_shape_mbh.get_hier_coord(
+                self._current_work_linear_idx, loc=loc, ip=ip
+            )
+        else:
+            blk_coord = self._blk_coord
+
+        # cur_tile_coord is (mid, 0, (bid, hid))
+        cur_tile_coord = (
+            blk_coord[0],
+            0,
+            (blk_coord[1], blk_coord[2]),
+        )
+
+        return cutlass.utils.WorkTileInfo(cur_tile_coord, is_valid)
+
+    def initial_work_tile_info(self, *, loc=None, ip=None):
+        """
+        Get the initial work tile information.
+
+        :return: Initial WorkTileInfo.
+        :rtype: WorkTileInfo
+        """
+        return self.get_current_work(loc=loc, ip=ip)
+
+    def advance_to_next_work(self, *, advance_count=1, loc=None, ip=None):
+        """
+        Advance to the next work tile and return it.
+
+        For persistent kernels, advances by the number of persistent SMs.
+        For non-persistent kernels, marks that the first block has been processed.
+        """
+        if self._is_persistent:
+            self._current_work_linear_idx += advance_count * self.num_persistent_sm
+        self._is_first_block = False
+        return self.get_current_work()
+
+    def prefetch_next_work(self, *, loc=None, ip=None):
+        """No-op for static scheduler."""
+        pass
+
+    def producer_tail(self, *, loc=None, ip=None):
+        """No-op for static scheduler."""
+        pass
+
+    def __extract_mlir_values__(self):
+        values = extract_mlir_values(self._params)
+        values.extend(extract_mlir_values(self._current_work_linear_idx))
+        values.extend(extract_mlir_values(self._blk_coord))
+        values.extend(extract_mlir_values(self._grid_shape))
+        return values
+
+    def __new_from_mlir_values__(self, values):
+        assert len(values) == 10
+        new_params = new_from_mlir_values(self._params, values[0:3])
+        new_current_work_linear_idx = new_from_mlir_values(
+            self._current_work_linear_idx, [values[3]]
+        )
+        new_blk_coord = new_from_mlir_values(self._blk_coord, values[4:7])
+        new_grid_shape = new_from_mlir_values(self._grid_shape, values[7:])
+        return Sm100FmhaStaticTileScheduler(
+            new_params, new_current_work_linear_idx, new_blk_coord, new_grid_shape
+        )
+
+
+def compute_sm100_fmha_grid(
+    o_shape: cute.Shape,
+    cta_tiler: Tuple[int, int, int],
+    is_persistent: bool,
+) -> Tuple[Sm100FmhaStaticTileSchedulerParams, Tuple[int, int, int]]:
+    """Compute grid parameters for FMHA (static scheduler).
+
+    The output tensor o has shape (s, d, ((h_r, h_k), b)).
+    """
+    tile_sched_params = Sm100FmhaStaticTileSchedulerParams(
+        is_persistent,
+        (
+            cute.ceil_div(cute.size(o_shape[0]), cta_tiler[0]),
+            cute.size(o_shape[2][0]),
+            cute.size(o_shape[2][1]),
+        ),
+    )
+    grid = Sm100FmhaStaticTileScheduler.get_grid_shape(tile_sched_params)
+    return tile_sched_params, grid
+
+
+##############################################################################
+# Fmha CLC dynamic tile scheduler
+##############################################################################
+
+
+class Sm100FmhaClcDynamicTileSchedulerParams:
+    """Parameters for FMHA CLC dynamic persistent tile scheduler.
+
+    This class manages the layout of tiles for CLC (Cluster Launch Control)
+    based dynamic scheduling, adapted for FMHA's (M, B, H) problem shape.
+
+    :ivar problem_shape_mbh: Problem shape in (M, B, H) format.
+    :type problem_shape_mbh: cute.Shape
+    :ivar cluster_shape_mnk: Cluster shape in (M, N, K) format.
+    :type cluster_shape_mnk: cute.Shape
+    """
+
+    def __init__(
+        self,
+        problem_shape_mbh: cute.Shape,
+        cluster_shape_mnk: cute.Shape,
+        *,
+        loc=None,
+        ip=None,
+    ):
+        self.problem_shape_mbh = problem_shape_mbh
+        self._cluster_shape_mnk = cluster_shape_mnk
+        self.cluster_shape_mn = cluster_shape_mnk[:2]
+        self._loc = loc
+        self._ip = ip
+
+        # FMHA uses linear indexing over (M, B, H), convert to (M, N, L) style
+        # For FMHA: M dim is tile count along sequence, N=1, L=(B*H)
+        self.problem_shape_ntile_mnl = (
+            problem_shape_mbh[0],  # M tiles
+            1,  # N tiles (always 1 for FMHA)
+            problem_shape_mbh[1] * problem_shape_mbh[2],  # L = B * H
+        )
+
+        # Create layout for cluster-to-tile mapping
+        self.problem_layout_ncluster_mnl = cute.make_layout(
+            cute.ceil_div(self.problem_shape_ntile_mnl, cluster_shape_mnk[:2]),
+            loc=loc,
+            ip=ip,
+        )
+
+    def __extract_mlir_values__(self):
+        values, self._values_pos = [], []
+        for obj in [
+            self.problem_shape_mbh,
+            self._cluster_shape_mnk,
+        ]:
+            obj_values = extract_mlir_values(obj)
+            values += obj_values
+            self._values_pos.append(len(obj_values))
+        return values
+
+    def __new_from_mlir_values__(self, values):
+        obj_list = []
+        values_copy = list(values)
+        for obj, n_items in zip(
+            [self.problem_shape_mbh, self._cluster_shape_mnk],
+            self._values_pos,
+        ):
+            obj_list.append(new_from_mlir_values(obj, values_copy[:n_items]))
+            values_copy = values_copy[n_items:]
+        return Sm100FmhaClcDynamicTileSchedulerParams(*(tuple(obj_list)), loc=self._loc)
+
+    def get_grid_shape(self, *, loc=None, ip=None) -> Tuple[int, int, int]:
+        """Compute grid shape aligned with cluster shape."""
+        return cute.round_up(self.problem_shape_ntile_mnl, self._cluster_shape_mnk)
+
+    def clc_hw_params(self) -> ClcDynamicPersistentTileSchedulerParams:
+        """Return params for the upstream CLC hardware scheduler."""
+        return ClcDynamicPersistentTileSchedulerParams(
+            problem_shape_ntile_mnl=self.problem_shape_ntile_mnl,
+            cluster_shape_mnk=self._cluster_shape_mnk,
+        )
+
+
+class Sm100FmhaClcDynamicTileScheduler:
+    """CLC dynamic persistent tile scheduler for FMHA.
+
+    This scheduler uses Blackwell's Cluster Launch Control hardware mechanism
+    for dynamic tile distribution, providing automatic load balancing.
+    Adapted for FMHA's (M, B, H) problem shape.
+    """
+
+    def __init__(
+        self,
+        params: Sm100FmhaClcDynamicTileSchedulerParams,
+        cta_id_in_cluster: cute.Coord,
+        num_tiles_executed: Int32,
+        clc_response_ptr: cute.Pointer,
+        block_idx: Tuple,
+        clc: ClcState = None,
+        *,
+        loc=None,
+        ip=None,
+    ):
+        self.params = params
+        self.cta_id_in_cluster = cta_id_in_cluster
+        self._num_tiles_executed = num_tiles_executed
+        self._clc_response_ptr = clc_response_ptr
+        self._block_idx = block_idx
+        self.clc = clc
+        self._loc = loc
+        self._ip = ip
+
+    def __extract_mlir_values__(self):
+        values = extract_mlir_values(self.cta_id_in_cluster)
+        values.extend(extract_mlir_values(self._num_tiles_executed))
+        values.extend(extract_mlir_values(self._clc_response_ptr))
+        values.extend(extract_mlir_values(self._block_idx))
+        if self.clc is not None:
+            values.extend(extract_mlir_values(self.clc))
+        return values
+
+    def __new_from_mlir_values__(self, values):
+        new_cta_id_in_cluster = new_from_mlir_values(self.cta_id_in_cluster, values[0:3])
+        new_num_tiles_executed = new_from_mlir_values(self._num_tiles_executed, [values[3]])
+        new_clc_response_ptr = new_from_mlir_values(self._clc_response_ptr, [values[4]])
+        new_block_idx = new_from_mlir_values(self._block_idx, values[5:8])
+        new_clc = None
+        if self.clc is not None:
+            new_clc = new_from_mlir_values(self.clc, values[8:])
+        return Sm100FmhaClcDynamicTileScheduler(
+            self.params,
+            new_cta_id_in_cluster,
+            new_num_tiles_executed,
+            new_clc_response_ptr,
+            new_block_idx,
+            new_clc,
+        )
+
+    @staticmethod
+    def create(
+        params: Sm100FmhaClcDynamicTileSchedulerParams,
+        block_idx: Tuple,
+        grid_dim: Tuple,
+        clc_response_ptr: cute.Pointer,
+        clc: ClcState = None,
+        *,
+        loc=None,
+        ip=None,
+    ):
+        """Create a CLC dynamic tile scheduler instance."""
+        bidx, bidy, bidz = block_idx
+
+        # CTA id in cluster
+        cta_id_in_cluster = (
+            Int32(bidx % params.cluster_shape_mn[0]),
+            Int32(bidy % params.cluster_shape_mn[1]),
+            Int32(0),
+        )
+
+        num_tiles_executed = Int32(0)
+
+        return Sm100FmhaClcDynamicTileScheduler(
+            params,
+            cta_id_in_cluster,
+            num_tiles_executed,
+            clc_response_ptr,
+            block_idx,
+            clc,
+        )
+
+    @staticmethod
+    def get_grid_shape(
+        params: Sm100FmhaClcDynamicTileSchedulerParams,
+        *,
+        loc=None,
+        ip=None,
+    ) -> Tuple[int, int, int]:
+        """Get grid shape for kernel launch."""
+        return params.get_grid_shape(loc=loc, ip=ip)
+
+    def work_tile_info_from_clc_response(self, result_addr: cute.Pointer, *, loc=None, ip=None):
+        """Parse CLC response and convert to FMHA tile coordinates."""
+        m_idx, n_idx, l_idx, vld = cute.arch.clc_response(result_addr, loc=loc, ip=ip)
+        cute.arch.fence_proxy("async.shared", space="cta")
+
+        # CLC returns first CTA coordinates: m_idx=x, l_idx=z
+        # l_idx is the L (batch) dimension; decode to (bid, hid)
+        hid = l_idx % self.params.problem_shape_mbh[2]
+        bid = l_idx // self.params.problem_shape_mbh[2]
+
+        cta_idx_in_cluster, cta_idy_in_cluster, _ = self.cta_id_in_cluster
+        cur_tile_coord = (
+            m_idx + cta_idx_in_cluster,  # M dimension
+            0,  # N always 0 for FMHA
+            (bid, hid),  # (B, H) packed
+        )
+
+        return cutlass.utils.WorkTileInfo(cur_tile_coord, vld)
+
+    def get_current_work(self, *, loc=None, ip=None):
+        """Get current work tile from CLC response."""
+        return self.work_tile_info_from_clc_response(self._clc_response_ptr, loc=loc, ip=ip)
+
+    def initial_work_tile_info(self, *, loc=None, ip=None):
+        """Get initial work tile based on block index."""
+        bidx, bidy, bidz = self._block_idx
+        # bidz is the L (batch) dimension; decode to (bid, hid)
+        hid = bidz % self.params.problem_shape_mbh[2]
+        bid = bidz // self.params.problem_shape_mbh[2]
+        return cutlass.utils.WorkTileInfo((bidx, 0, (bid, hid)), True)
+
+    def advance_to_next_work(self, *, loc=None, ip=None):
+        """Consumer-side advance: wait for next tile, read coordinates, release."""
+        self.clc.consumer_wait(loc=loc, ip=ip)
+        work = self.get_current_work(loc=loc, ip=ip)
+        self.clc.consumer_release(loc=loc, ip=ip)
+        self._num_tiles_executed += Int32(1)
+        return work
+
+    def prefetch_next_work(self, *, loc=None, ip=None):
+        """Producer-side: issue CLC query for next tile."""
+        self.clc.prefetch_next_work(loc=loc, ip=ip)
+
+    def producer_tail(self, *, loc=None, ip=None):
+        """Producer-side cleanup after last tile."""
+        self.clc.producer_tail(loc=loc, ip=ip)
+
+    @property
+    def num_tiles_executed(self) -> Int32:
+        return self._num_tiles_executed
+
+
+def compute_sm100_fmha_grid_clc(
+    o_shape: cute.Shape,
+    cta_tiler: Tuple[int, int, int],
+    cluster_shape_mnk: Tuple[int, int, int],
+) -> Tuple[Sm100FmhaClcDynamicTileSchedulerParams, Tuple[int, int, int]]:
+    """Compute grid parameters for FMHA with CLC dynamic scheduling."""
+    problem_shape_mbh = (
+        cute.ceil_div(cute.size(o_shape[0]), cta_tiler[0]),
+        cute.size(o_shape[2][0]),
+        cute.size(o_shape[2][1]),
+    )
+    tile_sched_params = Sm100FmhaClcDynamicTileSchedulerParams(problem_shape_mbh, cluster_shape_mnk)
+    grid = Sm100FmhaClcDynamicTileScheduler.get_grid_shape(tile_sched_params)
+    return tile_sched_params, grid
+
+
+##############################################################################
+# Fused Mask
+##############################################################################
+
+
+def make_sm100_thread_cooperative_group(size: int):
+    return cutlass.pipeline.CooperativeGroup(cutlass.pipeline.Agent.Thread, size)
+
+
+SM100_TMEM_CAPACITY_COLUMNS = 512

--- a/flashmask/flash_mask/flash_attn_v4/torch/interface.py
+++ b/flashmask/flash_mask/flash_attn_v4/torch/interface.py
@@ -62,6 +62,13 @@ from flash_mask.flash_attn_v4.flash_bwd_sm120 import FlashAttentionBackwardSm120
 from flash_mask.flash_attn_v4.flash_bwd_postprocess import FlashAttentionBackwardPostprocess
 from flash_mask.flash_attn_v4.flash_fwd_combine import FlashAttentionForwardCombine
 
+from cutlass import Int32
+
+# SM100 head_dim=256 2CTA kernel imports
+from flash_mask.flash_attn_v4.sm100_hd256_2cta_fmha_forward import BlackwellFusedMultiHeadAttentionForward
+from flash_mask.flash_attn_v4.sm100_hd256_2cta_fmha_backward import BlackwellFusedMultiHeadAttentionBackward
+from flash_mask.flash_attn_v4.mask import Sm100MaskEnum as MaskEnum
+
 from flash_mask.flash_attn_v4.block_sparsity import (
     BlockSparseTensorsTorch,
     get_sparse_q_block_size,
@@ -102,6 +109,7 @@ def _get_device_arch():
 def _validate_head_dims(head_dim: int, head_dim_v: int, compute_capability: int, alignment: int) -> None:
     """Validate head dimension constraints based on compute capability."""
     is_deepseek_shape = head_dim == 192 and head_dim_v == 128
+    is_dedicate_kernel_shape = head_dim == 256 and head_dim_v == 256
     is_standard_range = 8 <= head_dim <= 128 and 8 <= head_dim_v <= 128
 
     is_sm90_range = 8 <= head_dim <= 256 and 8 <= head_dim_v <= 256
@@ -111,9 +119,9 @@ def _validate_head_dims(head_dim: int, head_dim_v: int, compute_capability: int,
             f"head_dim and head_dim_v must be between 8 and 256 and divisible by {alignment}."
         )
     elif compute_capability in [10, 11]:
-        assert (is_standard_range or is_deepseek_shape) and head_dim % alignment == 0 and head_dim_v % alignment == 0, (
+        assert (is_standard_range or is_deepseek_shape or is_dedicate_kernel_shape) and head_dim % alignment == 0 and head_dim_v % alignment == 0, (
             f"(head_dim, head_dim_v)=({head_dim}, {head_dim_v}) is not supported on SM100/SM110. "
-            f"head_dim and head_dim_v must be between 8 and 128 and divisible by {alignment}, or (192, 128) for DeepSeek."
+            f"head_dim and head_dim_v must be between 8 and 128 and divisible by {alignment}, or (192, 128) for DeepSeek, or (256, 256) for hd256."
         )
 
 
@@ -292,7 +300,6 @@ def _resolve_causal_local_window(causal, window_size_left, window_size_right, ma
     else:
         local = False
     return causal, local, window_size_left, window_size_right
-
 
 def _flash_attn_fwd(
     q: torch.Tensor,
@@ -543,6 +550,10 @@ def _flash_attn_fwd(
         and (tile_m % qhead_per_kvhead == 0 or not pack_gqa)
     )
 
+    # hd=256 2CTA forward uses dedicated kernel (SM100 only)
+    use_dedicated_hd256_kernel = arch // 10 == 10 and head_dim == 256 and head_dim_v == 256
+    use_2cta_instrs = use_2cta_instrs or use_dedicated_hd256_kernel
+
     if softcap is not None:
         assert score_mod is None, "softcap and score_mod cannot be used together"
         score_mod = utils.create_softcap_scoremod(softcap)
@@ -640,6 +651,7 @@ def _flash_attn_fwd(
         requested_use_clc_scheduler,
         fa_logging.get_fa_log_level(),
     )
+
     if compile_key not in _flash_attn_fwd.compile_cache:
         (
             cu_seqlens_q_tensor,
@@ -722,7 +734,23 @@ def _flash_attn_fwd(
                 paged_kv_non_tma=page_size not in [None, tile_n],
             )
         elif arch // 10 in [10, 11]:
-            fa_fwd = FlashAttentionForwardSm100(
+            if use_dedicated_hd256_kernel:
+                # hd=256 2CTA forward: check for currently unsupported features
+                assert softcap is None, "SM100 forward with head_dim=256 does not support softcap"
+                assert not use_block_sparsity, \
+                    "SM100 forward with head_dim=256 does not support block sparsity"
+                assert learnable_sink is None, \
+                    "SM100 forward with head_dim=256 does not support learnable_sink"
+                assert seqused_q is None and seqused_k is None, \
+                    "SM100 forward with head_dim=256 does not support seqused_q/seqused_k"
+                # pack_gqa is an auto-selected optimization; disable it for hd256 kernel
+                pack_gqa = False
+            flash_fwd_obj_cls = (
+                BlackwellFusedMultiHeadAttentionForward
+                if use_dedicated_hd256_kernel
+                else FlashAttentionForwardSm100
+            )
+            fa_fwd = flash_fwd_obj_cls(
                 head_dim,
                 head_dim_v,
                 qhead_per_kvhead=qhead_per_kvhead,
@@ -879,7 +907,8 @@ def make_fake_bwd_tensors(dtype, has_gqa, varlen_q, varlen_k):
 
 
 def _compile_bwd_preprocess(
-    dtype, head_dim, head_dim_v, m_block_size, has_cuseqlens_q, has_seqused_q, has_dlse,
+    dtype, head_dim, head_dim_v, m_block_size, has_cuseqlens_q, has_seqused_q, has_dlse, has_dq_accum,
+    use_padded_offsets,
 ):
     """Compile bwd preprocess kernel using cute fake tensors (no real GPU tensors needed)."""
     mQ, mK, mV, mO, mdO, mdQ, mdK, mdV, mLSE, mLSElog2, mPdPsum, mdQaccum, mdKaccum, mdVaccum = make_fake_bwd_tensors(
@@ -890,7 +919,10 @@ def _compile_bwd_preprocess(
     mCuSeqlensQ = fake_tensor(Int32, (batchp1,), divisibility=1) if has_cuseqlens_q else None
     mSequsedQ = fake_tensor(Int32, (batch,), divisibility=1) if has_seqused_q else None
     mdLSE = fake_tensor(Float32, mLSE.shape, divisibility=1) if has_dlse else None
-    fa_bwd_pre = FlashAttentionBackwardPreprocess(dtype, head_dim, head_dim_v, m_block_size)
+    mdQaccum = mdQaccum if has_dq_accum else None
+    fa_bwd_pre = FlashAttentionBackwardPreprocess(
+        dtype, head_dim, head_dim_v, m_block_size, use_padded_offsets=use_padded_offsets
+    )
     return cute.compile(
         fa_bwd_pre, mO, mdO, mPdPsum, mLSE, mLSElog2, mdQaccum, mCuSeqlensQ, mSequsedQ, mdLSE,
         cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
@@ -902,11 +934,13 @@ def _bwd_preprocess(
     out, dout, dpsum, lse, lse_log2, dq_accum,
     cu_seqlens_q, seqused_q, dlse,
     dtype, head_dim, head_dim_v, m_block_size,
+    use_padded_offsets=True,
 ):
     """Backward preprocess: compute (o * dout).sum(dim=-1) - dLSE, lse * log2_e, and zero out dq_accum."""
     is_varlen = cu_seqlens_q is not None
     compile_key = (
-        dtype, head_dim, head_dim_v, m_block_size, is_varlen, seqused_q is not None, dlse is not None,
+        dtype, head_dim, head_dim_v, m_block_size, is_varlen, seqused_q is not None, dlse is not None, dq_accum is not None,
+        use_padded_offsets,
     )
     if compile_key not in _bwd_preprocess.compile_cache:
         _bwd_preprocess.compile_cache[compile_key] = _compile_bwd_preprocess(*compile_key)
@@ -1019,6 +1053,7 @@ def _flash_attn_bwd(
     num_head, head_dim = q.shape[-2:]
     head_dim_v = v.shape[-1]
 
+    window_size = [window_size_left, window_size_right]
     causal, local, window_size_left, window_size_right = _resolve_causal_local_window(
         causal, window_size_left, window_size_right
     )
@@ -1093,6 +1128,9 @@ def _flash_attn_bwd(
         )
         cluster_size = 2 if head_dim >= 128 and not disable_2cta else 1
         use_2cta_instrs = cluster_size==2
+
+    use_dedicated_hd256_kernel = arch // 10 == 10 and head_dim == 256 and head_dim_v == 256
+    use_2cta_instrs = use_2cta_instrs or use_dedicated_hd256_kernel
 
     q, k, v, out, dout, lse, cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k = [
         maybe_contiguous(t)
@@ -1210,12 +1248,16 @@ def _flash_attn_bwd(
     head_dim_rounded = (head_dim + 32 - 1) // 32 * 32
 
     if cu_seqlens_q is None:
-        dq_accum = torch.empty(
-            batch_size,
-            num_head,
-            seqlen_q_rounded * head_dim_rounded,
-            dtype=torch.float32,
-            device=device,
+        dq_accum = (
+            None
+            if use_dedicated_hd256_kernel
+            else torch.empty(
+                batch_size,
+                num_head,
+                seqlen_q_rounded * head_dim_rounded,
+                dtype=torch.float32,
+                device=device,
+            )
         )
         dpsum = torch.empty(
             batch_size, num_head, seqlen_q_rounded, dtype=torch.float32, device=device
@@ -1227,8 +1269,12 @@ def _flash_attn_bwd(
         total_q_rounded_padded = (
             (total_q + cu_seqlens_q.shape[0] * m_block_size - 1) // m_block_size * m_block_size
         )
-        dq_accum = torch.empty(
-            num_head, total_q_rounded_padded * head_dim_rounded, dtype=torch.float32, device=device
+        dq_accum = (
+            None
+            if use_dedicated_hd256_kernel
+            else torch.empty(
+                num_head, total_q_rounded_padded * head_dim_rounded, dtype=torch.float32, device=device
+            )
         )
         dpsum = torch.empty(num_head, total_q_rounded_padded, dtype=torch.float32, device=device)
         lse_log2 = torch.empty(num_head, total_q_rounded_padded, dtype=torch.float32, device=device)
@@ -1236,7 +1282,8 @@ def _flash_attn_bwd(
     # GQA (qhead_per_kvhead > 1) needs dK/dV accum+postprocess since multiple Q heads
     # accumulate into the same dK/dV. SM90 varlen_k with qhead_per_kvhead==1 now uses
     # ragged TMA tensors for direct store, so no longer needs accum+postprocess.
-    dKV_postprocess = qhead_per_kvhead > 1
+    # hd=256 2CTA backward has its own internal postprocess for dK/dV.
+    dKV_postprocess = qhead_per_kvhead > 1 and not use_dedicated_hd256_kernel
     if dKV_postprocess:
         head_dim_v_rounded = (head_dim_v + 32 - 1) // 32 * 32
         if cu_seqlens_k is None:
@@ -1288,10 +1335,12 @@ def _flash_attn_bwd(
         dV_semaphore = None
 
     # Preprocess kernel: compute (o * dout).sum(dim=-1) - dLSE, lse * log2_e, and zero out dq_accum.
+    # For hd=256 dedicated path, dq_accum is None so preprocess only fills dpsum/lse_log2.
     _bwd_preprocess(
         out, dout, dpsum, lse, lse_log2, dq_accum,
         cu_seqlens_q, seqused_q, dlse,
         dtype, head_dim, head_dim_v, m_block_size,
+        use_padded_offsets=use_dedicated_hd256_kernel,
     )
     # num_threads: SM90 derives from BwdConfig.num_wg, SM120 is set to 128 above,
     # SM100/SM110 uses default from function signature (384).
@@ -1401,13 +1450,13 @@ def _flash_attn_bwd(
             (seqlen_q_rounded // m_block_size == 1),
             (seqlen_k_rounded // n_block_size == 1),
         )
+
     if compile_key not in _flash_attn_bwd.compile_cache:
         q_tensor, k_tensor, v_tensor, do_tensor, dq_tensor, dk_tensor, dv_tensor = [
             to_cute_tensor(t) for t in (q, k, v, dout, dq, dk, dv)
         ]
-        dq_accum_tensor, dpsum_tensor, lse_log2_tensor = [
-            to_cute_tensor(t) for t in (dq_accum, dpsum, lse_log2)
-        ]
+        lse_log2_tensor, dpsum_tensor = [to_cute_tensor(t) for t in (lse_log2, dpsum)]
+        dq_accum_tensor = to_cute_tensor(dq_accum) if dq_accum is not None else None
         if dKV_postprocess:
             dk_accum_tensor, dv_accum_tensor = [
                 to_cute_tensor(t) for t in (dk_accum, dv_accum)
@@ -1475,28 +1524,61 @@ def _flash_attn_bwd(
                 dQ_single_wg=dQ_single_wg,
             )
         else:
-            fa_bwd_obj = FlashAttentionBackwardSm100(
-                head_dim,
-                head_dim_v,
-                is_causal=causal,
-                is_local=local,
-                qhead_per_kvhead=qhead_per_kvhead,
-                tile_m=m_block_size,
-                tile_n=n_block_size,
-                cluster_size=cluster_size,
-                use_2cta_instrs=use_2cta_instrs,
-                deterministic=deterministic,
-                score_mod=score_mod,
-                score_mod_bwd=score_mod_bwd,
-                mask_mod=mask_mod,
-                has_aux_tensors=aux_tensors is not None,
-                subtile_factor=subtile_factor,
-            )
+            if use_dedicated_hd256_kernel:
+                assert softcap == 0.0, "SM100 backward with head_dim=256 does not support softcap"
+                assert block_sparse_tensors is None, \
+                    "SM100 backward with head_dim=256 does not support block sparsity"
+                assert dlse is None, \
+                    "SM100 backward with head_dim=256 does not support dlse"
+                assert seqused_q is None and seqused_k is None, \
+                    "SM100 backward with head_dim=256 does not support seqused_q/seqused_k"
+
+                dq_tile_mn = (128, 128)
+                dkdv_tile_mn = (128, 64)
+                fa_bwd_obj = BlackwellFusedMultiHeadAttentionBackward(
+                    head_dim,
+                    head_dim_v,
+                    is_causal=causal,
+                    is_local=local,
+                    qhead_per_kvhead=qhead_per_kvhead,
+                    is_persistent=False,
+                    deterministic=deterministic,
+                    cluster_size=cluster_size,
+                    use_2cta_instrs=use_2cta_instrs,
+                    score_mod=score_mod,
+                    score_mod_bwd=score_mod_bwd,
+                    mask_mod=mask_mod,
+                    has_aux_tensors=aux_tensors is not None,
+                    subtile_factor=subtile_factor,
+                    tile_m_dq=dq_tile_mn[0],
+                    tile_n_dq=dq_tile_mn[1],
+                    tile_m_dkdv=dkdv_tile_mn[0],
+                    tile_n_dkdv=dkdv_tile_mn[1],
+                )
+            else:
+                fa_bwd_obj = FlashAttentionBackwardSm100(
+                    head_dim,
+                    head_dim_v,
+                    is_causal=causal,
+                    is_local=local,
+                    qhead_per_kvhead=qhead_per_kvhead,
+                    tile_m=m_block_size,
+                    tile_n=n_block_size,
+                    cluster_size=cluster_size,
+                    use_2cta_instrs=use_2cta_instrs,
+                    deterministic=deterministic,
+                    score_mod=score_mod,
+                    score_mod_bwd=score_mod_bwd,
+                    mask_mod=mask_mod,
+                    has_aux_tensors=aux_tensors is not None,
+                    subtile_factor=subtile_factor,
+                )
 
         # Block sparse tensors for backward use Q-direction indexing (transposed from forward).
         sparse_tensors_compile = None
         if normalized_block_sparse_tensors is not None:
             sparse_tensors_compile = to_cute_block_sparse_tensors(normalized_block_sparse_tensors)
+        dq_accum_tensor = dq_tensor if use_dedicated_hd256_kernel else dq_accum_tensor
 
         # TODO: check @can_implement
         _flash_attn_bwd.compile_cache[compile_key] = cute.compile(
@@ -1526,6 +1608,7 @@ def _flash_attn_bwd(
             options="--enable-tvm-ffi",
         )
     if not is_fake_mode():
+        dq_accum = dq if use_dedicated_hd256_kernel else dq_accum
         _flash_attn_bwd.compile_cache[compile_key](
             q.detach(),
             k.detach(),
@@ -1549,41 +1632,42 @@ def _flash_attn_bwd(
             aux_tensors,
             normalized_block_sparse_tensors[:4] if normalized_block_sparse_tensors is not None else None,
         )
-
-    if arch // 10 == 9:
-        # dQ postprocess: match main kernel's MMA WG count, unless dQ_single_wg
-        num_threads_post_dQ = 128 if dQ_single_wg else cfg.num_wg * 128
-        num_threads_post_dKV = cfg.num_wg * 128
-    else:
-        num_threads_post_dQ = 128
-        num_threads_post_dKV = 128
-
     # Postprocess: convert dq_accum from float32 to dq in bf16/fp16
-    _bwd_postprocess_convert(
-        dq_accum, dq, softmax_scale,
-        cu_seqlens_q, seqused_q,
-        arch, dtype, head_dim, m_block_size, num_threads_post_dQ,
-        AtomLayoutMdQ, dQ_swapAB,
-        use_2cta_instrs=use_2cta_instrs, cluster_size=1,
-    )
+    # hd=256 2CTA backward has its own internal postprocess, skip here.
+    if not use_dedicated_hd256_kernel:
+        if arch // 10 == 9:
+            # dQ postprocess: match main kernel's MMA WG count, unless dQ_single_wg
+            num_threads_post_dQ = 128 if dQ_single_wg else cfg.num_wg * 128
+            num_threads_post_dKV = cfg.num_wg * 128
+        else:
+            num_threads_post_dQ = 128
+            num_threads_post_dKV = 128
 
-    if dKV_postprocess:
-        # Postprocess: convert dk_accum from float32 to dk in bf16/fp16
         _bwd_postprocess_convert(
-            dk_accum, dk, softmax_scale,
-            cu_seqlens_k, seqused_k,
-            arch, dtype, head_dim, n_block_size, num_threads_post_dKV,
-            AtomLayoutNdKV, dKV_swapAB,
-            cluster_size=cluster_size,
+            dq_accum, dq, softmax_scale,
+            cu_seqlens_q, seqused_q,
+            arch, dtype, head_dim, m_block_size, num_threads_post_dQ,
+            AtomLayoutMdQ, dQ_swapAB,
+            use_2cta_instrs=use_2cta_instrs, cluster_size=1,
         )
-        # Postprocess: convert dv_accum from float32 to dv in bf16/fp16
-        _bwd_postprocess_convert(
-            dv_accum, dv, 1.0,
-            cu_seqlens_k, seqused_k,
-            arch, dtype, head_dim_v, n_block_size, num_threads_post_dKV,
-            AtomLayoutNdKV, dKV_swapAB,
-            cluster_size=cluster_size,
-        )
+
+        if dKV_postprocess:
+            # Postprocess: convert dk_accum from float32 to dk in bf16/fp16
+            _bwd_postprocess_convert(
+                dk_accum, dk, softmax_scale,
+                cu_seqlens_k, seqused_k,
+                arch, dtype, head_dim, n_block_size, num_threads_post_dKV,
+                AtomLayoutNdKV, dKV_swapAB,
+                cluster_size=cluster_size,
+            )
+            # Postprocess: convert dv_accum from float32 to dv in bf16/fp16
+            _bwd_postprocess_convert(
+                dv_accum, dv, 1.0,
+                cu_seqlens_k, seqused_k,
+                arch, dtype, head_dim_v, n_block_size, num_threads_post_dKV,
+                AtomLayoutNdKV, dKV_swapAB,
+                cluster_size=cluster_size,
+            )
 
     return dq, dk, dv
 

--- a/flashmask/flash_mask/flash_attn_v4/utils.py
+++ b/flashmask/flash_mask/flash_attn_v4/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+# Copyright (c) 2025, Tri Dao, Siyu Wang, Shengbin Di, Yuxi Chi, Linfeng Zheng, Haoyan Huang, Lanbo Li, Yun Zhong, Man Yuan, Minmin Sun, Yong Li, Wei Lin.
 
 import math
 import hashlib
@@ -198,6 +198,34 @@ def convert_from_dlpack(x, leading_dim, alignment=16, divisibility=1) -> cute.Te
             mode=leading_dim, stride_order=x.dim_order(), divisibility=divisibility
         )
     )
+
+
+def convert_from_dlpack_compact_dynamic(
+    x,
+    *,
+    dynamic_modes: tuple[int, ...],
+    alignment: int = 16,
+    stride_order=None,
+    divisibility: int = 1,
+    enable_tvm_ffi: bool = False,
+) -> cute.Tensor:
+    """Convert via DLPack and mark selected compact dimensions as dynamic."""
+    if isinstance(dynamic_modes, int):
+        dynamic_modes = (dynamic_modes,)
+    if stride_order is None:
+        stride_order = x.dim_order()
+    t = (
+        from_dlpack(x, assumed_align=alignment, enable_tvm_ffi=True)
+        if enable_tvm_ffi
+        else from_dlpack(x, assumed_align=alignment)
+    )
+    for mode in dynamic_modes:
+        t = t.mark_compact_shape_dynamic(
+            mode=mode,
+            stride_order=stride_order,
+            divisibility=divisibility,
+        )
+    return t
 
 
 def convert_from_dlpack_leading_static(
@@ -816,6 +844,91 @@ def domain_offset_aligned(
         assumed_align=tensor.iterator.alignment,
     )
     return cute.make_tensor(new_ptr, tensor.layout)
+
+@dsl_user_op
+def warp_reduction(
+    val: cute.Numeric, op: Callable, *, threads_in_group: int = 32, loc=None, ip=None
+) -> cute.Numeric:
+    """Warp-wide reduction helper for a custom binary op."""
+    offset = threads_in_group // 2
+    while offset > 0:
+        val = op(
+            val,
+            cute.arch.shuffle_sync_bfly(
+                val, offset=offset, mask=-1, mask_and_clamp=31, loc=loc, ip=ip
+            ),
+        )
+        offset //= 2
+    return val
+
+
+warp_reduction_max = partial(
+    warp_reduction, op=lambda x, y: fmax(x, y) if isinstance(x, Float32) else max(x, y)
+)
+warp_reduction_sum = partial(warp_reduction, op=lambda x, y: x + y)  # noqa: FURB118
+
+
+@dsl_user_op
+def make_cotiled_copy(
+    atom: cute.CopyAtom, atom_layout_tv: cute.Layout, data_layout: cute.Layout, *, loc=None, ip=None
+) -> cute.TiledCopy:
+    """Compatibility wrapper for deprecated CuTeDSL `make_cotiled_copy`."""
+    assert cute.is_static(atom_layout_tv.type), "atom_layout_tv must be static"
+    assert cute.is_static(data_layout.type), "data_layout must be static"
+
+    inv_layout_ = cute.left_inverse(data_layout, loc=loc, ip=ip)
+    inv_data_layout = cute.make_layout(
+        (inv_layout_.shape, (1)), stride=(inv_layout_.stride, (0)), loc=loc, ip=ip
+    )
+    layout_tv_data = cute.composition(inv_data_layout, atom_layout_tv, loc=loc, ip=ip)
+
+    atom_layout_v_to_check = cute.coalesce(
+        cute.make_layout(atom_layout_tv.shape[1], stride=atom_layout_tv.stride[1], loc=loc, ip=ip),
+        loc=loc,
+        ip=ip,
+    )
+    data_layout_v_to_check = cute.coalesce(
+        cute.composition(
+            data_layout,
+            cute.make_layout(
+                layout_tv_data.shape[1], stride=layout_tv_data.stride[1], loc=loc, ip=ip
+            ),
+            loc=loc,
+            ip=ip,
+        ),
+        loc=loc,
+        ip=ip,
+    )
+    assert data_layout_v_to_check == atom_layout_v_to_check, (
+        "the memory pointed to by atom_layout_tv does not exist in the data_layout."
+    )
+
+    flat_data_shape = cute.product_each(data_layout.shape, loc=loc, ip=ip)
+    tiler = tuple(
+        cute.filter(
+            cute.composition(
+                cute.make_layout(
+                    flat_data_shape,
+                    stride=tuple(0 if j != i else 1 for j in range(cute.rank(flat_data_shape))),
+                    loc=loc,
+                    ip=ip,
+                ),
+                layout_tv_data,
+                loc=loc,
+                ip=ip,
+            ),
+            loc=loc,
+            ip=ip,
+        )
+        for i in range(cute.rank(flat_data_shape))
+    )
+    tile2data = cute.composition(
+        cute.make_layout(flat_data_shape, loc=loc, ip=ip), tiler, loc=loc, ip=ip
+    )
+    layout_tv = cute.composition(
+        cute.left_inverse(tile2data, loc=loc, ip=ip), layout_tv_data, loc=loc, ip=ip
+    )
+    return cute.make_tiled_copy(atom, layout_tv, tiler, loc=loc, ip=ip)
 
 
 @cute.jit


### PR DESCRIPTION
基于 FA4 b6aa1d, https://github.com/Dao-AILab/flash-attention/pull/2412

1. varlen fa4 d/dv=256,256 迁移
2. 去掉 quack 依赖
3. 修复了在 Python 3.10 下因将参数化泛型（tuple[cute.Tensor]）用于 isinstance 校验导致的 TypeError，改为使用普通类型 list 以兼容 CUTLASS DSL 的类型检查。
4. 完善 paddle 接口、实现
