### PR TITLE
fix blockmask oob

### DIFF
--- a/csrc/flashmask_v2/mainloop_fwd_sm90_tma_gmma_ws.hpp
+++ b/csrc/flashmask_v2/mainloop_fwd_sm90_tma_gmma_ws.hpp
@@ -805,8 +805,10 @@ struct CollectiveMainloopFwdSm90 {
         const int valid_block_mblock_seqlen = (seqlen_info.seqlen_q + m_block_dim - 1) / m_block_dim;
         int blockmask_offset = (bidb * params.h_flashmask + bidh / params.h_h_flashmask_ratio) * valid_block_nblock_seqlen * valid_block_mblock_seqlen; // row_offset
         blockmask_offset += m_block * valid_block_nblock_seqlen / m_factor;
-        blockmask_offset += std::max((chunks_size - (reverse_chunk_idx + 1) * Blockmask_n_block_buffer_valid_length), 0);
-        int blockmask_length = Blockmask_n_block_buffer_valid_length < valid_block_nblock_seqlen ? Blockmask_n_block_buffer_valid_length : valid_block_nblock_seqlen;
+        int chunk_col_start = std::max((chunks_size - (reverse_chunk_idx + 1) * Blockmask_n_block_buffer_valid_length), 0);
+        blockmask_offset += chunk_col_start;
+        int remaining = valid_block_nblock_seqlen - chunk_col_start;
+        int blockmask_length = remaining < Blockmask_n_block_buffer_valid_length ? remaining : Blockmask_n_block_buffer_valid_length;
 
         //xhy: blockmask ptr maybe not 16-aligned, since load_blockmask is called before load_max_min, sync can be shared with load_max_min
         for(int64_t idx = thread_idx; idx < blockmask_length && (offset + idx >= 0); idx += ProducerThreadNum) {


### PR DESCRIPTION
seqlen_k 超过单个 16K chunk 且序列长度不为 128 的倍数时，load_blockmask 中 rightmost chunk 的 cp.async 存在越界读全局内存的问题。 chunk 不受影响。

问题原因：

blockmask_length 取的是 chunk 大小与整行宽度的较小值，但没有扣除当前 chunk 在行内的起始列偏移。对于 rightmost chunk，从起始列到行尾的实际剩余元素可能不足一个完整 chunk，导致 cp.async 读到 block_mask 张量当前行有效范围之外。越界读到的是相邻行/相邻 head 的数据，或直接超出分配空间触发 CUDA Error 700。

本 PR 的修复：

将 blockmask_length 的计算改为基于当前 chunk 起始位置到行尾的实际剩余元素数进行 clamp，即 min(Blockmask_n_block_buffer_valid_length, valid_block_nblock_seqlen - chunk_col_start)。