### PR TITLE
[Fix] Fix Overlap CP size >= 32 UB caused-hang

### DIFF
--- a/csrc/flashmask_v2/distributed/ag_semaphore_ops.cuh
+++ b/csrc/flashmask_v2/distributed/ag_semaphore_ops.cuh
@@ -41,8 +41,7 @@ __global__ void NotifySemaphoreEmptyKernel(
         // Note(heqianyue): bitwise op is generally safer than add, if we are using only 1 node
         // we can opt for the following atomic_and approach
         // clear bit representing the current PE on the all other target PE
-        // nvshmem_int64_atomic_and(semaphores + threadIdx.x, ~(1 << my_pe), threadIdx.x);
-        nvshmem_long_atomic_add(semaphores + threadIdx.x, -(1 << my_pe), threadIdx.x);
+        nvshmem_long_atomic_add(semaphores + threadIdx.x, -(1LL << my_pe), threadIdx.x);
     }
 }
 
@@ -59,7 +58,7 @@ __global__ void NotifySegmentSemaphoreEmptyKernel(
         // the other PE will not notify us before we reset
         wait_full(semaphores, target_rank);
         semaphores[target_rank] = 0;
-        nvshmem_long_atomic_add(semaphores + target_rank, -(1 << my_pe), target_rank);
+        nvshmem_long_atomic_add(semaphores + target_rank, -(1LL << my_pe), target_rank);
     }
 }
 
@@ -92,14 +91,14 @@ __global__ void DebugWaitOnStreamLocalKernel(
 
 __global__ void SetFullKernel(
     int64_t* const __restrict__ semaphores,
-    int value,
+    int64_t value,
     int self_rank
 ) {
     if (threadIdx.x == 0) {
-        semaphores[self_rank] = int64_t(value);
+        semaphores[self_rank] = value;
     }
     __threadfence();
-    __syncwarp();
+    __syncthreads();
     if (threadIdx.x == self_rank) return;
     // set the semaphores[self_rank] = 1 for all remote ranks
     nvshmem_int64_p(semaphores + self_rank, 1, threadIdx.x);
@@ -185,7 +184,7 @@ void notify_full(
     nvshmem_team_t team,
     cudaStream_t stream
 ) {
-    int bit_val = (1 << total_pes) - (1 << my_pe) - 1;
+    int64_t bit_val = (1LL << total_pes) - (1LL << my_pe) - 1;
     // make sure local store is visible to other ranks and notify other PE that data is ready (full) 
     SetFullKernel<<<1, total_pes, 0, stream>>>(semaphores, bit_val, my_pe);
 }

--- a/csrc/flashmask_v2/distributed/rs_semaphore_ops.cuh
+++ b/csrc/flashmask_v2/distributed/rs_semaphore_ops.cuh
@@ -32,11 +32,12 @@ __global__ void ProducerNotifyFull(
     // quiet make sure the previous put/get on this stream is done, then we can clear bit
     if (self_rank == target_rank) return;
     semaphores[target_rank] = 0;        // clear the local status (set by the remote target)
+    const int64_t clear_mask = -(1LL << self_rank);
 #ifdef NVSHMEM_DEBUG
-    auto fetched = nvshmem_long_atomic_fetch_add(semaphores + target_rank, -(1 << self_rank), target_rank);
+    auto fetched = nvshmem_long_atomic_add(semaphores + target_rank, clear_mask, target_rank);
     DEBUG_PRINT("Producer %d notifies remote %d full, fetched: %ld\n", self_rank, target_rank, fetched);
 #else
-    nvshmem_long_atomic_add(semaphores + target_rank, -(1 << self_rank), target_rank);
+    nvshmem_long_atomic_add(semaphores + target_rank, clear_mask, target_rank);
 #endif  // NVSHMEM_DEBUG
 }
 
@@ -44,7 +45,7 @@ __global__ void FusedConsumerNotifyEmpty(
     int64_t* const __restrict__ semaphores,
     int remote_producer_end_rank,
     int nranks,
-    int value,
+    int64_t value,
     int self_rank
 ) {
     // for example: rank 3 local consumer needs the data from [12, 15] (remote producer) for seg 1
@@ -56,7 +57,7 @@ __global__ void FusedConsumerNotifyEmpty(
     }
     // the following fence makes sure semaphore setting is visible across all CP ranks 
     __threadfence();
-    __syncwarp();
+    __syncthreads();
     int target_rank = remote_producer_end_rank - threadIdx.x;
     target_rank = target_rank >= 0 ? target_rank : target_rank + nranks;
     if (target_rank == self_rank) return;
@@ -90,11 +91,11 @@ void notify_consumer_empty(
     int self_rank,
     cudaStream_t comm_stream
 ) {
-    int local_flag = 0;
+    int64_t local_flag = 0;
     for (int i = 0; i < seg_size; i++) {
         int target_rank = remote_producer_end_rank - i;
         target_rank = target_rank >= 0 ? target_rank : target_rank + nranks;
-        local_flag |= target_rank == self_rank ? 0 : (1 << target_rank);
+        local_flag |= target_rank == self_rank ? 0 : (1LL << target_rank);
     }
     // Fused step 1 & 2 in one kernel. Should the following gets buggy, you can revert to 1540b3438fb8 for testing
     // step 1. set self (inform reduce kernel that we haven't got data from other ranks, so we wait)


### PR DESCRIPTION
CP >= 32 时，此前的逻辑由于输入 kernel 时用的是 int, kernel 内操作也是 int，在 1 << 31 操作时（self_rank = 31）导致 UB（2^31 溢出），导致了 CP32 的 hang。

本 PR 的修复：
1. 将所有在大CP下潜在的不安全 int 操作换为 int64。底层的 nvhshmem 对称 signals 是 int64，但当时 kernel 撰写时用的是 int32。修复后在 CP <= 63 (64 仍然不安全) 情况下不会有 UB。CP 64 及以上可能要探索一下新版本 NVSHMEM 下 bitwise ops AMO (3.2.5 下 bitwise ops 如 AND，OR，XOR 在 uint64 上的跨机 AMO 貌似是不被支持的，跨机 AMO 只支持 8B 的 加操作以及设置操作)。
2. 将 __syncwarp 换为了 __syncthreads。不影响 CP size <= 32 但是影响 CP > 32。
3. ag 的修改目前并不会跑到。因为默认不开 AG 的细粒度通信量同步。但为了完整性，本 PR 一起修复了。

本修改对性能没有影响，逻辑也不影响低CP size的正确性。