### PR TITLE
Revert "update flashmask bwd sm100 (#125)"

### DIFF
--- a/flashmask/flash_mask/cute/blackwell_helpers.py
+++ b/flashmask/flash_mask/cute/blackwell_helpers.py
@@ -21,7 +21,6 @@ def gemm_w_idx(
     B_idx: Optional[Int32] = None,
     zero_init: bool | Boolean = False,
     swap_AB: bool = False,
-    num_unroll_groups: int = 1,
 ) -> None:
     if const_expr(swap_AB):
         return gemm_w_idx(
@@ -31,9 +30,7 @@ def gemm_w_idx(
         rA = tCrA if const_expr(A_idx is None) else tCrA[None, None, None, A_idx]
         rB = tCrB if const_expr(B_idx is None) else tCrB[None, None, None, B_idx]
         mma_atom = cute.make_mma_atom(tiled_mma.op)
-        for k in cutlass.range(
-            cute.size(tCrA.shape[2]), unroll=cute.size(tCrA.shape[2]) // num_unroll_groups
-        ):
+        for k in cutlass.range_constexpr(cute.size(tCrA.shape[2])):
             mma_atom.set(tcgen05.Field.ACCUMULATE, not zero_init or k != 0)
             cute.gemm(mma_atom, acc, rA[None, None, k], rB[None, None, k], acc)
 
@@ -49,7 +46,6 @@ def gemm_ptx_w_idx(
     A_idx: Optional[Int32] = None,
     B_idx: Optional[Int32] = None,
     zero_init: bool | Boolean = False,
-    cta_group: int = 1,
     **kwargs,
 ) -> None:
     rA = tCrA if const_expr(A_idx is None) else tCrA[None, None, None, A_idx]
@@ -61,19 +57,11 @@ def gemm_ptx_w_idx(
     mma_atom = cute.make_mma_atom(tiled_mma.op)
     acc_tmem_addr = acc.iterator.toint()
     gemm_ptx_partial(
-        mma_atom.op,
-        acc_tmem_addr,
-        rA,
-        rB,
-        sA_cur,
-        sB_cur,
-        zero_init=zero_init,
-        cta_group=cta_group,
-        **kwargs,
+        mma_atom.op, acc_tmem_addr, rA, rB, sA_cur, sB_cur, zero_init=zero_init, **kwargs
     )
 
-@cute.jit
 
+@cute.jit
 def gemm(
     tiled_mma: cute.TiledMma,
     acc: cute.Tensor,
@@ -384,7 +372,6 @@ def gemm_ptx_partial(
     # sA_offset: Int32 = 0,
     # acc_offset: Int32 = 0,
     tA_addr: Optional[Int32] = None,
-    cta_group: int = 1,
 ) -> None:
     # acc_tmem_addr += acc_offset
     is_ts = op.a_src == cute.nvgpu.tcgen05.OperandSource.TMEM
@@ -476,7 +463,7 @@ def gemm_ptx_partial(
             f"mov.b64 smem_desc_a, {{smem_desc_a_lo_start, smem_desc_a_hi}};\n\t"
             f"mov.b64 smem_desc_b, {{smem_desc_b_lo_start, smem_desc_b_hi}};\n\t"
             "setp.ne.b32 p, $2, 0;\n\t"
-            f"@leader_thread tcgen05.mma.cta_group::{cta_group}.kind::f16 [tmem_acc], smem_desc_a, smem_desc_b, idesc, {pred_str};\n\t"
+            f"@leader_thread tcgen05.mma.cta_group::1.kind::f16 [tmem_acc], smem_desc_a, smem_desc_b, idesc, {pred_str};\n\t"
             + "".join(
                 (
                     # f"add.u32 smem_desc_a_lo, smem_desc_a_lo, {hex(offset_a_diff[k - 1])};\n\t"
@@ -485,7 +472,7 @@ def gemm_ptx_partial(
                     f"add.u32 smem_desc_b_lo, smem_desc_b_lo_start, {hex(offset_b[k])};\n\t"
                     f"mov.b64 smem_desc_a, {{smem_desc_a_lo, smem_desc_a_hi}};\n\t"
                     f"mov.b64 smem_desc_b, {{smem_desc_b_lo, smem_desc_b_hi}};\n\t"
-                    f"@leader_thread tcgen05.mma.cta_group::{cta_group}.kind::f16 [tmem_acc], smem_desc_a, smem_desc_b, idesc, 1;\n\t"
+                    f"@leader_thread tcgen05.mma.cta_group::1.kind::f16 [tmem_acc], smem_desc_a, smem_desc_b, idesc, 1;\n\t"
                 )
                 for k in range(1, cute.size(tCrA.shape[2]))
             )
@@ -549,7 +536,7 @@ def gemm_ptx_partial(
             f"mov.b32 smem_desc_b_hi, {hex(smem_desc_b_hi)};\n\t"
             f"mov.b64 smem_desc_b, {{smem_desc_b_lo_start, smem_desc_b_hi}};\n\t"
             "setp.ne.b32 p, $2, 0;\n\t"
-            f"@leader_thread tcgen05.mma.cta_group::{cta_group}.kind::f16 [tmem_acc], [tmem_a], smem_desc_b, idesc, {pred_str};\n\t"
+            f"@leader_thread tcgen05.mma.cta_group::1.kind::f16 [tmem_acc], [tmem_a], smem_desc_b, idesc, {pred_str};\n\t"
             + "".join(
                 (
                     # f"add.u32 tmem_a, tmem_a, {hex(offset_a_diff[k - 1])};\n\t"
@@ -557,7 +544,7 @@ def gemm_ptx_partial(
                     f"add.u32 smem_desc_b_lo, smem_desc_b_lo_start, {hex(offset_b[k])};\n\t"
                     f"mov.b64 smem_desc_b, {{smem_desc_b_lo, smem_desc_b_hi}};\n\t"
                     # f"@leader_thread tcgen05.mma.cta_group::1.kind::f16 [tmem_acc], [tmem_a], smem_desc_b, idesc, 1;\n\t"
-                    f"@leader_thread tcgen05.mma.cta_group::{cta_group}.kind::f16 [tmem_acc], [tmem_a + {hex(offset_a[k])}], smem_desc_b, idesc, 1;\n\t"
+                    f"@leader_thread tcgen05.mma.cta_group::1.kind::f16 [tmem_acc], [tmem_a + {hex(offset_a[k])}], smem_desc_b, idesc, 1;\n\t"
                 )
                 for k in range(
                     1,
@@ -572,7 +559,7 @@ def gemm_ptx_partial(
                     (
                         f"add.u32 smem_desc_b_lo, smem_desc_b_lo, {hex(offset_b_diff[k - 1])};\n\t"
                         f"mov.b64 smem_desc_b, {{smem_desc_b_lo, smem_desc_b_hi}};\n\t"
-                        f"@leader_thread tcgen05.mma.cta_group::{cta_group}.kind::f16 [tmem_acc], [tmem_a + {hex(offset_a[k])}], smem_desc_b, idesc, 1;\n\t"
+                        f"@leader_thread tcgen05.mma.cta_group::1.kind::f16 [tmem_acc], [tmem_a + {hex(offset_a[k])}], smem_desc_b, idesc, 1;\n\t"
                     )
                     for k in range(cute.size(tCrA.shape[2]) // 4 * 3, cute.size(tCrA.shape[2]))
                 )

--- a/flashmask/flash_mask/cute/copy_utils.py
+++ b/flashmask/flash_mask/cute/copy_utils.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2025, Wentao Guo, Ted Zadouri, Tri Dao.
 
 import math
-from typing import Optional, Type, Callable
+from typing import Optional, Type, Tuple, Callable
 
 import cutlass
 import cutlass.cute as cute
-from cutlass import Float32, Int32, const_expr
+from cutlass import Float32, Int32, Boolean, const_expr
 from cutlass.cute.nvgpu import cpasync
 import cutlass.utils.blackwell_helpers as sm100_utils
 from cutlass.cutlass_dsl import T, dsl_user_op
@@ -208,38 +208,6 @@ def store_shared_remote_fp32x4(
 
 
 @dsl_user_op
-def cpasync_bulk_s2cluster(
-    smem_src_ptr: cute.Pointer,
-    smem_dst_ptr: cute.Pointer,
-    mbar_ptr: cute.Pointer,
-    size: int | Int32,
-    peer_cta_rank_in_cluster: Int32,
-    *,
-    loc=None,
-    ip=None,
-):
-    smem_src_ptr_i32 = smem_src_ptr.toint(loc=loc, ip=ip).ir_value()
-    smem_dst_ptr_i32 = set_block_rank(
-        smem_dst_ptr, peer_cta_rank_in_cluster, loc=loc, ip=ip
-    ).ir_value()
-    mbar_ptr_i32 = set_block_rank(mbar_ptr, peer_cta_rank_in_cluster, loc=loc, ip=ip).ir_value()
-    llvm.inline_asm(
-        None,
-        [
-            smem_dst_ptr_i32,
-            smem_src_ptr_i32,
-            mbar_ptr_i32,
-            Int32(size).ir_value(loc=loc, ip=ip),
-        ],
-        "cp.async.bulk.shared::cluster.shared::cta.mbarrier::complete_tx::bytes [$0], [$1], $3, [$2];",
-        "r,r,r,r",
-        has_side_effects=True,
-        is_align_stack=False,
-        asm_dialect=llvm.AsmDialect.AD_ATT,
-    )
-
-
-@dsl_user_op
 def cpasync_bulk_g2s(
     gmem_ptr: cute.Pointer,
     smem_ptr: cute.Pointer,
@@ -311,7 +279,7 @@ def cpasync_bulk_get_copy_fn(
             dst[None, dst_idx].iterator,
             size=size,
             **new_kwargs,
-            **kwargs,
+            **kwargs
         )
 
     def copy_bulk_single_stage(**new_kwargs):

--- a/flashmask/flash_mask/cute/cute_dsl_utils.py
+++ b/flashmask/flash_mask/cute/cute_dsl_utils.py
@@ -122,21 +122,3 @@ def cute_compile_patched(*args, **kwargs):
             sass = extract(cubin_path, None)
             pathlib.Path(cubin_path).with_suffix(".annotated.sass").write_text(sass)
     return output
-
-
-def assume_strides_aligned(t):
-    """Assume all strides except the last are divisible by 128 bits.
-
-    Python int strides (e.g., stride=0 from GQA expand) are kept as-is
-    since they're static and don't need alignment assumptions.
-    """
-    divby = 128 // t.element_type.width
-    strides = tuple(s if isinstance(s, int) else cute.assume(s, divby=divby) for s in t.stride[:-1])
-    return (*strides, t.stride[-1])
-
-
-def assume_tensor_aligned(t):
-    """Rebuild a tensor with 128-bit aligned stride assumptions. Passes through None."""
-    if t is None:
-        return None
-    return cute.make_tensor(t.iterator, cute.make_layout(t.shape, stride=assume_strides_aligned(t)))

--- a/flashmask/flash_mask/cute/flash_bwd_postprocess.py
+++ b/flashmask/flash_mask/cute/flash_bwd_postprocess.py
@@ -38,8 +38,6 @@ class FlashAttentionBackwardPostprocess:
         num_threads: int = 256,
         AtomLayoutMdQ: int = 1,
         dQ_swapAB: bool = False,
-        use_2cta_instrs: bool = False,
-        cluster_size: int = 1,
     ):
         """
         :param head_dim: head dimension
@@ -54,14 +52,12 @@ class FlashAttentionBackwardPostprocess:
         )
         self.arch = arch
         # padding head_dim to a multiple of 64 for SM100 (32 for others) to match head_dim_rounded
-        hdim_multiple_of = 64 if arch // 10 == 10 else 32
+        hdim_multiple_of = 64 if arch == 100 else 32
         self.tile_hdim = int(math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of)
         self.check_hdim_oob = head_dim != self.tile_hdim
         self.num_threads = num_threads
         self.AtomLayoutMdQ = AtomLayoutMdQ
         self.dQ_swapAB = dQ_swapAB
-        self.use_2cta_instrs = use_2cta_instrs and arch // 10 == 10 and head_dim != 64
-        self.cluster_size = cluster_size
 
     @staticmethod
     def can_implement(dtype, head_dim, tile_m, num_threads) -> bool:
@@ -174,7 +170,7 @@ class FlashAttentionBackwardPostprocess:
             )
 
         self.gmem_tiled_copy_dQ = copy_utils.tiled_copy_2d(
-            self.dtype, math.gcd(128, self.tile_hdim), self.num_threads
+            self.dtype, self.tile_hdim, self.num_threads
         )
         # ///////////////////////////////////////////////////////////////////////////////
         # Shared memory layout: dQ
@@ -368,194 +364,78 @@ class FlashAttentionBackwardPostprocess:
             seqlen_q = seqlen.seqlen_q
             seqlen_q_rounded = cute.round_up(seqlen_q, self.tile_m)
 
-            if const_expr(self.arch // 10 == 10 and self.use_2cta_instrs):
-                # 2-CTA: remap dQaccum layout into TMEM view before writing sdQ
-                num_reduce_threads = self.num_threads
-                thr_mma_dsk = tiled_mma.get_slice(tidx)
-                dQacc_shape = thr_mma_dsk.partition_shape_C((self.tile_m, self.tile_hdim))
-                tdQtdQ = thr_mma_dsk.make_fragment_C(dQacc_shape)
-                tdQtdQ = cute.make_tensor(tdQtdQ.iterator, tdQtdQ.layout)
+            # Step 1: load dQaccum from gmem to smem
+            g2s_thr_copy_dQaccum = g2s_tiled_copy_dQaccum.get_slice(tidx)
+            tdQgdQaccum = g2s_thr_copy_dQaccum.partition_S(gdQaccum)
+            tdQsdQaccumg2s = g2s_thr_copy_dQaccum.partition_D(sdQaccum_flat)
+            cute.copy(g2s_tiled_copy_dQaccum, tdQgdQaccum, tdQsdQaccumg2s)
+            cute.arch.cp_async_commit_group()
+            cute.arch.cp_async_wait_group(0)
+            cute.arch.barrier()
 
+            # Step 2: load dQ from smem to rmem
+            s2r_thr_copy_dQaccum = s2r_tiled_copy_dQaccum.get_slice(tidx)
+            tdQsdQaccum = s2r_thr_copy_dQaccum.partition_S(sdQaccum)
+            tile_shape = (self.tile_m, self.tile_hdim)
+            acc = None
+            tiled_copy_t2r = None
+            if const_expr(self.arch in [80, 90]):
+                acc_shape = tiled_mma.partition_shape_C(
+                    tile_shape if const_expr(not dQ_swapAB) else tile_shape[::-1]
+                )
+                acc = cute.make_fragment(acc_shape, cutlass.Float32)
+                assert cute.size(acc) == cute.size(tdQsdQaccum)
+            else:
+                thr_mma = tiled_mma.get_slice(0)  # 1-CTA
+                dQacc_shape = tiled_mma.partition_shape_C((self.tile_m, self.tile_hdim))
+                tdQtdQ = tiled_mma.make_fragment_C(dQacc_shape)
+                tdQcdQ = thr_mma.partition_C(
+                    cute.make_identity_tensor((self.tile_m, self.tile_hdim))
+                )
                 tmem_load_atom = cute.make_copy_atom(
                     tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(self.dQ_reduce_ncol)), Float32
                 )
-                tiled_tmem_ld = tcgen05.make_tmem_copy(tmem_load_atom, tdQtdQ)
-                thr_tmem_ld = tiled_tmem_ld.get_slice(tidx)
+                tiled_copy_t2r = tcgen05.make_tmem_copy(tmem_load_atom, tdQtdQ)
+                thr_copy_t2r = tiled_copy_t2r.get_slice(tidx)
+                tdQrdQ_t2r_shape = thr_copy_t2r.partition_D(tdQcdQ).shape
+                acc = cute.make_fragment(tdQrdQ_t2r_shape, Float32)
+            tdQrdQaccum = cute.make_tensor(acc.iterator, cute.make_layout(tdQsdQaccum.shape))
+            cute.autovec_copy(tdQsdQaccum, tdQrdQaccum)
+            # Convert tdQrdQaccum from fp32 to fp16/bf16
+            rdQ = cute.make_fragment_like(acc, self.dtype)
+            rdQ.store((acc.load() * scale).to(self.dtype))
 
-                cdQ = cute.make_identity_tensor((self.tile_m, self.tile_hdim))
-                tdQcdQ = thr_mma_dsk.partition_C(cdQ)
-                tdQcdQ_tensor = cute.make_tensor(tdQcdQ.iterator, tdQcdQ.layout)
-                tdQrdQ = thr_tmem_ld.partition_D(tdQcdQ_tensor)
-
-                tiled_copy_accum = s2r_tiled_copy_dQaccum
-                g2s_thr_copy = tiled_copy_accum.get_slice(tidx)
-
-                # S -> R
-                tdQrdQ_fp32 = cute.make_fragment(tdQrdQ.shape, cutlass.Float32)
-                tdQrdQ_s2r = cute.make_tensor(tdQrdQ_fp32.iterator, tdQrdQ_fp32.shape)
-
-                smem_copy_atom = sm100_utils_basic.get_smem_store_op(
-                    LayoutEnum.ROW_MAJOR, self.dtype, cutlass.Float32, tiled_tmem_ld
+            # Step 3: Copy dQ from register to smem
+            cute.arch.barrier()  # make sure all threads have finished loading dQaccum
+            if const_expr(self.arch in [80, 90]):
+                copy_atom_r2s_dQ = utils.get_smem_store_atom(
+                    self.arch, self.dtype, transpose=self.dQ_swapAB
                 )
-                r2s_tiled_copy = cute.make_tiled_copy(
-                    smem_copy_atom,
-                    layout_tv=tiled_tmem_ld.layout_dst_tv_tiled,
-                    tiler_mn=tiled_tmem_ld.tiler_mn,
-                )
-                tdQsdQ_r2s = thr_tmem_ld.partition_D(thr_mma_dsk.partition_C(sdQ))
-                tdQrdQ_r2s = cute.make_fragment(tdQsdQ_r2s.shape, self.dtype)
-
-                num_stages = cute.size(tdQrdQ_fp32, mode=[1])
-                stage_stride = self.dQ_reduce_ncol
-                row_groups = 2
-                assert num_stages % row_groups == 0
-                assert num_reduce_threads % row_groups == 0
-                stage_groups = num_stages // row_groups
-                threads_per_row_group = num_reduce_threads // row_groups
-                stage_loads = tuple((row_group, row_group) for row_group in range(row_groups))
-                stage_iters = tuple(
-                    (row_group, row_group * threads_per_row_group)
-                    for row_group in range(row_groups)
-                )
-                s2r_lane = tidx % threads_per_row_group
-                s2r_buf = tidx // threads_per_row_group
-
-                gdQaccum_layout_g2s = cute.make_layout(
-                    shape=(self.tile_m * self.dQ_reduce_ncol, 1), stride=(1, 0)
-                )
-                sdQaccum_g2s = g2s_thr_copy.partition_D(sdQaccum)
-
-                # G -> S
-                for stage_group in cutlass.range_constexpr(stage_groups):
-                    for stage_offset, smem_buf in stage_loads:
-                        stage_idx = stage_group + stage_offset * stage_groups
-                        gdQaccum_stage = cute.local_tile(
-                            gdQaccum,
-                            (self.tile_m * self.dQ_reduce_ncol,),
-                            (stage_idx,),
-                        )
-                        gdQaccum_stage_g2s = cute.make_tensor(
-                            gdQaccum_stage.iterator,
-                            gdQaccum_layout_g2s,
-                        )
-                        tdQgdQ = g2s_thr_copy.partition_S(gdQaccum_stage_g2s)
-                        cute.copy(
-                            g2s_thr_copy,
-                            tdQgdQ[None, None, 0],
-                            sdQaccum_g2s[None, None, smem_buf],
-                        )
-
-                    cute.arch.fence_view_async_shared()
-                    cute.arch.barrier(barrier_id=6, number_of_threads=num_reduce_threads)
-
-                    # S -> R
-                    for stage_offset, lane_offset in stage_iters:
-                        stage_idx = stage_group + stage_offset * stage_groups
-                        s2r_src_tidx = s2r_lane + lane_offset
-                        s2r_thr_copy = tiled_copy_accum.get_slice(s2r_src_tidx)
-                        sdQaccum_src = s2r_thr_copy.partition_S(sdQaccum)[None, None, s2r_buf]
-
-                        tdQrdQ_s2r_cpy = tdQrdQ_s2r[None, stage_idx, None, None]
-                        tdQrdQ_r2s_cpy = cute.make_tensor(
-                            tdQrdQ_s2r_cpy.iterator, cute.make_layout(sdQaccum_src.shape)
-                        )
-                        cute.copy(s2r_thr_copy, sdQaccum_src, tdQrdQ_r2s_cpy)
-                        cute.arch.fence_view_async_shared()
-                        cute.arch.barrier(barrier_id=7, number_of_threads=num_reduce_threads)
-
-                        # R -> S
-                        stage_lo = stage_idx % stage_stride
-                        stage_hi = stage_idx // stage_stride
-                        tdQrdQ_r2s_cpy = cute.make_tensor(
-                            cute.recast_ptr(tdQrdQ_r2s_cpy.iterator),
-                            tdQrdQ_r2s[((None, 0), (stage_lo, stage_hi), 0, 0)].shape,
-                        )
-                        dQ_vec = tdQrdQ_r2s_cpy.load() * scale
-                        tdQrdQ_r2s[((None, 0), (stage_lo, stage_hi), 0, 0)].store(
-                            dQ_vec.to(self.dtype)
-                        )
-
-                # R -> S
-                cute.copy(
-                    r2s_tiled_copy,
-                    tdQrdQ_r2s[None, None, None, 0],
-                    tdQsdQ_r2s[None, None, None, 0],
-                )
-                cute.arch.fence_view_async_shared()
-                cute.arch.barrier(barrier_id=8, number_of_threads=num_reduce_threads)
+                tiled_copy_r2s_dQ = cute.make_tiled_copy_C(copy_atom_r2s_dQ, tiled_mma)
             else:
-                # Step 1: load dQaccum from gmem to smem
-                g2s_thr_copy_dQaccum = g2s_tiled_copy_dQaccum.get_slice(tidx)
-                tdQgdQaccum = g2s_thr_copy_dQaccum.partition_S(gdQaccum)
-                tdQsdQaccumg2s = g2s_thr_copy_dQaccum.partition_D(sdQaccum_flat)
-                cute.copy(g2s_tiled_copy_dQaccum, tdQgdQaccum, tdQsdQaccumg2s)
-                cute.arch.cp_async_commit_group()
-                cute.arch.cp_async_wait_group(0)
-                cute.arch.barrier()
-
-                # Step 2: load dQ from smem to rmem
-                s2r_thr_copy_dQaccum = s2r_tiled_copy_dQaccum.get_slice(tidx)
-                tdQsdQaccum = s2r_thr_copy_dQaccum.partition_S(sdQaccum)
-                tile_shape = (self.tile_m, self.tile_hdim)
-                acc = None
-                tiled_copy_t2r = None
-                if const_expr(self.arch in [80, 90]):
-                    acc_shape = tiled_mma.partition_shape_C(
-                        tile_shape if const_expr(not dQ_swapAB) else tile_shape[::-1]
-                    )
-                    acc = cute.make_fragment(acc_shape, cutlass.Float32)
-                    assert cute.size(acc) == cute.size(tdQsdQaccum)
-                else:
-                    thr_mma = tiled_mma.get_slice(0)  # 1-CTA
-                    dQacc_shape = tiled_mma.partition_shape_C((self.tile_m, self.tile_hdim))
-                    tdQtdQ = tiled_mma.make_fragment_C(dQacc_shape)
-                    tdQcdQ = thr_mma.partition_C(
-                        cute.make_identity_tensor((self.tile_m, self.tile_hdim))
-                    )
-                    tmem_load_atom = cute.make_copy_atom(
-                        tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(self.dQ_reduce_ncol)), Float32
-                    )
-                    tiled_copy_t2r = tcgen05.make_tmem_copy(tmem_load_atom, tdQtdQ)
-                    thr_copy_t2r = tiled_copy_t2r.get_slice(tidx)
-                    tdQrdQ_t2r_shape = thr_copy_t2r.partition_D(tdQcdQ).shape
-                    acc = cute.make_fragment(tdQrdQ_t2r_shape, Float32)
-                tdQrdQaccum = cute.make_tensor(acc.iterator, cute.make_layout(tdQsdQaccum.shape))
-                cute.autovec_copy(tdQsdQaccum, tdQrdQaccum)
-                # Convert tdQrdQaccum from fp32 to fp16/bf16
-                rdQ = cute.make_fragment_like(acc, self.dtype)
-                rdQ.store((acc.load() * scale).to(self.dtype))
-
-                # Step 3: Copy dQ from register to smem
-                cute.arch.barrier()  # make sure all threads have finished loading dQaccum
-                if const_expr(self.arch in [80, 90]):
-                    copy_atom_r2s_dQ = utils.get_smem_store_atom(
-                        self.arch, self.dtype, transpose=self.dQ_swapAB
-                    )
-                    tiled_copy_r2s_dQ = cute.make_tiled_copy_C(copy_atom_r2s_dQ, tiled_mma)
-                else:
-                    # copy_atom_r2s_dQ = sm100_utils_basic.get_smem_store_op(
-                    #     LayoutEnum.ROW_MAJOR, self.dtype, Float32, tiled_copy_t2r,
-                    # )
-                    # tiled_copy_r2s_dQ = cute.make_tiled_copy_D(copy_atom_r2s_dQ, tiled_copy_t2r)
-                    thr_layout_r2s_dQ = cute.make_layout((self.num_threads, 1))  # 128 threads
-                    val_layout_r2s_dQ = cute.make_layout((1, 128 // self.dtype.width))
-                    copy_atom_r2s_dQ = cute.make_copy_atom(
-                        cute.nvgpu.CopyUniversalOp(),
-                        self.dtype,
-                        num_bits_per_copy=128,
-                    )
-                    tiled_copy_r2s_dQ = cute.make_tiled_copy_tv(
-                        copy_atom_r2s_dQ, thr_layout_r2s_dQ, val_layout_r2s_dQ
-                    )
-                thr_copy_r2s_dQ = tiled_copy_r2s_dQ.get_slice(tidx)
-                cdQ = cute.make_identity_tensor((self.tile_m, self.tile_hdim))
-                if const_expr(self.arch in [80, 90]):
-                    taccdQrdQ = thr_copy_r2s_dQ.retile(rdQ)
-                else:
-                    taccdQcdQ_shape = thr_copy_r2s_dQ.partition_S(cdQ).shape
-                    taccdQrdQ = cute.make_tensor(rdQ.iterator, taccdQcdQ_shape)
-                taccdQsdQ = thr_copy_r2s_dQ.partition_D(sdQ if const_expr(not self.dQ_swapAB) else sdQt)
-                cute.copy(thr_copy_r2s_dQ, taccdQrdQ, taccdQsdQ)
+                # copy_atom_r2s_dQ = sm100_utils_basic.get_smem_store_op(
+                #     LayoutEnum.ROW_MAJOR, self.dtype, Float32, tiled_copy_t2r,
+                # )
+                # tiled_copy_r2s_dQ = cute.make_tiled_copy_D(copy_atom_r2s_dQ, tiled_copy_t2r)
+                thr_layout_r2s_dQ = cute.make_layout((self.num_threads, 1))  # 128 threads
+                val_layout_r2s_dQ = cute.make_layout((1, 128 // self.dtype.width))
+                copy_atom_r2s_dQ = cute.make_copy_atom(
+                    cute.nvgpu.CopyUniversalOp(),
+                    self.dtype,
+                    num_bits_per_copy=128,
+                )
+                tiled_copy_r2s_dQ = cute.make_tiled_copy_tv(
+                    copy_atom_r2s_dQ, thr_layout_r2s_dQ, val_layout_r2s_dQ
+                )
+            thr_copy_r2s_dQ = tiled_copy_r2s_dQ.get_slice(tidx)
+            cdQ = cute.make_identity_tensor((self.tile_m, self.tile_hdim))
+            if const_expr(self.arch in [80, 90]):
+                taccdQrdQ = thr_copy_r2s_dQ.retile(rdQ)
+            else:
+                taccdQcdQ_shape = thr_copy_r2s_dQ.partition_S(cdQ).shape
+                taccdQrdQ = cute.make_tensor(rdQ.iterator, taccdQcdQ_shape)
+            taccdQsdQ = thr_copy_r2s_dQ.partition_D(sdQ if const_expr(not self.dQ_swapAB) else sdQt)
+            cute.copy(thr_copy_r2s_dQ, taccdQrdQ, taccdQsdQ)
 
             # Step 4: Copy dQ from smem to register to prepare for coalesced write to gmem
             cute.arch.barrier()  # make sure all smem stores are done

--- a/flashmask/flash_mask/cute/flash_bwd_preprocess.py
+++ b/flashmask/flash_mask/cute/flash_bwd_preprocess.py
@@ -27,7 +27,6 @@ class FlashAttentionBackwardPreprocess:
         self,
         dtype: Type[cutlass.Numeric],
         head_dim: int,
-        head_dim_v: int,
         m_block_size: int = 128,
         num_threads: int = 128,
         dq_head_dim: Optional[int] = None,
@@ -36,10 +35,8 @@ class FlashAttentionBackwardPreprocess:
         All contiguous dimensions must be at least 16 bytes aligned which indicates the head dimension
         should be a multiple of 8.
 
-        :param head_dim: head dimension for Q/K
+        :param head_dim: head dimension
         :type head_dim: int
-        :param head_dim_v: head dimension for V/O (can differ from head_dim for hdim=192/hdimv=128)
-        :type head_dim_v: int
         :param m_block_size: m block size
         :type m_block_size: int
         :param num_threads: number of threads
@@ -52,9 +49,7 @@ class FlashAttentionBackwardPreprocess:
         # padding head_dim to a multiple of 32 as k_block_size
         hdim_multiple_of = 32
         self.head_dim_padded = int(math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of)
-        self.head_dim_v_padded = int(math.ceil(head_dim_v / hdim_multiple_of) * hdim_multiple_of)
         self.check_hdim_oob = head_dim != self.head_dim_padded
-        self.check_hdim_v_oob = head_dim_v != self.head_dim_v_padded
         # dQaccum may use a different head_dim_rounded (e.g., 128 for SM100 with head_dim=80)
         if dq_head_dim is not None:
             self.dq_head_dim_padded = int(math.ceil(dq_head_dim / hdim_multiple_of) * hdim_multiple_of)
@@ -97,11 +92,11 @@ class FlashAttentionBackwardPreprocess:
         # it's just between threads in the same warp
         gmem_k_block_size = (
             128
-            if self.head_dim_v_padded % 128 == 0
+            if self.head_dim_padded % 128 == 0
             else (
                 64
-                if self.head_dim_v_padded % 64 == 0
-                else (32 if self.head_dim_v_padded % 32 == 0 else 16)
+                if self.head_dim_padded % 64 == 0
+                else (32 if self.head_dim_padded % 32 == 0 else 16)
             )
         )
         self.gmem_tiled_copy_O = copy_utils.tiled_copy_2d(
@@ -255,7 +250,7 @@ class FlashAttentionBackwardPreprocess:
                 mdPsum_cur = cute.domain_offset((padded_offset_q,), mdPsum[num_head, None])
                 headdim_v = mO.shape[2]
 
-            blkOdO_shape = (self.m_block_size, self.head_dim_v_padded)
+            blkOdO_shape = (self.m_block_size, self.head_dim_padded)
             # (m_block_size, head_dim)
             gO = cute.local_tile(mO_cur, blkOdO_shape, (m_block, 0))
             gdO = cute.local_tile(mdO_cur, blkOdO_shape, (m_block, 0))
@@ -270,7 +265,7 @@ class FlashAttentionBackwardPreprocess:
             # of tile_shape
             # ///////////////////////////////////////////////////////////////////////////////
             # Construct identity layout for KV
-            cO = cute.make_identity_tensor((self.m_block_size, self.head_dim_v_padded))
+            cO = cute.make_identity_tensor((self.m_block_size, self.head_dim_padded))
             tOcO = gmem_thr_copy_O.partition_S(cO)
             t0OcO = gmem_thr_copy_O.get_slice(0).partition_S(cO)
             tOpO = utils.predicate_k(tOcO, limit=headdim_v)
@@ -294,7 +289,7 @@ class FlashAttentionBackwardPreprocess:
             tOrdO = cute.make_fragment_like(tOgdO)
             # Zero-fill fragments before predicated copy to avoid NaN in reduction
             # when head_dim is not a multiple of head_dim_padded
-            if cutlass.const_expr(self.check_hdim_v_oob):
+            if cutlass.const_expr(self.check_hdim_oob):
                 tOrO.fill(0)
                 tOrdO.fill(0)
             assert cute.size(tOgO, mode=[0]) == cute.size(tOgdO, mode=[0])
@@ -309,7 +304,7 @@ class FlashAttentionBackwardPreprocess:
                         tOgO[None, m, None],
                         tOrO[None, m, None],
                         pred=tOpO[None, m, None]
-                        if cutlass.const_expr(self.check_hdim_v_oob)
+                        if cutlass.const_expr(self.check_hdim_oob)
                         else None,
                     )
                     cute.copy(
@@ -317,7 +312,7 @@ class FlashAttentionBackwardPreprocess:
                         tOgdO[None, m, None],
                         tOrdO[None, m, None],
                         pred=tOpdO[None, m, None]
-                        if cutlass.const_expr(self.check_hdim_v_oob)
+                        if cutlass.const_expr(self.check_hdim_oob)
                         else None,
                     )
             # Sum across the "k" dimension

--- a/flashmask/flash_mask/cute/flash_bwd_sm100.py
+++ b/flashmask/flash_mask/cute/flash_bwd_sm100.py
@@ -28,7 +28,6 @@ import cutlass.utils.blackwell_helpers as sm100_utils_basic
 from cutlass.pipeline import PipelineAsync, PipelineConsumer
 
 from flash_mask.cute import utils
-from flash_mask.cute.cute_dsl_utils import assume_tensor_aligned
 from flash_mask.cute import copy_utils
 from flash_mask.cute import pipeline
 from flash_mask.cute.blackwell_helpers import gemm_w_idx, gemm_ptx_w_idx  # noqa
@@ -62,14 +61,17 @@ class FlashAttentionBackwardSm100:
         is_persistent: bool = False,
         deterministic: bool = False,
         cluster_size: int = 1,
-        use_2cta_instrs: bool = False,
     ):
         # padding head_dim to a multiple of 64 to match head_dim_rounded in interface
         hdim_multiple_of = 64
         self.tile_hdim = int(math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of)
         head_dim_v = head_dim_v if head_dim_v is not None else head_dim
         self.same_hdim_kv = head_dim == head_dim_v
+        assert head_dim == head_dim_v, "head_dim and head_dim_v must be the same for now"
         self.tile_hdimv = int(math.ceil(head_dim_v / hdim_multiple_of) * hdim_multiple_of)
+        assert self.tile_hdim == self.tile_hdimv, (
+            "tile_hdim and tile_hdimv must be the same for now"
+        )
         self.check_hdim_oob = head_dim != self.tile_hdim
         self.check_hdim_v_oob = head_dim_v != self.tile_hdimv
 
@@ -77,27 +79,18 @@ class FlashAttentionBackwardSm100:
         self.tile_n = tile_n
         self.debug_print = False
 
-        assert self.tile_hdim <= 128 or (self.tile_hdim == 192 and self.tile_hdimv == 128)
-        assert self.tile_hdimv <= 128
-
-        self.use_2cta_instrs = bool(use_2cta_instrs and cluster_size == 2)
-        self.cta_group_size = 2 if self.use_2cta_instrs else 1
-
-        assert self.tile_hdim != 192 or self.use_2cta_instrs, "Must use 2CTA for hdim 192"
-
         # CTA tiler
-        self.cta_tiler = (tile_n, tile_m, self.tile_hdim)
+        self.cta_tiler = (tile_m, tile_n, self.tile_hdim)
         # S = K @ Q.T
-        self.mma_tiler_kq = (self.cta_group_size * tile_n, tile_m, self.tile_hdim)
+        self.mma_tiler_kq = (tile_n, tile_m, self.tile_hdim)
         # dP = V @ dO.T
-        self.mma_tiler_vdo = (self.cta_group_size * tile_n, tile_m, self.tile_hdimv)
+        self.mma_tiler_vdo = (tile_n, tile_m, self.tile_hdimv)
         # dV = P.T @ dO
-        self.mma_tiler_pdo = (self.cta_group_size * tile_n, self.tile_hdimv, tile_m)
-        # dK = dS.T @ Q
-        self.mma_tiler_dsq = (self.cta_group_size * tile_n, self.tile_hdim, tile_m)
+        self.mma_tiler_pdo = (tile_n, self.tile_hdimv, tile_m)
+        # dK = dS.T @ Q (N, M) (M, D)
+        self.mma_tiler_dsq = (tile_n, self.tile_hdimv, tile_m)
         # dQ = dS @ K
-        # 2-CTA: reduction dim is cluster-wide (tile_n * cta_group_size).
-        self.mma_tiler_dsk = (tile_m, self.tile_hdim, tile_n * self.cta_group_size)
+        self.mma_tiler_dsk = (tile_m, self.tile_hdimv, tile_n)
 
         self.acc_dtype = Float32
         self.startend_row_indices_dtype = Int32
@@ -109,19 +102,19 @@ class FlashAttentionBackwardSm100:
         self.is_local = False
         self.qhead_per_kvhead = qhead_per_kvhead
         self.pack_gqa = False
-        self.dKV_postprocess = self.qhead_per_kvhead > 1
+        self.use_tma_store = True
         self.deterministic = deterministic
 
         # Speed optimizations, does not affect correctness
         self.shuffle_LSE = False
         self.shuffle_dPsum = False
-        self.use_smem_dS_for_mma_dK = False
+        self.use_smem_dS_for_mma_dK = self.deterministic and self.is_causal
 
         self.reduce_warp_ids = (0, 1, 2, 3)
         self.compute_warp_ids = (4, 5, 6, 7, 8, 9, 10, 11)
         self.mma_warp_id = 12
         self.load_warp_id = 13
-        self.relay_warp_id = 14
+        self.epi_warp_id = 14
         self.empty_warp_id = 15
 
         # 16 warps -> 512 threads
@@ -131,7 +124,7 @@ class FlashAttentionBackwardSm100:
                 *self.compute_warp_ids,
                 self.mma_warp_id,
                 self.load_warp_id,
-                self.relay_warp_id,
+                self.epi_warp_id,
                 self.empty_warp_id,
             )
         )
@@ -163,94 +156,49 @@ class FlashAttentionBackwardSm100:
         # self.tmem_total = self.tmem_S_offset + self.tile_n
         # assert self.tmem_total <= self.tmem_alloc_cols
 
-        if self.use_2cta_instrs and self.tile_hdim == 192 and self.tile_hdimv == 128:
-            assert self.tile_m == 128
-            assert self.tile_n == 128
-            self.tmem_dV_offset = 0
-            self.tmem_dK_offset = self.tmem_dV_offset + self.tile_hdimv
-            self.tmem_S_offset = self.tmem_dK_offset + self.tile_hdim
-            self.tmem_P_offset = self.tmem_S_offset  # overlap with S
-            self.tmem_dP_offset = 512 - self.tile_m
-            self.tmem_dS_offset = self.tmem_dP_offset  # overlaps with dP
-            self.tmem_dQ_offset = 512 - self.tile_hdim // 2
-        else:
-            self.tmem_S_offset = 0
-            self.tmem_P_offset = 0  # overlap with S
-            self.tmem_dV_offset = self.tmem_S_offset + self.tile_n
-            self.tmem_dP_offset = self.tmem_dV_offset + self.tile_hdimv
-            self.tmem_dQ_offset = (
-                (self.tmem_S_offset + (self.tile_hdim // 2))
-                if self.use_2cta_instrs
-                else self.tmem_dP_offset
-            )
-            self.tmem_dK_offset = self.tmem_dP_offset + self.tile_m
-            self.tmem_dS_offset = self.tmem_dP_offset  # overlap with dP
+        self.tmem_S_offset = 0
+        self.tmem_P_offset = 0  # overlap with S
+        self.tmem_dV_offset = self.tmem_S_offset + self.tile_n
+        self.tmem_dP_offset = self.tmem_dV_offset + self.tile_hdimv
+        self.tmem_dQ_offset = self.tmem_dP_offset  # overlap with dP
+        self.tmem_dK_offset = self.tmem_dP_offset + self.tile_m
+        self.tmem_dS_offset = self.tmem_dP_offset  # overlap with dP
 
         if (not is_causal and not is_local) or deterministic:
-            self.num_regs_reduce = 136 if self.use_2cta_instrs else 152
+            self.num_regs_reduce = 152
             self.num_regs_compute = 136
-            self.num_regs_load = 104 if self.use_2cta_instrs else 96 - 8
-            self.num_regs_mma = 104 if self.use_2cta_instrs else self.num_regs_load
         else:
-            self.num_regs_reduce = 136 if self.use_2cta_instrs else 136
-            self.num_regs_compute = 136 if self.use_2cta_instrs else 144
-            self.num_regs_load = 104 if self.use_2cta_instrs else 96 - 8
-            self.num_regs_mma = 104 if self.use_2cta_instrs else self.num_regs_load
+            self.num_regs_reduce = 136
+            self.num_regs_compute = 144
+        self.num_regs_other = 96 - 8
         self.num_regs_empty = 24
-
-        if const_expr(self.tile_hdim == 192):
-            self.num_regs_reduce = 128 + 8
-            self.num_regs_compute = 128 + 8
-            self.num_regs_load = 128 - 24
-            self.num_regs_mma = self.num_regs_load
-
-        assert (
-            self.num_regs_reduce
-            + self.num_regs_compute * 2
-            + max(self.num_regs_load, self.num_regs_mma)
-            <= 512
-        )
+        assert self.num_regs_reduce + self.num_regs_compute * 2 + self.num_regs_other <= 512
 
         self.buffer_align_bytes = 1024
 
     def _setup_attributes(self):
-        self.Q_stage = 1 if self.use_2cta_instrs else 2
+        self.Q_stage = 2
         self.dO_stage = 1
-        self.single_stage = 1
         # LSE_stage = Q_stage and dPsum_stage = dO_stage
-        self.sdKVaccum_stage = 2
+        # self.sdKVaccum_stage = 2
         # number of tma reduce adds per dQacc mma
-        # todo: try 32/1 or 48/2 for 2cta d=192 dv=128
-        if self.use_2cta_instrs and self.tile_hdim == 192:
-            self.dQ_reduce_ncol_t2r = 32
-            self.dQ_reduce_ncol = 24 if not self.is_causal else 32
-            self.sdQaccum_stage = 2 if not self.is_causal else 1
-        else:
-            if self.use_2cta_instrs:
-                self.dQ_reduce_ncol = 16 if self.deterministic else 8
-                self.sdQaccum_stage = 2 if self.deterministic else 4
-                self.dQ_reduce_ncol_t2r = 32
-            else:
-                self.dQ_reduce_ncol = 32
-                self.sdQaccum_stage = 64 // self.dQ_reduce_ncol
-                self.dQ_reduce_ncol_t2r = self.dQ_reduce_ncol
-        assert (self.tile_hdim // self.cta_group_size) % self.dQ_reduce_ncol == 0
+        self.dQ_reduce_ncol = 32 if self.tile_hdim % 32 == 0 else 16
+        self.sdQaccum_stage = 64 // self.dQ_reduce_ncol
+        assert self.tile_hdim % self.dQ_reduce_ncol == 0
         self.dQaccum_reduce_stage = self.tile_hdim // self.dQ_reduce_ncol
-        self.dQaccum_reduce_stage_t2r = self.tile_hdim // self.dQ_reduce_ncol_t2r
         self.cluster_reduce_dQ = False and cute.size(self.cluster_shape_mn) > 1
         # number of tma reduce adds for dKacc and dVacc epilogue
         self.dK_reduce_ncol = 32
-        # CTA group for MMA operations
-        self.cta_group = tcgen05.CtaGroup.TWO if self.use_2cta_instrs else tcgen05.CtaGroup.ONE
 
     def _get_tiled_mma(self):
+        cta_group = tcgen05.CtaGroup.ONE
         # S = K @ Q.T
         tiled_mma_S = sm100_utils_basic.make_trivial_tiled_mma(
             self.q_dtype,
             tcgen05.OperandMajorMode.K,
             tcgen05.OperandMajorMode.K,
             self.acc_dtype,
-            self.cta_group,
+            cta_group,
             self.mma_tiler_kq[:2],
         )
         # dP = V @ dO.T
@@ -259,7 +207,7 @@ class FlashAttentionBackwardSm100:
             tcgen05.OperandMajorMode.K,
             tcgen05.OperandMajorMode.K,
             self.acc_dtype,
-            self.cta_group,
+            cta_group,
             self.mma_tiler_vdo[:2],
         )
         # dV += P @ dO --> (K, MN) major
@@ -268,7 +216,7 @@ class FlashAttentionBackwardSm100:
             tcgen05.OperandMajorMode.K,  # P_major_mode
             tcgen05.OperandMajorMode.MN,  # dO_major_mode
             self.acc_dtype,
-            self.cta_group,
+            cta_group,
             self.mma_tiler_pdo[:2],
             a_source=tcgen05.OperandSource.TMEM,
         )
@@ -282,7 +230,7 @@ class FlashAttentionBackwardSm100:
             tcgen05.OperandMajorMode.K,  # dS_major_mode
             tcgen05.OperandMajorMode.MN,  # Q_major_mode
             self.acc_dtype,
-            self.cta_group,
+            cta_group,
             self.mma_tiler_dsq[:2],
             a_source=mma_dK_a_src,
         )
@@ -292,13 +240,13 @@ class FlashAttentionBackwardSm100:
             tcgen05.OperandMajorMode.MN,  # dS_major_mode
             tcgen05.OperandMajorMode.MN,  # Kt_major_mode
             self.acc_dtype,
-            self.cta_group,
+            cta_group,
             self.mma_tiler_dsk[:2],
         )
         return tiled_mma_S, tiled_mma_dP, tiled_mma_dK, tiled_mma_dV, tiled_mma_dQ
 
     def _setup_smem_layout(self):
-        # S.T = K @ Q.T
+        # S = K @ Q.T
         sK_layout = sm100_utils_basic.make_smem_layout_a(
             self.tiled_mma_S,
             self.mma_tiler_kq,
@@ -312,7 +260,7 @@ class FlashAttentionBackwardSm100:
             self.q_dtype,
             self.Q_stage,
         )
-        # dP.T = V @ dO.T
+        # dP = V @ dO.T
         sV_layout = sm100_utils_basic.make_smem_layout_a(
             self.tiled_mma_dP,
             self.mma_tiler_vdo,
@@ -326,7 +274,7 @@ class FlashAttentionBackwardSm100:
             self.do_dtype,
             self.dO_stage,
         )
-        # dV += P.T @ dO
+        # dV += P @ dO
         tP_layout = sm100_utils_basic.make_smem_layout_a(
             self.tiled_mma_dV,
             self.mma_tiler_pdo,
@@ -376,7 +324,6 @@ class FlashAttentionBackwardSm100:
             1,
         )
         self.sKt_layout = cute.slice_(sKt_layout, (None, None, None, 0))
-        self.sdS_xchg_layout = cute.make_layout(shape=(self.tile_n, self.tile_m // 2))
         self.sdQaccum_layout = cute.make_layout(
             (self.tile_m * self.dQ_reduce_ncol, self.sdQaccum_stage)
         )
@@ -388,37 +335,25 @@ class FlashAttentionBackwardSm100:
             shape=(self.tile_m, self.dO_stage),
             stride=(1, cute.round_up(self.tile_m, 64)),
         )
-        self.sdK_epi_tile = (
+        self.sdKV_epi_tile = (
             self.tile_n,
-            math.gcd(128 // (self.dk_dtype.width // 8), self.tile_hdim // 2),  # 64 or 32
+            min(128 // (self.dk_dtype.width // 8),  (self.tile_hdim // 2)) # 64 or 32
         )  # subtiles mma_tiler_dsq[:2] = mma_tiler_pdo[:2]
-        self.sdV_epi_tile = (
-            self.tile_n,
-            math.gcd(128 // (self.dk_dtype.width // 8), self.tile_hdimv // 2),  # 64 or 32
-        )  # subtiles mma_tiler_pdo[:2]
         # headdim_64 gets 1 stage
-        self.num_epi_stages = max(1, (self.tile_hdim // 2) // self.sdK_epi_tile[1])
-        self.num_epi_stages_v = max(1, (self.tile_hdimv // 2) // self.sdV_epi_tile[1])
-        self.sdK_flat_epi_tile = self.tile_n * (self.tile_hdim // 2) // self.num_epi_stages
-        self.sdV_flat_epi_tile = self.tile_n * (self.tile_hdimv // 2) // self.num_epi_stages_v
+        self.num_epi_stages = max(1, (self.tile_hdim // 2) // self.sdKV_epi_tile[1])
 
-        if const_expr(not self.dKV_postprocess):
-            self.sdK_layout = sm100_utils_basic.make_smem_layout_epi(
+        self.sdKV_flat_epi_tile = self.tile_n * (self.tile_hdim // 2) // self.num_epi_stages
+
+        # TODO: dK and dV could have different shapes
+        if const_expr(self.qhead_per_kvhead == 1):
+            self.sdKV_layout = sm100_utils_basic.make_smem_layout_epi(
                 self.dk_dtype,
                 LayoutEnum.ROW_MAJOR,
-                self.sdK_epi_tile,
-                2,  # num compute wgs
-            )
-            self.sdV_layout = sm100_utils_basic.make_smem_layout_epi(
-                self.dv_dtype,
-                LayoutEnum.ROW_MAJOR,
-                self.sdV_epi_tile,
+                self.sdKV_epi_tile,
                 2,  # num compute wgs
             )
         else:
-            self.sdK_layout = cute.make_layout((self.tile_n * self.dK_reduce_ncol, 2))
-            # self.dK_reduce_ncol same for dV
-            self.sdV_layout = cute.make_layout((self.tile_n * self.dK_reduce_ncol, 2))
+            self.sdKV_layout = cute.make_layout((self.tile_n * self.dK_reduce_ncol, 2))
 
         # TODO(GuoxiaWang): 2 means only support flashmask startend_row_indices.shape[-1] <= 2
         self.sStartEndRowIndices_layout = cute.make_layout(
@@ -468,43 +403,42 @@ class FlashAttentionBackwardSm100:
 
         self.enable_flashmask = cutlass.const_expr(flashmask_info is not None)
 
-        if const_expr(self.dKV_postprocess):
+        if const_expr(self.qhead_per_kvhead > 1):
             assert self.dk_dtype.width == 32, "Must accumulate dK in float precision for GQA"
             assert self.dv_dtype.width == 32, "Must accumulate dV in float precision for GQA"
 
-        mdQaccum, mdK, mdV = [assume_tensor_aligned(t) for t in (mdQaccum, mdK, mdV)]
+        # Assume all strides are divisible by 128 bits except the last stride
+        new_stride = lambda t: (
+            *(cute.assume(s, divby=128 // t.element_type.width) for s in t.stride[:-1]),
+            t.stride[-1],
+        )
+        (mdQaccum,) = [
+            cute.make_tensor(t.iterator, cute.make_layout(t.shape, stride=new_stride(t)))
+            if t is not None
+            else None
+            for t in (mdQaccum,)
+        ]
 
-        # (b, s, n, h) --> (s, h, n, b) or (t, n, h) -> (t, h, n)
-        QO_layout_transpose = [1, 3, 2, 0] if const_expr(mCuSeqlensQ is None) else [0, 2, 1]
-        mQ, mdO = [utils.select(t, mode=QO_layout_transpose) for t in (mQ, mdO)]
-
-        KV_layout_transpose = [1, 3, 2, 0] if const_expr(mCuSeqlensK is None) else [0, 2, 1]
-        mK, mV = [utils.select(t, mode=KV_layout_transpose) for t in (mK, mV)]
-
-        # (b, n, s) --> (s, n, b) or (n, t) --> (t, n)
-        LSE_dPsum_dQaccum_transpose = [2, 1, 0] if const_expr(mCuSeqlensQ is None) else [1, 0]
+        layout_transpose = [1, 3, 2, 0]  # (b, s, n, h) --> (s, h, n, b)
+        mQ, mK, mV, mdO = [utils.select(t, mode=layout_transpose) for t in (mQ, mK, mV, mdO)]
+        LSE_dPsum_dQaccum_transpose = [2, 1, 0]  # (b, n, s) --> (s, n, b)
         mLSE, mdPsum, mdQaccum = [
             utils.select(t, mode=LSE_dPsum_dQaccum_transpose) for t in (mLSE, mdPsum, mdQaccum)
         ]
-        if const_expr(not self.dKV_postprocess):
-            layout_dKV_transpose = KV_layout_transpose
+        if const_expr(self.qhead_per_kvhead == 1):
+            layout_dKV_transpose = layout_transpose
         else:
             layout_dKV_transpose = LSE_dPsum_dQaccum_transpose
         mdK, mdV = [utils.select(t, mode=layout_dKV_transpose) for t in (mdK, mdV)]
-        # (s, h, n, b) --> (h, s, n, b) or (t, h, n) -> (h, t, b)
-        dO_transpose = [1, 0, 2, 3] if const_expr(mCuSeqlensQ is None) else [1, 0, 2]
+        dO_transpose = [1, 0, 2, 3]  # (s, h, n, b) --> (h, s, n, b)
         mdO = utils.select(mdO, mode=dO_transpose)
-
-        # Transposes for 2-CTA K/Q paths (Q follows Q seqlens, K follows K seqlens)
-        transpose_sh_q = dO_transpose
-        transpose_sh_k = [1, 0, 2, 3] if const_expr(mCuSeqlensK is None) else [1, 0, 2]
 
         semaphore_transpose = [2, 3, 1, 0]  # (b, n, block, stage) -> (block, stage, n, b)
         if const_expr(self.deterministic):
             assert mdQ_semaphore is not None
             mdQ_semaphore = utils.select(mdQ_semaphore, mode=semaphore_transpose)
 
-        if const_expr(self.deterministic and self.dKV_postprocess):
+        if const_expr(self.deterministic and self.qhead_per_kvhead > 1):
             assert mdK_semaphore is not None
             assert mdV_semaphore is not None
             mdK_semaphore, mdV_semaphore = [
@@ -524,7 +458,7 @@ class FlashAttentionBackwardSm100:
         ) = self._get_tiled_mma()
         self._setup_smem_layout()
 
-        self.use_tma_store = not (self.qhead_per_kvhead == 1 and mCuSeqlensK is not None)
+        cta_group = tcgen05.CtaGroup.ONE
 
         self.cluster_shape_mnk = (*self.cluster_shape_mn, 1)
         self.cluster_layout_vmnk = cute.tiled_divide(
@@ -534,7 +468,7 @@ class FlashAttentionBackwardSm100:
         self.num_mcast_ctas_b = cute.size(self.cluster_layout_vmnk.shape[1])
         self.is_q_do_mcast = self.num_mcast_ctas_b > 1
 
-        if const_expr(not self.dKV_postprocess):
+        if const_expr(self.qhead_per_kvhead == 1):
             self.mdK_layout_enum = LayoutEnum.from_tensor(mdK)
             self.mdV_layout_enum = LayoutEnum.from_tensor(mdV)
             dK_major_mode = self.mdK_layout_enum.mma_major_mode()
@@ -544,20 +478,20 @@ class FlashAttentionBackwardSm100:
             if const_expr(dV_major_mode != tcgen05.OperandMajorMode.K):
                 raise RuntimeError("The layout of mdV is wrong")
 
-        if const_expr(self.use_tma_store and not self.dKV_postprocess):
+        if const_expr(self.use_tma_store and self.qhead_per_kvhead == 1):
             tma_copy_op_dKV = cpasync.CopyBulkTensorTileS2GOp()
             tma_atom_dK, mdK_tma_tensor = cpasync.make_tiled_tma_atom(
                 tma_copy_op_dKV,
                 mdK,
-                cute.select(self.sdK_layout, mode=[0, 1]),
-                self.sdK_epi_tile,
+                cute.select(self.sdKV_layout, mode=[0, 1]),
+                self.sdKV_epi_tile,
                 1,  # no mcast
             )
             tma_atom_dV, mdV_tma_tensor = cpasync.make_tiled_tma_atom(
                 tma_copy_op_dKV,
                 mdV,
-                cute.select(self.sdV_layout, mode=[0, 1]),
-                self.sdV_epi_tile,
+                cute.select(self.sdKV_layout, mode=[0, 1]),
+                self.sdKV_epi_tile,
                 1,  # no mcast
             )
         else:
@@ -566,7 +500,7 @@ class FlashAttentionBackwardSm100:
             tma_atom_dV = None
             tma_atom_dK = None
 
-        if const_expr(not self.dKV_postprocess):
+        if const_expr(self.qhead_per_kvhead == 1):
             thr_layout_r2s_dKV = cute.make_ordered_layout((128, 1), order=(1, 0))  # 128 threads
             val_layout_r2s_dKV = cute.make_ordered_layout(
                 (1, 128 // self.dk_dtype.width), order=(1, 0)
@@ -584,8 +518,8 @@ class FlashAttentionBackwardSm100:
                 Float32, 128, num_copy_elems=128 // Float32.width
             )
 
-        tma_load_op = cpasync.CopyBulkTensorTileG2SOp(self.cta_group)
-        tma_load_op_multicast = cpasync.CopyBulkTensorTileG2SMulticastOp(self.cta_group)
+        tma_load_op = cpasync.CopyBulkTensorTileG2SOp(cta_group)
+        tma_load_op_multicast = cpasync.CopyBulkTensorTileG2SMulticastOp(cta_group)
 
         # S.T = K @ Q.T
         tma_atom_K, tma_tensor_K = cute.nvgpu.make_tiled_tma_atom_A(
@@ -630,46 +564,8 @@ class FlashAttentionBackwardSm100:
             self.cluster_layout_vmnk.shape,
         )
 
-        # ------------------------------------------------------------
-        # 2-CTA
-        # ------------------------------------------------------------
-        tma_atom_dOt = tma_tensor_dOt = None
-        if const_expr(self.use_2cta_instrs):
-            tma_atom_dOt, tma_tensor_dOt = cute.nvgpu.make_tiled_tma_atom_B(
-                dO_tma_op,
-                utils.select(mdO, mode=transpose_sh_q),
-                cute.select(self.sdOt_layout, mode=[0, 1, 2]),
-                self.mma_tiler_vdo,
-                self.tiled_mma_dP,
-                self.cluster_layout_vmnk.shape,
-            )
-        tma_atom_Qt = tma_tensor_Qt = None
-        if const_expr(self.use_2cta_instrs):
-            tma_atom_Qt, tma_tensor_Qt = cute.nvgpu.make_tiled_tma_atom_B(
-                Q_tma_op,
-                utils.select(mQ, mode=transpose_sh_q),
-                cute.select(self.sQt_layout, mode=[0, 1, 2]),
-                self.mma_tiler_dsq,
-                self.tiled_mma_dK,
-                self.cluster_layout_vmnk.shape,
-            )
-        tma_atom_Kt = tma_tensor_Kt = None
-        if const_expr(self.use_2cta_instrs):
-            Kt_tma_op = sm100_utils_basic.cluster_shape_to_tma_atom_B(
-                self.cluster_shape_mnk, self.tiled_mma_dQ.thr_id
-            )
-            tma_atom_Kt, tma_tensor_Kt = cute.nvgpu.make_tiled_tma_atom_B(
-                Kt_tma_op,
-                utils.select(mK, mode=transpose_sh_k),
-                cute.select(self.sKt_layout, mode=[0, 1, 2]),
-                self.mma_tiler_dsk,
-                self.tiled_mma_dQ,
-                self.cluster_layout_vmnk.shape,
-            )
-
         self.tma_copy_bytes = {
-            name: self.cta_group_size
-            * cute.size_in_bytes(mX.element_type, cute.select(layout, mode=[0, 1, 2]))
+            name: cute.size_in_bytes(mX.element_type, cute.select(layout, mode=[0, 1, 2]))
             for name, mX, layout in [
                 ("Q", mQ, self.sQ_layout),
                 ("K", mK, self.sK_layout),
@@ -681,18 +577,13 @@ class FlashAttentionBackwardSm100:
         self.tma_copy_bytes["dPsum"] = self.tile_m * Float32.width // 8
         self.tma_copy_bytes["dQ"] = self.tile_m * self.dQ_reduce_ncol * Float32.width // 8
         self.tma_copy_bytes["dKacc"] = self.tile_n * self.dK_reduce_ncol * Float32.width // 8
-        self.tma_copy_bytes["dS"] = cute.size_in_bytes(self.ds_dtype, self.sdS_layout)
-        self.tma_copy_bytes["sdS_xchg"] = self.tma_copy_bytes["dS"] // 2  # Half of dS for exchange
 
         # TileScheduler = SingleTileScheduler
         if const_expr(self.deterministic):
             TileScheduler = SingleTileLPTBwdScheduler
         else:
             TileScheduler = SingleTileScheduler
-        # spt is disabled for 2-CTA temporarily
-        self.spt = (
-            self.is_causal and self.deterministic
-        )
+        self.spt = self.is_causal and self.deterministic
         tile_sched_args = TileSchedulerArguments(
             cute.ceil_div(cute.size(mK.shape[0]), self.cta_tiler[0]),
             cute.size(mQ.shape[2]),  # num_heads = num_query_heads
@@ -721,192 +612,124 @@ class FlashAttentionBackwardSm100:
         # sQ is reused for sdK, sdO is reused for sdV
         sQ_alloc_bytes = max(
             cute.size_in_bytes(self.q_dtype, self.sQ_layout),
-            cute.size_in_bytes(self.dk_dtype, self.sdK_layout),
+            cute.size_in_bytes(self.dk_dtype, self.sdKV_layout),
         )
         sdO_alloc_bytes = max(
-            cute.size_in_bytes(self.dv_dtype, self.sdV_layout),
+            cute.size_in_bytes(self.dv_dtype, self.sdKV_layout),
             cute.size_in_bytes(self.do_dtype, self.sdO_layout),
         )
         # Sanity check that layouts fit in allocation
-        sdV_bytes = cute.size_in_bytes(self.dv_dtype, self.sdV_layout)
-        sdK_bytes = cute.size_in_bytes(self.dk_dtype, self.sdK_layout)
+        sdV_bytes = cute.size_in_bytes(self.dv_dtype, self.sdKV_layout)
+        sdK_bytes = cute.size_in_bytes(self.dk_dtype, self.sdKV_layout)
         assert sdV_bytes <= sdO_alloc_bytes, "sdV doesn't fit in sdO storage allocation"
         assert sdK_bytes <= sQ_alloc_bytes, "sdK doesn't fit in sQ storage allocation"
-        # 2-CTA: sdV reuses sV, sdK reuses sK
-        sV_bytes = cute.size_in_bytes(self.v_dtype, self.sV_layout)
-        sK_bytes = cute.size_in_bytes(self.k_dtype, self.sK_layout)
-        if const_expr(self.use_2cta_instrs):
-            assert sdV_bytes <= sV_bytes, "sdV doesn't fit in sV storage allocation (2-CTA)"
-            assert sdK_bytes <= sK_bytes, "sdK doesn't fit in sK storage allocation (2-CTA)"
 
-        if const_expr(self.use_2cta_instrs):
-            sQt_size = cute.cosize(self.sQt_layout) if const_expr(self.tile_hdim <= 128) else 0
-            sdOt_size = cute.cosize(self.sdOt_layout) if const_expr(self.tile_hdim <= 128) else 0
-            sdS_xchg_size = cute.cosize(self.sdS_xchg_layout) if const_expr(self.tile_hdim <= 128) else 0
+        @cute.struct
+        class SharedStorage:
+            Q_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.Q_stage]
+            dO_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.dO_stage]
+            LSE_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.Q_stage]
+            dPsum_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.dO_stage]
+            S_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * 1]
+            dP_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * 1]
+            dS_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * 1]
+            dKV_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * 2]
+            dQ_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2]
+            dQ_cluster_full_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.dQaccum_reduce_stage // 2
+            ]
+            dQ_cluster_empty_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.dQaccum_reduce_stage // 2
+            ]
+            tmem_holding_buf: Int32
+            tmem_dealloc_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 1]
+            flashmask_loaded_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 1]
+            sFM_max_min_ptr: cute.struct.MemRange[cutlass.Int32, 8]
+            # 240
+            sdPsum: cute.struct.Align[
+                cute.struct.MemRange[self.dpsum_dtype, cute.cosize(self.sdPsum_layout)],
+                128,
+            ]
 
-            @cute.struct
-            class SharedStorage:
-                Q_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.Q_stage]
-                dO_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.dO_stage]
-                LSE_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.Q_stage]
-                dPsum_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.dO_stage]
-                S_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.single_stage]
-                dP_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.single_stage]
-                dS_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.single_stage]
-                dKV_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.sdKVaccum_stage]
-                dQ_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2]
-                dQ_cluster_full_mbar_ptr: cute.struct.MemRange[
-                    cutlass.Int64, self.dQaccum_reduce_stage // 2
-                ]
-                dQ_cluster_empty_mbar_ptr: cute.struct.MemRange[
-                    cutlass.Int64, self.dQaccum_reduce_stage // 2
-                ]
-                tmem_holding_buf: Int32
-                tmem_dealloc_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 1]
-                flashmask_loaded_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 1]
-                sFM_max_min_ptr: cute.struct.MemRange[cutlass.Int32, 8]
-
-                # 2-CTA
-                Qt_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.Q_stage]
-                Kt_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.single_stage]
-                dS_cluster_empty_mbar_ptr: cutlass.Int64
-                dS_cluster_full_mbar_ptr: cutlass.Int64
-                dS_cluster_leader_mbar_ptr: cutlass.Int64
-                tmem_cluster_mbar_ptr: cutlass.Int64
-                dQaccum_empty_mbar_ptr: cutlass.Int64
-
-                sQ: cute.struct.Align[
-                    cute.struct.MemRange[self.q_dtype, cute.cosize(self.sQ_layout)],
-                    self.buffer_align_bytes,
-                ]
-                sK: cute.struct.Align[
-                    cute.struct.MemRange[self.k_dtype, cute.cosize(self.sK_layout)],
-                    self.buffer_align_bytes,
-                ]
-                sV: cute.struct.Align[
-                    cute.struct.MemRange[self.v_dtype, cute.cosize(self.sV_layout)],
-                    self.buffer_align_bytes,
-                ]
-                sdO: cute.struct.Align[
-                    cute.struct.MemRange[self.do_dtype, cute.cosize(self.sdO_layout)],
-                    self.buffer_align_bytes,
-                ]
-                sQt: cute.struct.Align[
-                    cute.struct.MemRange[self.q_dtype, sQt_size],
-                    self.buffer_align_bytes,
-                ]
-                sdOt: cute.struct.Align[
-                    cute.struct.MemRange[self.do_dtype, sdOt_size],
-                    self.buffer_align_bytes,
-                ]
-                sdS_xchg: cute.struct.Align[
-                    cute.struct.MemRange[self.ds_dtype, sdS_xchg_size],
-                    self.buffer_align_bytes,
-                ]
-                sKt: cute.struct.Align[
-                    cute.struct.MemRange[self.k_dtype, cute.cosize(self.sKt_layout)],
-                    self.buffer_align_bytes,
-                ]
-                sdS: cute.struct.Align[
-                    cute.struct.MemRange[self.ds_dtype, cute.cosize(self.sdSt_layout)],
-                    self.buffer_align_bytes,
-                ]
-                sLSE: cute.struct.Align[
-                    cute.struct.MemRange[self.lse_dtype, cute.cosize(self.sLSE_layout)],
-                    128,
-                ]
-                sdPsum: cute.struct.Align[
-                    cute.struct.MemRange[self.dpsum_dtype, cute.cosize(self.sdPsum_layout)],
-                    128,
-                ]
-                sdQaccum: cute.struct.Align[
-                    cute.struct.MemRange[self.dqaccum_dtype, cute.cosize(self.sdQaccum_layout)],
-                    self.buffer_align_bytes if sdS_xchg_size == 0 else 128,
-                ]
-                sStartEndRowIndices: cute.struct.Align[
-                    cute.struct.MemRange[self.startend_row_indices_dtype, cute.cosize(self.sStartEndRowIndices_layout)],
-                    64,
-                ]
-        else:
-
-            @cute.struct
-            class SharedStorage:
-                Q_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.Q_stage]
-                dO_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.dO_stage]
-                LSE_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.Q_stage]
-                dPsum_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.dO_stage]
-                S_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.single_stage]
-                dP_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.single_stage]
-                dS_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.single_stage]
-                dKV_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.sdKVaccum_stage]
-                dQ_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2]
-                dQ_cluster_full_mbar_ptr: cute.struct.MemRange[
-                    cutlass.Int64, self.dQaccum_reduce_stage // 2
-                ]
-                dQ_cluster_empty_mbar_ptr: cute.struct.MemRange[
-                    cutlass.Int64, self.dQaccum_reduce_stage // 2
-                ]
-                tmem_holding_buf: Int32
-                tmem_dealloc_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 1]
-                flashmask_loaded_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 1]
-                sFM_max_min_ptr: cute.struct.MemRange[cutlass.Int32, 8]
-
-                sdPsum: cute.struct.Align[
-                    cute.struct.MemRange[self.dpsum_dtype, cute.cosize(self.sdPsum_layout)],
-                    128,
-                ]
-
-                # Smem tensors
-                # sQ is reused for sdK which in the non-MHA case needs float32
-                sQ: cute.struct.Align[
-                    cute.struct.MemRange[cute.Uint8, sQ_alloc_bytes],
-                    self.buffer_align_bytes,
-                ]
-                sK: cute.struct.Align[
-                    cute.struct.MemRange[self.k_dtype, cute.cosize(self.sK_layout)],
-                    self.buffer_align_bytes,
-                ]
-                sV: cute.struct.Align[
-                    cute.struct.MemRange[self.v_dtype, cute.cosize(self.sV_layout)],
-                    self.buffer_align_bytes,
-                ]
-                # sdO is reused for sdV which in the non-MHA case needs float32
-                sdO: cute.struct.Align[
-                    cute.struct.MemRange[cute.Uint8, sdO_alloc_bytes],
-                    self.buffer_align_bytes,
-                ]
-                sdQaccum: cute.struct.Align[
-                    cute.struct.MemRange[self.dqaccum_dtype, cute.cosize(self.sdQaccum_layout)],
-                    self.buffer_align_bytes,
-                ]
-                sdS: cute.struct.Align[
-                    cute.struct.MemRange[self.ds_dtype, cute.cosize(self.sdSt_layout)],
-                    128,
-                ]
-                sLSE: cute.struct.Align[
-                    cute.struct.MemRange[self.lse_dtype, cute.cosize(self.sLSE_layout)],
-                    128,
-                ]
-                sStartEndRowIndices: cute.struct.Align[
-                    cute.struct.MemRange[self.startend_row_indices_dtype, cute.cosize(self.sStartEndRowIndices_layout)],
-                    64,
-                ]
+            # Smem tensors
+            # sQ is reused for sdK which in the non-MHA case needs float32
+            sQ: cute.struct.Align[
+                cute.struct.MemRange[cute.Uint8, sQ_alloc_bytes],
+                self.buffer_align_bytes,
+            ]
+            # self.sQ_layout S<3,4,3> o 0 o ((128,16),1,(4,2),2):((64,1),0,(16,8192),16384)
+            # 128 * 16 * 4 * 2 * 2 = 32768 * 2 = 65536
+            # 66560
+            sK: cute.struct.Align[
+                cute.struct.MemRange[self.k_dtype, cute.cosize(self.sK_layout)],
+                self.buffer_align_bytes,
+            ]
+            # self.sK_layout S<3,4,3> o 0 o ((128,16),1,(4,2)):((64,1),0,(16,8192))
+            # 128 * 16 * 4 * 2 = 16384 * 2 = 32768
+            # 99328
+            sV: cute.struct.Align[
+                cute.struct.MemRange[self.v_dtype, cute.cosize(self.sV_layout)],
+                self.buffer_align_bytes,
+            ]
+            # self.sV_layout S<3,4,3> o 0 o ((128,16),1,(4,2)):((64,1),0,(16,8192))
+            # 128 * 16 * 4 * 2 = 16384 * 2 = 32768
+            # 132096
+            # sdO is reused for sdV which in the non-MHA case needs float32
+            sdO: cute.struct.Align[
+                cute.struct.MemRange[cute.Uint8, sdO_alloc_bytes],
+                self.buffer_align_bytes,
+            ]
+            # self.sdO_layout S<3,4,3> o 0 o (((64,2),16),1,8,1):(((1,8192),64),0,1024,0)
+            # 64 * 2 * 16 * 8 = 16384 * 2 = 32768
+            # 164864
+            sdQaccum: cute.struct.Align[
+                cute.struct.MemRange[self.dqaccum_dtype, cute.cosize(self.sdQaccum_layout)],
+                self.buffer_align_bytes,
+            ]
+            # self.sdQaccum_layout (4096,2):(1,4096)
+            # 4096 * 2 = 8192 * 4 = 32768
+            # 197632
+            sdS: cute.struct.Align[
+                cute.struct.MemRange[self.ds_dtype, cute.cosize(self.sdSt_layout)],
+                128,
+            ]
+            # self.sdSt_layout S<3,4,3> o 0 o ((128,16),1,(4,2)):((64,1),0,(16,8192))
+            # 128 * 16 * 4 * 2 = 16384 * 2 = 32768
+            # 230400
+            sLSE: cute.struct.Align[
+                cute.struct.MemRange[self.lse_dtype, cute.cosize(self.sLSE_layout)],
+                128,
+            ]
+            # self.sLSE_layout (128,2):(1,128)
+            # 128 * 2 = 256 * 4 = 1024
+            # 231424
+            #sdPsum: cute.struct.Align[
+            #    cute.struct.MemRange[self.dpsum_dtype, cute.cosize(self.sdPsum_layout)],
+            #    128,
+            #]
+            # self.sdPsum_layout (128,1):(1,128)
+            # 128 * 1 = 128 * 4 = 512
+            # 232448
+            sStartEndRowIndices: cute.struct.Align[
+                cute.struct.MemRange[self.startend_row_indices_dtype, cute.cosize(self.sStartEndRowIndices_layout)],
+                64,
+            ]
+            # sStartEndRowIndices_layout (128,4):(1,128)
+            # 128 * 4 = 512 * 4 = 2048
+            # 234496
 
         self.shared_storage = SharedStorage
+        #print("self.shared_storage.size_in_bytes()", self.shared_storage.size_in_bytes())
 
         LOG2_E = math.log2(math.e)
         softmax_scale_log2 = softmax_scale * LOG2_E
-
         self.kernel(
             tma_tensor_Q,
-            tma_tensor_Qt,
             tma_tensor_K,
-            tma_tensor_Kt,
             tma_tensor_V,
             mLSE,
             mdPsum,
             tma_tensor_dO,
-            tma_tensor_dOt,
             mdV,
             mdK,
             mdQaccum,
@@ -916,19 +739,15 @@ class FlashAttentionBackwardSm100:
             mdK_semaphore,
             mdV_semaphore,
             tma_atom_Q,
-            tma_atom_Qt,
             tma_atom_K,
-            tma_atom_Kt,
             tma_atom_V,
             tma_atom_dO,
-            tma_atom_dOt,
             tma_atom_dV,
             tma_atom_dK,
             flashmask_info,
             self.sQ_layout,
             self.sQt_layout,
             self.sK_layout,
-            self.sKt_layout,
             self.sV_layout,
             self.sLSE_layout,
             self.sdPsum_layout,
@@ -936,10 +755,9 @@ class FlashAttentionBackwardSm100:
             self.sdOt_layout,
             self.sdSt_layout,
             self.sdS_layout,
-            self.sdS_xchg_layout,
+            self.sKt_layout,
             self.sdQaccum_layout,
-            self.sdK_layout,
-            self.sdV_layout,
+            self.sdKV_layout,
             self.tP_layout,
             self.tdS_layout,
             self.sStartEndRowIndices_layout,
@@ -965,14 +783,11 @@ class FlashAttentionBackwardSm100:
     def kernel(
         self,
         mQ: cute.Tensor,
-        mQt: Optional[cute.Tensor],
         mK: cute.Tensor,
-        mKt: Optional[cute.Tensor],
         mV: cute.Tensor,
         mLSE: cute.Tensor,
         mdPsum: cute.Tensor,
         mdO: cute.Tensor,
-        mdOt: Optional[cute.Tensor],
         mdV: cute.Tensor,
         mdK: cute.Tensor,
         mdQaccum: cute.Tensor,
@@ -982,19 +797,15 @@ class FlashAttentionBackwardSm100:
         mdK_semaphore: Optional[cute.Tensor],
         mdV_semaphore: Optional[cute.Tensor],
         tma_atom_Q: cute.CopyAtom,
-        tma_atom_Qt: Optional[cute.CopyAtom],
         tma_atom_K: cute.CopyAtom,
-        tma_atom_Kt: Optional[cute.CopyAtom],
         tma_atom_V: cute.CopyAtom,
         tma_atom_dO: cute.CopyAtom,
-        tma_atom_dOt: Optional[cute.CopyAtom],
         tma_atom_dV: Optional[cute.CopyAtom],
         tma_atom_dK: Optional[cute.CopyAtom],
         flashmask_info: Optional[FlashMaskInfo],
         sQ_layout: cute.ComposedLayout,
         sQt_layout: cute.ComposedLayout,
         sK_layout: cute.ComposedLayout,
-        sKt_layout: cute.ComposedLayout,
         sV_layout: cute.ComposedLayout,
         sLSE_layout: cute.Layout,
         sdPsum_layout: cute.Layout,
@@ -1002,10 +813,9 @@ class FlashAttentionBackwardSm100:
         sdOt_layout: cute.ComposedLayout,
         sdSt_layout: cute.ComposedLayout,
         sdS_layout: cute.ComposedLayout,
-        sdS_xchg_layout: cute.Layout,
+        sKt_layout: cute.ComposedLayout,
         sdQaccum_layout: cute.Layout,
-        sdK_layout: cute.ComposedLayout | cute.Layout,
-        sdV_layout: cute.ComposedLayout | cute.Layout,
+        sdKV_layout: cute.ComposedLayout | cute.Layout,
         tP_layout: cute.ComposedLayout,
         tdS_layout: cute.ComposedLayout,
         sStartEndRowIndices_layout: cute.Layout,
@@ -1020,10 +830,6 @@ class FlashAttentionBackwardSm100:
         tile_sched_params: ParamsBase,
     ):
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
-        bidx, _, _ = cute.arch.block_idx()
-        mma_tile_coord_v = bidx % self.cta_group_size
-        is_leader_cta = mma_tile_coord_v == 0
-        cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
 
         # Prefetch tma descriptor
         if warp_idx == self.load_warp_id:
@@ -1036,12 +842,6 @@ class FlashAttentionBackwardSm100:
                     cpasync.prefetch_descriptor(tma_atom_dV)
                 if const_expr(tma_atom_dK is not None):
                     cpasync.prefetch_descriptor(tma_atom_dK)
-                if const_expr(tma_atom_Qt is not None):
-                    cpasync.prefetch_descriptor(tma_atom_Qt)
-                if const_expr(tma_atom_Kt is not None):
-                    cpasync.prefetch_descriptor(tma_atom_Kt)
-                if const_expr(tma_atom_dOt is not None):
-                    cpasync.prefetch_descriptor(tma_atom_dOt)
 
         cluster_layout_vmnk = cute.tiled_divide(
             cute.make_layout(self.cluster_shape_mnk),
@@ -1057,20 +857,6 @@ class FlashAttentionBackwardSm100:
         dQ_cluster_full_mbar_ptr = storage.dQ_cluster_full_mbar_ptr.data_ptr()
         dQ_cluster_empty_mbar_ptr = storage.dQ_cluster_empty_mbar_ptr.data_ptr()
 
-        if const_expr(self.use_2cta_instrs):
-            dS_cluster_full_mbar_ptr = storage.dS_cluster_full_mbar_ptr
-            dS_cluster_empty_mbar_ptr = storage.dS_cluster_empty_mbar_ptr
-            dS_cluster_leader_mbar_ptr = storage.dS_cluster_leader_mbar_ptr
-            tmem_cluster_mbar_ptr = storage.tmem_cluster_mbar_ptr
-            dQaccum_empty_mbar_ptr = storage.dQaccum_empty_mbar_ptr
-        else:
-            dS_cluster_full_mbar_ptr = None
-            dS_cluster_empty_mbar_ptr = None
-            dS_cluster_leader_mbar_ptr = None
-            tmem_cluster_mbar_ptr = None
-            dQaccum_empty_mbar_ptr = None
-
-        # Barrier initialization
         if warp_idx == 1:
             cute.arch.mbarrier_init(
                 tmem_dealloc_mbar_ptr, cute.arch.WARP_SIZE * len(self.compute_warp_ids)
@@ -1078,22 +864,6 @@ class FlashAttentionBackwardSm100:
             cute.arch.mbarrier_init(
                 flashmask_loaded_mbar_ptr, cute.arch.WARP_SIZE
             )
-        if const_expr(self.use_2cta_instrs):
-            if warp_idx == 1:
-                cute.arch.mbarrier_init(
-                    tmem_cluster_mbar_ptr, cute.arch.WARP_SIZE * len([self.mma_warp_id])
-                )
-            if const_expr(self.tile_hdim == 192):
-                if warp_idx == 2:
-                    cute.arch.mbarrier_init(
-                        dQaccum_empty_mbar_ptr,
-                        len(self.reduce_warp_ids),
-                    )
-            if warp_idx == 4:
-                cute.arch.mbarrier_init(dS_cluster_full_mbar_ptr, 1)
-                cute.arch.mbarrier_init(dS_cluster_empty_mbar_ptr, 1)
-                cute.arch.mbarrier_init(dS_cluster_leader_mbar_ptr, 2)
-
         if const_expr(self.cluster_reduce_dQ):
             if warp_idx == 4:
                 for i in range(self.dQaccum_reduce_stage // 2):
@@ -1106,46 +876,41 @@ class FlashAttentionBackwardSm100:
         )
         # Only 1 thread per warp will signal
         pipeline_consumer_group_MMA_AsyncThread = cutlass.pipeline.CooperativeGroup(
-            cutlass.pipeline.Agent.Thread, len(self.compute_warp_ids) * self.cta_group_size
+            cutlass.pipeline.Agent.Thread, len(self.compute_warp_ids)
         )
         pipeline_S_P = cutlass.pipeline.PipelineUmmaAsync.create(
             num_stages=1,
             producer_group=pipeline_producer_group_MMA_AsyncThread,
             consumer_group=pipeline_consumer_group_MMA_AsyncThread,
             barrier_storage=storage.S_mbar_ptr.data_ptr(),
-            cta_layout_vmnk=cluster_layout_vmnk,
         )
         pipeline_dP = cutlass.pipeline.PipelineUmmaAsync.create(
             num_stages=1,
             producer_group=pipeline_producer_group_MMA_AsyncThread,
             consumer_group=pipeline_consumer_group_MMA_AsyncThread,
             barrier_storage=storage.dP_mbar_ptr.data_ptr(),
-            cta_layout_vmnk=cluster_layout_vmnk,
         )
         pipeline_dKV = cutlass.pipeline.PipelineUmmaAsync.create(
             num_stages=2,
             producer_group=pipeline_producer_group_MMA_AsyncThread,
             consumer_group=pipeline_consumer_group_MMA_AsyncThread,
             barrier_storage=storage.dKV_mbar_ptr.data_ptr(),
-            cta_layout_vmnk=cluster_layout_vmnk,
         )
         pipeline_consumer_group_MMA_AsyncThread_dQ = cutlass.pipeline.CooperativeGroup(
             cutlass.pipeline.Agent.Thread,
-            len(self.reduce_warp_ids) * self.cta_group_size,
+            len(self.reduce_warp_ids),
         )  # Compute
         pipeline_dQ = cutlass.pipeline.PipelineUmmaAsync.create(
             num_stages=1,
             producer_group=pipeline_producer_group_MMA_AsyncThread,
             consumer_group=pipeline_consumer_group_MMA_AsyncThread_dQ,
             barrier_storage=storage.dQ_mbar_ptr.data_ptr(),
-            cta_layout_vmnk=cluster_layout_vmnk,
         )
 
         # AsyncThread producers and UMMA consumers
         # Only 1 thread per warp will signal
         pipeline_PdS_producer_group = cutlass.pipeline.CooperativeGroup(
-            cutlass.pipeline.Agent.Thread,
-            len(self.compute_warp_ids) * self.cta_group_size,
+            cutlass.pipeline.Agent.Thread, len(self.compute_warp_ids)
         )  # Compute
         pipeline_PdS_consumer_group = cutlass.pipeline.CooperativeGroup(
             cutlass.pipeline.Agent.Thread, len([self.mma_warp_id])
@@ -1155,7 +920,6 @@ class FlashAttentionBackwardSm100:
             producer_group=pipeline_PdS_producer_group,
             consumer_group=pipeline_PdS_consumer_group,
             barrier_storage=storage.dS_mbar_ptr.data_ptr(),
-            cta_layout_vmnk=cluster_layout_vmnk,
         )
 
         # TMA producer and UMMA consumers
@@ -1178,7 +942,7 @@ class FlashAttentionBackwardSm100:
             consumer_group=pipeline_consumer_group_compute,
             tx_count=self.tma_copy_bytes["LSE"],
             # cta_layout_vmnk=cluster_layout_vmnk,
-            defer_sync=True,
+            # init_wait=False,
         )
         pipeline_dPsum = cutlass.pipeline.PipelineTmaAsync.create(
             barrier_storage=storage.dPsum_mbar_ptr.data_ptr(),
@@ -1187,7 +951,7 @@ class FlashAttentionBackwardSm100:
             consumer_group=pipeline_consumer_group_compute,
             tx_count=self.tma_copy_bytes["dPsum"],
             # cta_layout_vmnk=cluster_layout_vmnk,
-            defer_sync=True,
+            # init_wait=False,
         )
         pipeline_Q = pipeline.PipelineTmaUmma.create(
             barrier_storage=storage.Q_mbar_ptr.data_ptr(),
@@ -1196,34 +960,8 @@ class FlashAttentionBackwardSm100:
             consumer_group=pipeline_consumer_group,
             tx_count=self.tma_copy_bytes["Q"],
             cta_layout_vmnk=cluster_layout_vmnk,
-            defer_sync=True,
+            init_wait=False,
         )
-
-        if const_expr(self.use_2cta_instrs):
-            if const_expr(self.tile_hdim == 192):
-                pipeline_Qt = pipeline_Q
-            else:
-                pipeline_Qt = pipeline.PipelineTmaUmma.create(
-                    barrier_storage=storage.Qt_mbar_ptr.data_ptr(),
-                    num_stages=self.Q_stage,
-                    producer_group=pipeline_producer_group,
-                    consumer_group=pipeline_consumer_group,
-                    tx_count=self.tma_copy_bytes["Q"],
-                    cta_layout_vmnk=cluster_layout_vmnk,
-                    defer_sync=True,
-                )
-            pipeline_Kt = pipeline.PipelineTmaUmma.create(
-                barrier_storage=storage.Kt_mbar_ptr.data_ptr(),
-                num_stages=self.single_stage,
-                producer_group=pipeline_producer_group,
-                consumer_group=pipeline_consumer_group,
-                tx_count=self.tma_copy_bytes["K"],
-                cta_layout_vmnk=cluster_layout_vmnk,
-                defer_sync=True,
-            )
-        else:
-            pipeline_Qt = pipeline_Kt = pipeline_Q
-
         pipeline_dO = pipeline.PipelineTmaUmma.create(
             barrier_storage=storage.dO_mbar_ptr.data_ptr(),
             num_stages=self.dO_stage,
@@ -1231,69 +969,30 @@ class FlashAttentionBackwardSm100:
             consumer_group=pipeline_consumer_group,
             tx_count=self.tma_copy_bytes["dO"],
             cta_layout_vmnk=cluster_layout_vmnk,
-            defer_sync=False,
+            init_wait=True,
         )
 
         sQ = storage.sQ.get_tensor(sQ_layout.outer, swizzle=sQ_layout.inner, dtype=self.q_dtype)
-        if const_expr(self.use_2cta_instrs and self.tile_hdim <= 128):
-            sQt = storage.sQt.get_tensor(
-                sQt_layout.outer, swizzle=sQt_layout.inner, dtype=self.q_dtype
-            )
-        else:
-            sQt = cute.make_tensor(
-                cute.recast_ptr(sQ.iterator, sQt_layout.inner, dtype=self.q_dtype), sQt_layout.outer
-            )
+        sQt = cute.make_tensor(cute.recast_ptr(sQ.iterator, sQt_layout.inner, dtype=self.q_dtype), sQt_layout.outer)
         sK = storage.sK.get_tensor(sK_layout.outer, swizzle=sK_layout.inner)
-        if const_expr(self.use_2cta_instrs):
-            sKt = storage.sKt.get_tensor(sKt_layout.outer, swizzle=sKt_layout.inner)
-        else:
-            sKt = cute.make_tensor(cute.recast_ptr(sK.iterator, sKt_layout.inner), sKt_layout.outer)
+        sKt = cute.make_tensor(cute.recast_ptr(sK.iterator, sKt_layout.inner), sKt_layout.outer)
         sV = storage.sV.get_tensor(sV_layout.outer, swizzle=sV_layout.inner)
         sdSt = storage.sdS.get_tensor(sdSt_layout.outer, swizzle=sdSt_layout.inner)
         sdS = cute.make_tensor(cute.recast_ptr(sdSt.iterator, sdS_layout.inner), sdS_layout.outer)
-
-        if const_expr(self.use_2cta_instrs):
-            if const_expr(self.tile_hdim <= 128):
-                sdS_xchg = storage.sdS_xchg.get_tensor(sdS_xchg_layout)
-            else:
-                sdS_xchg = storage.sdQaccum.get_tensor(sdS_xchg_layout, dtype=self.ds_dtype)
-        else:
-            sdS_xchg = None
-
         sdO = storage.sdO.get_tensor(sdO_layout.outer, swizzle=sdO_layout.inner, dtype=self.do_dtype)
-        if const_expr(self.use_2cta_instrs and self.tile_hdim <= 128):
-            sdOt = storage.sdOt.get_tensor(
-                sdOt_layout.outer, swizzle=sdOt_layout.inner, dtype=self.do_dtype
-            )
-        else:
-            sdOt = cute.make_tensor(
-                cute.recast_ptr(sdO.iterator, sdOt_layout.inner, dtype=self.do_dtype),
-                sdOt_layout.outer,
-            )
-
+        sdOt = cute.make_tensor(cute.recast_ptr(sdO.iterator, sdOt_layout.inner, dtype=self.do_dtype), sdOt_layout.outer)
         sLSE = storage.sLSE.get_tensor(sLSE_layout)
         sdPsum = storage.sdPsum.get_tensor(sdPsum_layout)
-        if const_expr(self.use_2cta_instrs):
-            if const_expr(not self.dKV_postprocess):
-                sdV = storage.sV.get_tensor(
-                    sdV_layout.outer, swizzle=sdV_layout.inner, dtype=self.dv_dtype
-                )
-                sdK = storage.sK.get_tensor(
-                    sdK_layout.outer, swizzle=sdK_layout.inner, dtype=self.dk_dtype
-                )
-            else:
-                sdV = storage.sV.get_tensor(sdV_layout, dtype=self.dv_dtype)
-                sdK = storage.sK.get_tensor(sdK_layout, dtype=self.dk_dtype)
-        elif const_expr(not self.dKV_postprocess):
+        if const_expr(self.qhead_per_kvhead == 1):
             sdV = storage.sdO.get_tensor(
-                sdV_layout.outer, swizzle=sdV_layout.inner, dtype=self.dv_dtype
+                sdKV_layout.outer, swizzle=sdKV_layout.inner, dtype=self.dv_dtype
             )
             sdK = storage.sQ.get_tensor(
-                sdK_layout.outer, swizzle=sdK_layout.inner, dtype=self.dk_dtype
+                sdKV_layout.outer, swizzle=sdKV_layout.inner, dtype=self.dk_dtype
             )
         else:
-            sdV = storage.sdO.get_tensor(sdV_layout, dtype=self.dv_dtype)
-            sdK = storage.sQ.get_tensor(sdK_layout, dtype=self.dk_dtype)
+            sdV = storage.sdO.get_tensor(sdKV_layout, dtype=self.dv_dtype)
+            sdK = storage.sQ.get_tensor(sdKV_layout, dtype=self.dk_dtype)
 
         # Buffer sizing is guaranteed by max(...) in SharedStorage declarations
         # for both sQ (reused as sdK) and sdO (reused as sdV)
@@ -1306,18 +1005,18 @@ class FlashAttentionBackwardSm100:
         # request 512 columns of tmem, so we know that it starts at 0.
         tmem_ptr = cute.make_ptr(Float32, 0, mem_space=cute.AddressSpace.tmem, assumed_align=16)
         # S
-        thr_mma_S = tiled_mma_S.get_slice(mma_tile_coord_v)
+        thr_mma_S = tiled_mma_S.get_slice(0)
         Sacc_shape = thr_mma_S.partition_shape_C(self.mma_tiler_kq[:2])  # (M, N)
         tStS = thr_mma_S.make_fragment_C(Sacc_shape)
         # (MMA, MMA_M, MMA_N)
         tStS = cute.make_tensor(tmem_ptr + self.tmem_S_offset, tStS.layout)
         # dP
-        thr_mma_dP = tiled_mma_dP.get_slice(mma_tile_coord_v)
+        thr_mma_dP = tiled_mma_dP.get_slice(0)
         dPacc_shape = thr_mma_dP.partition_shape_C(self.mma_tiler_vdo[:2])
         tdPtdP = thr_mma_dP.make_fragment_C(dPacc_shape)
         tdPtdP = cute.make_tensor(tmem_ptr + self.tmem_dP_offset, tdPtdP.layout)
         # dV
-        thr_mma_dV = tiled_mma_dV.get_slice(mma_tile_coord_v)
+        thr_mma_dV = tiled_mma_dV.get_slice(0)
         dvacc_shape = thr_mma_dV.partition_shape_C(self.mma_tiler_pdo[:2])
         tdVtdV = thr_mma_dV.make_fragment_C(dvacc_shape)
         tdVtdV = cute.make_tensor(tmem_ptr + self.tmem_dV_offset, tdVtdV.layout)
@@ -1325,7 +1024,7 @@ class FlashAttentionBackwardSm100:
             cute.recast_ptr(tmem_ptr + self.tmem_P_offset, dtype=self.do_dtype), tP_layout.outer
         )
         # dK
-        thr_mma_dK = tiled_mma_dK.get_slice(mma_tile_coord_v)
+        thr_mma_dK = tiled_mma_dK.get_slice(0)
         dkacc_shape = thr_mma_dK.partition_shape_C(self.mma_tiler_dsq[:2])
         tdKtdK = thr_mma_dK.make_fragment_C(dkacc_shape)
         tdKtdK = cute.make_tensor(tmem_ptr + self.tmem_dK_offset, tdKtdK.layout)
@@ -1333,7 +1032,7 @@ class FlashAttentionBackwardSm100:
             cute.recast_ptr(tmem_ptr + self.tmem_dS_offset, dtype=self.ds_dtype), tdS_layout.outer
         )
         # dQ
-        thr_mma_dQ = tiled_mma_dQ.get_slice(mma_tile_coord_v)
+        thr_mma_dQ = tiled_mma_dQ.get_slice(0)
         dQacc_shape = thr_mma_dQ.partition_shape_C(self.mma_tiler_dsk[:2])
         tdQtdQ = thr_mma_dQ.make_fragment_C(dQacc_shape)
         tdQtdQ = cute.make_tensor(tmem_ptr + self.tmem_dQ_offset, tdQtdQ.layout)
@@ -1364,70 +1063,46 @@ class FlashAttentionBackwardSm100:
         AttentionMaskCls = partial(
             AttentionMask,
             self.tile_m,
-            self.tile_n * self.cta_group_size,
+            self.tile_n,
             swap_AB=True,
         )
 
         #  EMPTY
         # (15)
         if warp_idx == self.empty_warp_id:
-            cute.arch.setmaxregister_decrease(self.num_regs_empty)
+            cute.arch.warpgroup_reg_dealloc(self.num_regs_empty)
 
-        #  EPI / RELAY
+        #  EPI
         # (14)
-        if warp_idx == self.relay_warp_id:
-            if const_expr(self.use_2cta_instrs):
-                cute.arch.setmaxregister_decrease(self.num_regs_mma)
-                self.relay(
-                    dS_cluster_full_mbar_ptr,
-                    dS_cluster_empty_mbar_ptr,
-                    dS_cluster_leader_mbar_ptr,
-                    cluster_layout_vmnk,
-                    block_info,
-                    SeqlenInfoCls,
-                    TileSchedulerCls,
-                )
-            else:
-                cute.arch.setmaxregister_decrease(self.num_regs_empty)
+        if warp_idx == self.epi_warp_id:
+            # currently no-op, could use for tma store/reduce
+            cute.arch.warpgroup_reg_dealloc(self.num_regs_empty)
 
         #  LOAD
         # (13)
         if warp_idx == self.load_warp_id:
-            cute.arch.setmaxregister_decrease(self.num_regs_load)
+            cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
             self.load(
                 thr_mma_S,
                 thr_mma_dP,
                 thr_mma_dV,
-                thr_mma_dK,
-                thr_mma_dQ,
                 mQ,
                 mK,
-                mKt,
                 mV,
-                mdO,
-                mQt,
-                mdOt,
                 mLSE,
                 mdPsum,
+                mdO,
                 sQ,
                 sK,
-                sKt,
                 sV,
-                sdO,
-                sQt,
-                sdOt,
                 sLSE,
                 sdPsum,
+                sdO,
                 tma_atom_Q,
                 tma_atom_K,
-                tma_atom_Kt,
                 tma_atom_V,
                 tma_atom_dO,
-                tma_atom_Qt,
-                tma_atom_dOt,
                 pipeline_Q,
-                pipeline_Qt,
-                pipeline_Kt,
                 pipeline_dO,
                 pipeline_LSE,
                 pipeline_dPsum,
@@ -1439,18 +1114,18 @@ class FlashAttentionBackwardSm100:
                 sStartEndRowIndices,
                 sFM_max_min,
                 flashmask_loaded_mbar_ptr,
+                should_load_Q=True,
+                should_load_dO=True,
             )
 
         #  MMA
         # (12)
         if warp_idx == self.mma_warp_id:
-            cute.arch.setmaxregister_decrease(self.num_regs_mma)
+            cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
 
             # Alloc tmem buffer
             tmem_alloc_cols = Int32(self.tmem_alloc_cols)
-            cute.arch.alloc_tmem(
-                tmem_alloc_cols, storage.tmem_holding_buf, is_two_cta=self.use_2cta_instrs
-            )
+            cute.arch.alloc_tmem(tmem_alloc_cols, storage.tmem_holding_buf)
             cute.arch.sync_warp()
 
             self.mma(
@@ -1475,14 +1150,7 @@ class FlashAttentionBackwardSm100:
                 tdVtdV,
                 tdKtdK,
                 tdQtdQ,
-                dS_cluster_full_mbar_ptr,
-                dS_cluster_empty_mbar_ptr,
-                dS_cluster_leader_mbar_ptr,
-                dQaccum_empty_mbar_ptr,
-                pipeline_Q,
                 pipeline_Q.make_consumer(),
-                pipeline_Qt,
-                pipeline_Kt,
                 pipeline_dO,
                 pipeline_S_P,
                 pipeline_dS,
@@ -1495,49 +1163,40 @@ class FlashAttentionBackwardSm100:
                 flashmask_info,
                 sFM_max_min,
                 flashmask_loaded_mbar_ptr,
-                is_leader_cta,
             )
-            cute.arch.relinquish_tmem_alloc_permit(is_two_cta=self.use_2cta_instrs)
+            cute.arch.relinquish_tmem_alloc_permit()
             tmem_ptr = cute.arch.retrieve_tmem_ptr(
                 Float32, alignment=16, ptr_to_buffer_holding_addr=storage.tmem_holding_buf
             )
+
             cute.arch.mbarrier_wait(tmem_dealloc_mbar_ptr, 0)
-
-            if const_expr(self.use_2cta_instrs):
-                cute.arch.mbarrier_arrive(tmem_cluster_mbar_ptr, cta_rank_in_cluster ^ 1)
-                cute.arch.mbarrier_wait(tmem_cluster_mbar_ptr, 0)
-
             tmem_alloc_cols = Int32(self.tmem_alloc_cols)
-            cute.arch.dealloc_tmem(tmem_ptr, tmem_alloc_cols, is_two_cta=self.use_2cta_instrs)
+            cute.arch.dealloc_tmem(tmem_ptr, tmem_alloc_cols, is_two_cta=False)
 
         # Compute
         # (4, 5, 6, 7, 8, 9, 10, 11) --> 8 warps
         if warp_idx >= self.compute_warp_ids[0] and warp_idx <= self.compute_warp_ids[-1]:
-            cute.arch.setmaxregister_increase(self.num_regs_compute)  # 8 warps
+            cute.arch.warpgroup_reg_alloc(self.num_regs_compute)  # 8 warps
             self.compute_loop(
                 thr_mma_S,
                 thr_mma_dP,
                 thr_mma_dV,
                 thr_mma_dK,
                 tStS,
-                tdPtdP,
-                tdVtdV,
-                tdKtdK,
                 sLSE,
                 sdPsum,
+                tdVtdV,
+                tdKtdK,
                 mdV,
                 mdK,
                 sdS,
-                sdS_xchg,
+                tdPtdP,
                 pipeline_LSE,
                 pipeline_dPsum,
                 pipeline_S_P,
                 pipeline_dS,
                 pipeline_dKV,
                 pipeline_dP,
-                dS_cluster_empty_mbar_ptr,
-                dS_cluster_full_mbar_ptr,
-                dQaccum_empty_mbar_ptr,
                 softmax_scale,
                 softmax_scale_log2,
                 block_info,
@@ -1557,21 +1216,19 @@ class FlashAttentionBackwardSm100:
                 sStartEndRowIndices,
                 sFM_max_min,
                 flashmask_loaded_mbar_ptr,
-                is_leader_cta,
             )
             cute.arch.mbarrier_arrive(tmem_dealloc_mbar_ptr)
 
         # Reduce
         # (0, 1, 2, 3) - dQ
         if warp_idx >= self.reduce_warp_ids[0] and warp_idx <= self.reduce_warp_ids[-1]:
-            cute.arch.setmaxregister_increase(self.num_regs_reduce)
+            cute.arch.warpgroup_reg_alloc(self.num_regs_reduce)
             self.dQacc_reduce(
                 mdQaccum,
                 sdQaccum,
                 thr_mma_dQ,
                 tdQtdQ,
                 pipeline_dQ,
-                dQaccum_empty_mbar_ptr,
                 block_info,
                 SeqlenInfoCls,
                 TileSchedulerCls,
@@ -1579,50 +1236,9 @@ class FlashAttentionBackwardSm100:
                 flashmask_info,
                 sFM_max_min,
                 flashmask_loaded_mbar_ptr,
-                is_leader_cta,
             )
+
         return
-
-    @cute.jit
-    def relay(
-        self,
-        dS_cluster_full_mbar_ptr: cute.Pointer,
-        dS_cluster_empty_mbar_ptr: cute.Pointer,
-        dS_cluster_leader_mbar_ptr: cute.Pointer,
-        cluster_layout_vmnk: cute.Layout,
-        block_info: BlockInfo,
-        SeqlenInfoCls: Callable,
-        TileSchedulerCls: Callable,
-    ):
-        cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
-        dS_cluster_phase = Int32(0)
-
-        tile_scheduler = TileSchedulerCls()
-        work_tile = tile_scheduler.initial_work_tile_info()
-        while work_tile.is_valid_tile:
-            n_block, head_idx, batch_idx, _ = work_tile.tile_idx
-            seqlen = SeqlenInfoCls(batch_idx)
-            m_block_min, m_block_max = block_info.get_m_block_min_max(
-                seqlen, n_block // self.cluster_shape_mnk[0]
-            )
-            head_idx_kv = head_idx // self.qhead_per_kvhead
-
-            process_tile = m_block_min < m_block_max
-
-            if process_tile:
-                num_iters = m_block_max - m_block_min
-                for _ in cutlass.range(num_iters, unroll=1):
-                    # Wait for dS_xchg from peer CTA
-                    cute.arch.mbarrier_wait(dS_cluster_full_mbar_ptr, phase=dS_cluster_phase)
-
-                    # Arrive on MMA leader warp
-                    with cute.arch.elect_one():
-                        cute.arch.mbarrier_arrive(dS_cluster_leader_mbar_ptr, Int32(0))
-
-                    dS_cluster_phase ^= 1
-
-            tile_scheduler.advance_to_next_work()
-            work_tile = tile_scheduler.get_current_work()
 
     @cute.jit
     def load(
@@ -1630,36 +1246,23 @@ class FlashAttentionBackwardSm100:
         thr_mma_S: cute.core.ThrMma,
         thr_mma_dP: cute.core.ThrMma,
         thr_mma_dV: cute.core.ThrMma,
-        thr_mma_dK: cute.core.ThrMma,
-        thr_mma_dQ: cute.core.ThrMma,
         mQ: cute.Tensor,
         mK: cute.Tensor,
-        mKt: Optional[cute.Tensor],
         mV: cute.Tensor,
-        mdO: cute.Tensor,
-        mQt: Optional[cute.Tensor],
-        mdOt: Optional[cute.Tensor],
         mLSE: cute.Tensor,
         mdPsum: cute.Tensor,
+        mdO: cute.Tensor,
         sQ: cute.Tensor,
         sK: cute.Tensor,
-        sKt: cute.Tensor,
         sV: cute.Tensor,
-        sdO: cute.Tensor,
-        sQt: cute.Tensor,
-        sdOt: cute.Tensor,
         sLSE: cute.Tensor,
         sdPsum: cute.Tensor,
+        sdO: cute.Tensor,
         tma_atom_Q: cute.CopyAtom,
         tma_atom_K: cute.CopyAtom,
-        tma_atom_Kt: Optional[cute.CopyAtom],
         tma_atom_V: cute.CopyAtom,
         tma_atom_dO: cute.CopyAtom,
-        tma_atom_Qt: Optional[cute.CopyAtom],
-        tma_atom_dOt: Optional[cute.CopyAtom],
         pipeline_Q: PipelineAsync,
-        pipeline_Qt: PipelineAsync,
-        pipeline_Kt: PipelineAsync,
         pipeline_dO: PipelineAsync,
         pipeline_LSE: PipelineAsync,
         pipeline_dPsum: PipelineAsync,
@@ -1680,26 +1283,7 @@ class FlashAttentionBackwardSm100:
         producer_state_Q_LSE = cutlass.pipeline.make_pipeline_state(
             cutlass.pipeline.PipelineUserType.Producer, self.Q_stage
         )
-        producer_state_Qt = cutlass.pipeline.make_pipeline_state(
-            cutlass.pipeline.PipelineUserType.Producer, self.Q_stage
-        )
-        producer_state_Kt = cutlass.pipeline.make_pipeline_state(
-            cutlass.pipeline.PipelineUserType.Producer, self.single_stage
-        )
         producer_state_dO_dPsum = cutlass.pipeline.make_pipeline_state(
-            cutlass.pipeline.PipelineUserType.Producer, self.dO_stage
-        )
-        # States used in the hdim192 path
-        producer_state_Q_Qt = cutlass.pipeline.make_pipeline_state(
-            cutlass.pipeline.PipelineUserType.Producer, self.Q_stage
-        )
-        producer_state_O_Ot = cutlass.pipeline.make_pipeline_state(
-            cutlass.pipeline.PipelineUserType.Producer, self.dO_stage
-        )
-        producer_state_LSE = cutlass.pipeline.make_pipeline_state(
-            cutlass.pipeline.PipelineUserType.Producer, self.Q_stage
-        )
-        producer_state_dPsum = cutlass.pipeline.make_pipeline_state(
             cutlass.pipeline.PipelineUserType.Producer, self.dO_stage
         )
 
@@ -1721,8 +1305,6 @@ class FlashAttentionBackwardSm100:
                 seqlen, n_block // self.cluster_shape_mnk[0]
             )
             head_idx_kv = head_idx // self.qhead_per_kvhead
-            n_block_cta_group = n_block // self.cta_group_size
-
             mQ_cur = mQ[None, None, head_idx, batch_idx]
             mK_cur = mK[None, None, head_idx_kv, batch_idx]
             mV_cur = mV[None, None, head_idx_kv, batch_idx]
@@ -1730,32 +1312,19 @@ class FlashAttentionBackwardSm100:
             mLSE_cur = mLSE[None, head_idx, batch_idx]
             mPsum_cur = mdPsum[None, head_idx, batch_idx]
 
-            if const_expr(self.use_2cta_instrs):
-                mQt_cur = mQt[None, None, head_idx, batch_idx]
-                mdOt_cur = mdOt[None, None, head_idx, batch_idx]
-                mKt_cur = mKt[None, None, head_idx_kv, batch_idx]
-
-            gK = cute.local_tile(mK_cur, cute.select(self.mma_tiler_kq, mode=[0, 2]), (n_block_cta_group, 0))
+            gK = cute.local_tile(mK_cur, cute.select(self.mma_tiler_kq, mode=[0, 2]), (n_block, 0))
             tSgK = thr_mma_S.partition_A(gK)
-            gV = cute.local_tile(mV_cur, cute.select(self.mma_tiler_vdo, mode=[0, 2]), (n_block_cta_group, 0))
+            gV = cute.local_tile(mV_cur, cute.select(self.mma_tiler_vdo, mode=[0, 2]), (n_block, 0))
             tdPgV = thr_mma_dP.partition_A(gV)
             gQ = cute.local_tile(mQ_cur, cute.select(self.mma_tiler_kq, mode=[1, 2]), (None, 0))
             tSgQ = thr_mma_S.partition_B(gQ)
-            gLSE = cute.local_tile(mLSE_cur, (self.tile_m,), (None,))
-            gdPsum = cute.local_tile(mPsum_cur, (self.tile_m,), (None,))
+            gLSE = cute.local_tile(mLSE_cur, (self.tile_n,), (None,))
+            gdPsum = cute.local_tile(mPsum_cur, (self.tile_n,), (None,))
             gdO = cute.local_tile(mdO_cur, cute.select(self.mma_tiler_pdo, mode=[1, 2]), (0, None))
             tdPgdO = thr_mma_dV.partition_B(gdO)
 
-            load_dOt = load_Qt = load_Kt = None
-
-            a_cta_layout = cute.make_layout(cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape)
             load_K, _, _ = copy_utils.tma_get_copy_fn(
-                tma_atom_K,
-                block_in_cluster_coord_vmnk[2],
-                a_cta_layout,
-                tSgK,
-                sK,
-                single_stage=True,
+                tma_atom_K, 0, cute.make_layout(1), tSgK, sK, single_stage=True
             )
             load_V, _, _ = copy_utils.tma_get_copy_fn(
                 tma_atom_V,
@@ -1775,24 +1344,6 @@ class FlashAttentionBackwardSm100:
                 mcast_mask=q_do_mcast_mask,
             )
             load_Q = copy_utils.tma_producer_copy_fn(load_Q, pipeline_Q)
-
-            # (2) dP = V @ dO.T
-            if const_expr(tma_atom_dOt is not None):
-                gdOt = cute.local_tile(
-                    mdOt_cur, cute.select(self.mma_tiler_vdo, mode=[1, 2]), (None, 0)
-                )
-                tdPgdOt = thr_mma_dP.partition_B(gdOt)
-                load_dOt, _, _ = copy_utils.tma_get_copy_fn(
-                    tma_atom_dOt,
-                    cta_coord=block_in_cluster_coord_vmnk[1],
-                    cta_layout=b_cta_layout,
-                    src_tensor=tdPgdOt,
-                    dst_tensor=sdOt,
-                    mcast_mask=q_do_mcast_mask,
-                )
-                load_dOt = copy_utils.tma_producer_copy_fn(load_dOt, pipeline_dO)
-
-            # (3) dV += P.T @ dO
             load_dO, _, _ = copy_utils.tma_get_copy_fn(
                 tma_atom_dO,
                 cta_coord=block_in_cluster_coord_vmnk[1],
@@ -1802,37 +1353,6 @@ class FlashAttentionBackwardSm100:
                 mcast_mask=q_do_mcast_mask,
             )
             load_dO = copy_utils.tma_producer_copy_fn(load_dO, pipeline_dO)
-
-            # (4) dK += dS.T @ Q (2-CTA: needs separate Qt load)
-            if const_expr(tma_atom_Qt is not None):
-                gQt = cute.local_tile(
-                    mQt_cur, cute.select(self.mma_tiler_dsq, mode=[1, 2]), (0, None)
-                )
-                tdKgQt = thr_mma_dK.partition_B(gQt)
-                load_Qt, _, _ = copy_utils.tma_get_copy_fn(
-                    tma_atom_Qt,
-                    cta_coord=block_in_cluster_coord_vmnk[1],
-                    cta_layout=b_cta_layout,
-                    src_tensor=tdKgQt,
-                    dst_tensor=sQt,
-                    mcast_mask=q_do_mcast_mask,
-                )
-                load_Qt = copy_utils.tma_producer_copy_fn(load_Qt, pipeline_Qt)
-
-            # (5) dQ = dS @ K
-            if const_expr(self.use_2cta_instrs):
-                gKt = cute.local_tile(
-                    mKt_cur, cute.select(self.mma_tiler_dsk, mode=[1, 2]), (0, n_block_cta_group)
-                )
-                tdQgK = thr_mma_dQ.partition_B(gKt)
-                load_Kt, _, _ = copy_utils.tma_get_copy_fn(
-                    tma_atom_Kt,
-                    block_in_cluster_coord_vmnk[1],
-                    b_cta_layout,
-                    tdQgK,
-                    sKt,
-                    single_stage=True,
-                )
             copy_atom_stats = cute.make_copy_atom(cpasync.CopyBulkG2SOp(), Float32)
             copy_stats = partial(cute.copy, copy_atom_stats)
             # copy_atom_stats = cute.make_copy_atom(cpasync.CopyBulkG2SMulticastOp(), Float32)
@@ -1843,7 +1363,8 @@ class FlashAttentionBackwardSm100:
             # copy_stats = partial(cute.copy, copy_atom_stats, mcast_mask=q_do_mcast_mask)
 
 
-            load_step_kwargs = dict(
+            load_step = partial(
+                self.load_step,
                 gLSE=gLSE,
                 sLSE=sLSE,
                 gdPsum=gdPsum,
@@ -1857,253 +1378,9 @@ class FlashAttentionBackwardSm100:
                 copy_stats=copy_stats,
                 should_load_Q=should_load_Q,
                 should_load_dO=should_load_dO,
-                pipeline_Qt=pipeline_Qt,
-                pipeline_Kt=pipeline_Kt,
-                load_Qt=load_Qt,
-                load_dOt=load_dOt,
             )
-            load_step = partial(self.load_step, **load_step_kwargs)
 
-            if const_expr(self.use_2cta_instrs):
-                # In 2CTA mode, load FM data but do NOT skip blocks.
-                # Both CTAs in the cluster have different n_blocks with different
-                # flashmask boundaries, but share pipeline stages. All warps on
-                # both CTAs must process the same number of blocks to stay in sync.
-                if const_expr(self.enable_flashmask):
-                    self.load_fm(flashmask_info, sStartEndRowIndices, sFM_max_min, seqlen, mQ.shape[2], n_block, head_idx, batch_idx)
-                    cute.arch.mbarrier_arrive(flashmask_loaded_mbar_ptr)
-                    if tidx == 0 and self.debug_print:
-                        cute.printf('LOAD FM: cta_rank=%d, n_block=%d, m_block_min=%d, m_block_max=%d, total_blocks=%d (no skip)', cute.arch.block_idx_in_cluster(), n_block, m_block_min, m_block_max, m_block_max - m_block_min)
-
-                if const_expr(self.tile_hdim == 192):
-                    #### Prologue ####
-                    assert should_load_Q and should_load_dO
-                    # K & Q (for S)
-                    pipeline_Q.producer_acquire(
-                        producer_state_Q_Qt,
-                        extra_tx_count=self.tma_copy_bytes["K"],
-                    )
-                    load_K(tma_bar_ptr=pipeline_Q.producer_get_barrier(producer_state_Q_Qt))
-                    load_Q(m_block_min, producer_state=producer_state_Q_Qt)
-                    pipeline_Q.producer_commit(producer_state_Q_Qt)
-                    producer_state_Q_Qt.advance()
-                    # LSE
-                    pipeline_LSE.producer_acquire(producer_state_LSE)
-                    with cute.arch.elect_one():
-                        copy_stats(
-                            gLSE[None, m_block_min],
-                            sLSE[None, producer_state_LSE.index],
-                            mbar_ptr=pipeline_LSE.producer_get_barrier(producer_state_LSE),
-                        )
-                    producer_state_LSE.advance()
-
-                    # dOt + V, for dP.T = V @ dO.T
-                    pipeline_dO.producer_acquire(
-                        producer_state_O_Ot,
-                        extra_tx_count=self.tma_copy_bytes["V"],
-                    )
-                    load_V(tma_bar_ptr=pipeline_dO.producer_get_barrier(producer_state_O_Ot))
-                    load_dOt(m_block_min, producer_state=producer_state_O_Ot)
-                    pipeline_dO.producer_commit(producer_state_O_Ot)
-                    producer_state_O_Ot.advance()
-                    # dPsum
-                    pipeline_dPsum.producer_acquire(producer_state_dPsum)
-                    with cute.arch.elect_one():
-                        copy_stats(
-                            gdPsum[None, m_block_min],
-                            sdPsum[None, producer_state_dPsum.index],
-                            mbar_ptr=pipeline_dPsum.producer_get_barrier(producer_state_dPsum),
-                        )
-                    producer_state_dPsum.advance()
-
-                    # Qt, for dK = dS.T @ Q
-                    pipeline_Qt.producer_acquire(
-                        producer_state_Q_Qt,
-                        extra_tx_count=self.tma_copy_bytes["K"],
-                    )
-                    load_Qt(m_block_min, producer_state=producer_state_Q_Qt)
-                    load_Kt(tma_bar_ptr=pipeline_Qt.producer_get_barrier(producer_state_Q_Qt))
-                    pipeline_Qt.producer_commit(producer_state_Q_Qt)
-                    producer_state_Q_Qt.advance()
-
-                    # dO, for dV = P.T @ dO
-                    pipeline_dO.producer_acquire(producer_state_O_Ot)
-                    load_dO(m_block_min, producer_state=producer_state_O_Ot)
-                    pipeline_dO.producer_commit(producer_state_O_Ot)
-                    producer_state_O_Ot.advance()
-
-                    #### Mainloop ####
-                    # 2CTA hdim192: [lse | Q | dOt | dPsum | Qt | dO]
-                    for m_block in cutlass.range(m_block_min + 1, m_block_max, unroll=1):
-                        # LSE
-                        pipeline_LSE.producer_acquire(producer_state_LSE)
-                        with cute.arch.elect_one():
-                            copy_stats(
-                                gLSE[None, m_block],
-                                sLSE[None, producer_state_LSE.index],
-                                mbar_ptr=pipeline_LSE.producer_get_barrier(producer_state_LSE),
-                            )
-                        producer_state_LSE.advance()
-
-                        # Q
-                        pipeline_Q.producer_acquire(producer_state_Q_Qt)
-                        load_Q(m_block, producer_state=producer_state_Q_Qt)
-                        pipeline_Q.producer_commit(producer_state_Q_Qt)
-                        producer_state_Q_Qt.advance()
-
-                        # dPsum
-                        pipeline_dPsum.producer_acquire(producer_state_dPsum)
-                        with cute.arch.elect_one():
-                            copy_stats(
-                                gdPsum[None, m_block],
-                                sdPsum[None, producer_state_dPsum.index],
-                                mbar_ptr=pipeline_dPsum.producer_get_barrier(
-                                    producer_state_dPsum
-                                ),
-                            )
-                        producer_state_dPsum.advance()
-
-                        # dOt, for dP.T = V @ dO.T
-                        pipeline_dO.producer_acquire(producer_state_O_Ot)
-                        load_dOt(m_block, producer_state=producer_state_O_Ot)
-                        pipeline_dO.producer_commit(producer_state_O_Ot)
-                        producer_state_O_Ot.advance()
-
-                        # Qt, for dK = dS.T @ Q
-                        pipeline_Qt.producer_acquire(producer_state_Q_Qt)
-                        load_Qt(m_block, producer_state=producer_state_Q_Qt)
-                        pipeline_Qt.producer_commit(producer_state_Q_Qt)
-                        producer_state_Q_Qt.advance()
-
-                        # dO, for dV = P.T @ dO
-                        pipeline_dO.producer_acquire(producer_state_O_Ot)
-                        load_dO(m_block, producer_state=producer_state_O_Ot)
-                        pipeline_dO.producer_commit(producer_state_O_Ot)
-                        producer_state_O_Ot.advance()
-
-                    #### Tail ####
-                    pipeline_Q.producer_tail(producer_state_Q_Qt)
-                    pipeline_LSE.producer_tail(producer_state_LSE)
-                    pipeline_dO.producer_tail(producer_state_O_Ot)
-                    pipeline_dPsum.producer_tail(producer_state_dPsum)
-
-                else:
-                    #### Prologue (2CTA hdim128) ####
-                    # K & Q (for S)
-                    pipeline_Q.producer_acquire(
-                        producer_state_Q_LSE, extra_tx_count=self.tma_copy_bytes["K"]
-                    )
-                    load_K(tma_bar_ptr=pipeline_Q.producer_get_barrier(producer_state_Q_LSE))
-                    load_Q(m_block_min, producer_state=producer_state_Q_LSE)
-                    pipeline_Q.producer_commit(producer_state_Q_LSE)
-
-                    # LSE
-                    pipeline_LSE.producer_acquire(producer_state_Q_LSE)
-                    with cute.arch.elect_one():
-                        copy_stats(
-                            gLSE[None, m_block_min],
-                            sLSE[None, producer_state_Q_LSE.index],
-                            mbar_ptr=pipeline_LSE.producer_get_barrier(producer_state_Q_LSE),
-                        )
-                    producer_state_Q_LSE.advance()
-
-                    # V + dO + dOt (for dP and dV)
-                    pipeline_dO.producer_acquire(
-                        producer_state_dO_dPsum,
-                        extra_tx_count=self.tma_copy_bytes["V"] + self.tma_copy_bytes["dO"]
-                        if const_expr(tma_atom_dOt is not None)
-                        else self.tma_copy_bytes["V"],
-                    )
-                    load_V(
-                        tma_bar_ptr=pipeline_dO.producer_get_barrier(producer_state_dO_dPsum)
-                    )
-                    load_dO(m_block_min, producer_state=producer_state_dO_dPsum)
-                    if const_expr(tma_atom_dOt is not None):
-                        load_dOt(m_block_min, producer_state=producer_state_dO_dPsum)
-                    pipeline_dO.producer_commit(producer_state_dO_dPsum)
-
-                    # dPsum
-                    pipeline_dPsum.producer_acquire(producer_state_dO_dPsum)
-                    with cute.arch.elect_one():
-                        copy_stats(
-                            gdPsum[None, m_block_min],
-                            sdPsum[None, producer_state_dO_dPsum.index],
-                            mbar_ptr=pipeline_dPsum.producer_get_barrier(
-                                producer_state_dO_dPsum
-                            ),
-                        )
-                    producer_state_dO_dPsum.advance()
-
-                    # Kt (loaded once, between prologue and main loop)
-                    pipeline_Kt.producer_acquire(producer_state_Kt)
-                    load_Kt(tma_bar_ptr=pipeline_Kt.producer_get_barrier(producer_state_Kt))
-                    pipeline_Kt.producer_commit(producer_state_Kt)
-                    producer_state_Kt.advance()
-
-                    #### Mainloop (2CTA hdim128) ####
-                    for m_block in cutlass.range(m_block_min + 1, m_block_max, unroll=1):
-                        if const_expr(tma_atom_Qt is not None):
-                            pipeline_Qt.producer_acquire(producer_state_Qt)
-                            load_Qt(m_block - 1, producer_state=producer_state_Qt)
-                            pipeline_Qt.producer_commit(producer_state_Qt)
-                            producer_state_Qt.advance()
-
-                        # Q (for S)
-                        pipeline_Q.producer_acquire(producer_state_Q_LSE)
-                        load_Q(m_block, producer_state=producer_state_Q_LSE)
-                        pipeline_Q.producer_commit(producer_state_Q_LSE)
-
-                        # LSE
-                        pipeline_LSE.producer_acquire(producer_state_Q_LSE)
-                        with cute.arch.elect_one():
-                            copy_stats(
-                                gLSE[None, m_block],
-                                sLSE[None, producer_state_Q_LSE.index],
-                                mbar_ptr=pipeline_LSE.producer_get_barrier(
-                                    producer_state_Q_LSE
-                                ),
-                            )
-                        producer_state_Q_LSE.advance()
-
-                        # dO + dOt
-                        pipeline_dO.producer_acquire(
-                            producer_state_dO_dPsum,
-                            extra_tx_count=self.tma_copy_bytes["dO"]
-                            if const_expr(tma_atom_dOt is not None)
-                            else 0,
-                        )
-                        load_dO(m_block, producer_state=producer_state_dO_dPsum)
-                        if const_expr(tma_atom_dOt is not None):
-                            load_dOt(m_block, producer_state=producer_state_dO_dPsum)
-                        pipeline_dO.producer_commit(producer_state_dO_dPsum)
-
-                        # dPsum
-                        pipeline_dPsum.producer_acquire(producer_state_dO_dPsum)
-                        with cute.arch.elect_one():
-                            copy_stats(
-                                gdPsum[None, m_block],
-                                sdPsum[None, producer_state_dO_dPsum.index],
-                                mbar_ptr=pipeline_dPsum.producer_get_barrier(
-                                    producer_state_dO_dPsum
-                                ),
-                            )
-                        producer_state_dO_dPsum.advance()
-
-                    #### Tail (2CTA hdim128) ####
-                    if const_expr(tma_atom_Qt is not None):
-                        pipeline_Qt.producer_acquire(producer_state_Qt)
-                        load_Qt(m_block_max - 1, producer_state=producer_state_Qt)
-                        pipeline_Qt.producer_commit(producer_state_Qt)
-                        producer_state_Qt.advance()
-
-                    pipeline_Q.producer_tail(producer_state_Q_LSE.clone())
-                    pipeline_LSE.producer_tail(producer_state_Q_LSE)
-                    if const_expr(tma_atom_Qt is not None):
-                        pipeline_Qt.producer_tail(producer_state_Qt)
-                    pipeline_dO.producer_tail(producer_state_dO_dPsum.clone())
-                    pipeline_dPsum.producer_tail(producer_state_dO_dPsum)
-
-            elif const_expr(self.enable_flashmask):
+            if const_expr(self.enable_flashmask):
                 self.load_fm(flashmask_info, sStartEndRowIndices, sFM_max_min, seqlen, mQ.shape[2], n_block, head_idx, batch_idx)
                 cute.arch.mbarrier_arrive(flashmask_loaded_mbar_ptr)
 
@@ -2134,13 +1411,6 @@ class FlashAttentionBackwardSm100:
                     load_K(tma_bar_ptr=pipeline_Q.producer_get_barrier(producer_state_Q_LSE))
                     load_Q(prefetch_m_block, producer_state=producer_state_Q_LSE)
                     pipeline_Q.producer_commit(producer_state_Q_LSE)
-
-                    if const_expr(self.use_2cta_instrs):
-                        pipeline_Kt.producer_acquire(producer_state_Kt)
-                        load_Kt(tma_bar_ptr=pipeline_Kt.producer_get_barrier(producer_state_Kt))
-                        pipeline_Kt.producer_commit(producer_state_Kt)
-                        producer_state_Kt.advance()
-
                     # LSE
                     pipeline_LSE.producer_acquire(producer_state_Q_LSE)
                     with cute.arch.elect_one():
@@ -2155,15 +1425,10 @@ class FlashAttentionBackwardSm100:
                         cute.printf('n_block: %d, before load_step prefetch_m_block: %d', n_block, prefetch_m_block)
                     # V & dO
                     pipeline_dO.producer_acquire(
-                        producer_state_dO_dPsum,
-                        extra_tx_count=self.tma_copy_bytes["V"] + self.tma_copy_bytes["dO"]
-                        if const_expr(tma_atom_dOt is not None)
-                        else self.tma_copy_bytes["V"],
+                        producer_state_dO_dPsum, extra_tx_count=self.tma_copy_bytes["V"]
                     )
                     load_V(tma_bar_ptr=pipeline_dO.producer_get_barrier(producer_state_dO_dPsum))
                     load_dO(prefetch_m_block, producer_state=producer_state_dO_dPsum)
-                    if const_expr(tma_atom_dOt is not None):
-                        load_dOt(prefetch_m_block, producer_state=producer_state_dO_dPsum)
                     pipeline_dO.producer_commit(producer_state_dO_dPsum)
                     # dPsum
                     pipeline_dPsum.producer_acquire(producer_state_dO_dPsum)
@@ -2177,7 +1442,7 @@ class FlashAttentionBackwardSm100:
                     if tidx == 0 and self.debug_print:
                         cute.printf('n_block: %d, after load_step prefetch_m_block: %d', n_block, prefetch_m_block)
 
-                if const_expr(self.use_2cta_instrs) or not zero_block:
+                if not zero_block:
                     loop_start = m_block_min
                     loop_end = m_block_max
                     if const_expr(not self.is_causal):
@@ -2188,13 +1453,10 @@ class FlashAttentionBackwardSm100:
                             for m_block in cutlass.range(loop_start + 1, loop_end, unroll=1):
                                 if tidx == 0 and self.debug_print:
                                     cute.printf('n_block: %d, before load_step 0 ~ UTS: %d', n_block, m_block)
-                                producer_state_Q_LSE, producer_state_dO_dPsum, producer_state_Qt, producer_state_Kt = load_step(
+                                producer_state_Q_LSE, producer_state_dO_dPsum = load_step(
                                     m_block,
                                     producer_state_Q_LSE=producer_state_Q_LSE,
                                     producer_state_dO_dPsum=producer_state_dO_dPsum,
-                                    producer_state_Qt=producer_state_Qt,
-                                    producer_state_Kt=producer_state_Kt,
-                                    m_block_prev=m_block - 1,
                                 )
                                 if tidx == 0 and self.debug_print:
                                     cute.printf('n_block: %d, after load_step 0 ~ UTS: %d', n_block, m_block)
@@ -2209,13 +1471,10 @@ class FlashAttentionBackwardSm100:
                     for m_block in cutlass.range(loop_start + 1, loop_end, unroll=1):
                         if tidx == 0 and self.debug_print:
                             cute.printf('n_block: %d, before load_step UTE ~ LTS: %d', n_block, m_block)
-                        producer_state_Q_LSE, producer_state_dO_dPsum, producer_state_Qt, producer_state_Kt = load_step(
+                        producer_state_Q_LSE, producer_state_dO_dPsum = load_step(
                             m_block,
                             producer_state_Q_LSE=producer_state_Q_LSE,
                             producer_state_dO_dPsum=producer_state_dO_dPsum,
-                            producer_state_Qt=producer_state_Qt,
-                            producer_state_Kt=producer_state_Kt,
-                            m_block_prev=m_block - 1,
                         )
                         if tidx == 0 and self.debug_print:
                             cute.printf('n_block: %d, after load_step UTE ~ LTS: %d', n_block, m_block)
@@ -2235,30 +1494,19 @@ class FlashAttentionBackwardSm100:
                         for m_block in cutlass.range(loop_start + 1, loop_end, unroll=1):
                             if tidx == 0 and self.debug_print:
                                 cute.printf('n_block: %d, before load_step LTE ~ seqlen_q: %d', n_block, m_block)
-                            producer_state_Q_LSE, producer_state_dO_dPsum, producer_state_Qt, producer_state_Kt = load_step(
+                            producer_state_Q_LSE, producer_state_dO_dPsum = load_step(
                                 m_block,
                                 producer_state_Q_LSE=producer_state_Q_LSE,
                                 producer_state_dO_dPsum=producer_state_dO_dPsum,
-                                producer_state_Qt=producer_state_Qt,
-                                producer_state_Kt=producer_state_Kt,
-                                m_block_prev=m_block - 1,
                             )
                             if tidx == 0 and self.debug_print:
                                 cute.printf('n_block: %d, after load_step LTE ~ seqlen_q: %d', n_block, m_block)
 
                     if not zero_block and should_load_Q:
-                        if const_expr(tma_atom_Qt is not None):
-                            pipeline_Qt.producer_acquire(producer_state_Qt)
-                            load_Qt(m_block_max - 1, producer_state=producer_state_Qt)
-                            pipeline_Qt.producer_commit(producer_state_Qt)
-                            producer_state_Qt.advance()
-
                         pipeline_Q.producer_tail(
                             producer_state_Q_LSE.clone()
                         )  # will hang if we don't clone
                         pipeline_LSE.producer_tail(producer_state_Q_LSE)
-                        if const_expr(tma_atom_Qt is not None):
-                            pipeline_Qt.producer_tail(producer_state_Qt.clone())
                     if not zero_block and should_load_dO:
                         pipeline_dO.producer_tail(producer_state_dO_dPsum.clone())
                         pipeline_dPsum.producer_tail(producer_state_dO_dPsum)
@@ -2273,7 +1521,6 @@ class FlashAttentionBackwardSm100:
                     load_K(tma_bar_ptr=pipeline_Q.producer_get_barrier(producer_state_Q_LSE))
                     load_Q(m_block_min, producer_state=producer_state_Q_LSE)
                     pipeline_Q.producer_commit(producer_state_Q_LSE)
-
                     # LSE
                     pipeline_LSE.producer_acquire(producer_state_Q_LSE)
                     with cute.arch.elect_one():
@@ -2286,15 +1533,10 @@ class FlashAttentionBackwardSm100:
                 if const_expr(should_load_dO):
                     # V & dO
                     pipeline_dO.producer_acquire(
-                        producer_state_dO_dPsum,
-                        extra_tx_count=self.tma_copy_bytes["V"] + self.tma_copy_bytes["dO"]
-                        if const_expr(tma_atom_dOt is not None)
-                        else self.tma_copy_bytes["V"],
+                        producer_state_dO_dPsum, extra_tx_count=self.tma_copy_bytes["V"]
                     )
                     load_V(tma_bar_ptr=pipeline_dO.producer_get_barrier(producer_state_dO_dPsum))
                     load_dO(m_block_min, producer_state=producer_state_dO_dPsum)
-                    if const_expr(tma_atom_dOt is not None):
-                        load_dOt(m_block_min, producer_state=producer_state_dO_dPsum)
                     pipeline_dO.producer_commit(producer_state_dO_dPsum)
                     # dPsum
                     pipeline_dPsum.producer_acquire(producer_state_dO_dPsum)
@@ -2306,35 +1548,18 @@ class FlashAttentionBackwardSm100:
                         )
                     producer_state_dO_dPsum.advance()
 
-                if const_expr(self.use_2cta_instrs):
-                    pipeline_Kt.producer_acquire(producer_state_Kt)
-                    load_Kt(tma_bar_ptr=pipeline_Kt.producer_get_barrier(producer_state_Kt))
-                    pipeline_Kt.producer_commit(producer_state_Kt)
-                    producer_state_Kt.advance()
-
                 for m_block in cutlass.range(m_block_min + 1, m_block_max, unroll=1):
-                    producer_state_Q_LSE, producer_state_dO_dPsum, producer_state_Qt, producer_state_Kt = load_step(
+                    producer_state_Q_LSE, producer_state_dO_dPsum = load_step(
                         m_block,
                         producer_state_Q_LSE=producer_state_Q_LSE,
                         producer_state_dO_dPsum=producer_state_dO_dPsum,
-                        producer_state_Qt=producer_state_Qt,
-                        producer_state_Kt=producer_state_Kt,
-                        m_block_prev=m_block - 1,
                     )
 
                 if const_expr(should_load_Q):
-                    if const_expr(tma_atom_Qt is not None):
-                        pipeline_Qt.producer_acquire(producer_state_Qt)
-                        load_Qt(m_block_max - 1, producer_state=producer_state_Qt)
-                        pipeline_Qt.producer_commit(producer_state_Qt)
-                        producer_state_Qt.advance()
-
                     pipeline_Q.producer_tail(
                         producer_state_Q_LSE.clone()
                     )  # will hang if we don't clone
                     pipeline_LSE.producer_tail(producer_state_Q_LSE)
-                    if const_expr(tma_atom_Qt is not None):
-                        pipeline_Qt.producer_tail(producer_state_Qt)
                 if const_expr(should_load_dO):
                     pipeline_dO.producer_tail(producer_state_dO_dPsum.clone())
                     pipeline_dPsum.producer_tail(producer_state_dO_dPsum)
@@ -2364,21 +1589,8 @@ class FlashAttentionBackwardSm100:
         copy_stats: Callable,
         should_load_Q: bool = True,
         should_load_dO: bool = True,
-        pipeline_Qt: PipelineAsync = None,
-        pipeline_Kt: PipelineAsync = None,
-        producer_state_Qt: cutlass.pipeline.PipelineState = None,
-        producer_state_Kt: cutlass.pipeline.PipelineState = None,
-        load_Qt: Callable = None,
-        load_dOt: Callable = None,
-        m_block_prev: cute.Int32 = None,
     ):
         if const_expr(should_load_Q):
-            if const_expr(load_Qt is not None):
-                pipeline_Qt.producer_acquire(producer_state_Qt)
-                load_Qt(m_block_prev, producer_state=producer_state_Qt)
-                pipeline_Qt.producer_commit(producer_state_Qt)
-                producer_state_Qt.advance()
-
             # Q
             pipeline_Q.producer_acquire(producer_state_Q_LSE)
             load_Q(m_block, producer_state=producer_state_Q_LSE)
@@ -2392,18 +1604,10 @@ class FlashAttentionBackwardSm100:
                     mbar_ptr=pipeline_LSE.producer_get_barrier(producer_state_Q_LSE),
                 )
             producer_state_Q_LSE.advance()
-
         if const_expr(should_load_dO):
             # dO
-            pipeline_dO.producer_acquire(
-                producer_state_dO_dPsum,
-                extra_tx_count=self.tma_copy_bytes["dO"]
-                if const_expr(load_dOt is not None)
-                else 0,
-            )
+            pipeline_dO.producer_acquire(producer_state_dO_dPsum)
             load_dO(m_block, producer_state=producer_state_dO_dPsum)
-            if const_expr(load_dOt is not None):
-                load_dOt(m_block, producer_state=producer_state_dO_dPsum)
             pipeline_dO.producer_commit(producer_state_dO_dPsum)
             # dPsum
             pipeline_dPsum.producer_acquire(producer_state_dO_dPsum)
@@ -2415,7 +1619,7 @@ class FlashAttentionBackwardSm100:
                 )
             producer_state_dO_dPsum.advance()
 
-        return producer_state_Q_LSE, producer_state_dO_dPsum, producer_state_Qt, producer_state_Kt
+        return producer_state_Q_LSE, producer_state_dO_dPsum
 
     @cute.jit
     def load_fm(
@@ -2505,14 +1709,7 @@ class FlashAttentionBackwardSm100:
         tdVtdV: cute.Tensor,
         tdKtdK: cute.Tensor,
         tdQtdQ: cute.Tensor,
-        dS_cluster_full_mbar_ptr: cute.Pointer,
-        dS_cluster_empty_mbar_ptr: cute.Pointer,
-        dS_cluster_leader_mbar_ptr: Optional[cute.Pointer],
-        dQaccum_empty_mbar_ptr: Optional[cute.Pointer],
-        pipeline_Q: PipelineAsync,
         pipeline_Q_consumer: PipelineConsumer,
-        pipeline_Qt: PipelineAsync,
-        pipeline_Kt: PipelineAsync,
         pipeline_dO: PipelineAsync,
         pipeline_S_P: PipelineAsync,
         pipeline_dS: PipelineAsync,
@@ -2525,7 +1722,6 @@ class FlashAttentionBackwardSm100:
         flashmask_info: FlashMaskInfo,
         sFM_max_min: cute.Tensor,
         flashmask_loaded_mbar_ptr: cute.Pointer,
-        is_leader_cta: cutlass.Boolean,
     ):
         # [2025-10-21] For reasons I don't understand, putting these partitioning in the main
         # kernel (before warp specialization) is a lot slower tha putting them here.
@@ -2539,11 +1735,10 @@ class FlashAttentionBackwardSm100:
         tdPrV = tiled_mma_dP.make_fragment_A(sV)
         tdPrdOt = tiled_mma_dP.make_fragment_B(sdOt)
         # dK = dS.T @ Q
-        # For 2-CTA, dS (dK mma) MUST come from TMEM (cannot use SMEM)
-        if const_expr(self.use_smem_dS_for_mma_dK and not self.use_2cta_instrs):
-            tdKrdS = tiled_mma_dK.make_fragment_A(sdSt)  # From SMEM
+        if const_expr(self.use_smem_dS_for_mma_dK):
+            tdKrdS = tiled_mma_dK.make_fragment_A(sdSt)
         else:
-            tdKrdS = tiled_mma_dK.make_fragment_A(tdS)  # From TMEM
+            tdKrdS = tiled_mma_dK.make_fragment_A(tdS)
         tdKrQ = tiled_mma_dK.make_fragment_B(sQt)
         # dQ = dS @ K
         tdQrdS = tiled_mma_dQ.make_fragment_A(sdS)
@@ -2554,8 +1749,7 @@ class FlashAttentionBackwardSm100:
 
         # mma_qk_fn = partial(gemm_w_idx, tiled_mma_S, tStS, tSrK, tSrQ, zero_init=True)
         mma_qk_fn = partial(
-            gemm_ptx_w_idx, tiled_mma_S, tStS, tSrK, tSrQ, sA=sK, sB=sQ, zero_init=True,
-            cta_group=self.cta_group_size,
+            gemm_ptx_w_idx, tiled_mma_S, tStS, tSrK, tSrQ, sA=sK, sB=sQ, zero_init=True
         )
         # mma_dov_fn = partial(gemm_w_idx, tiled_mma_dP, tdPtdP, tdPrV, tdPrdOt, zero_init=True)
         mma_dov_fn = partial(
@@ -2567,7 +1761,6 @@ class FlashAttentionBackwardSm100:
             sA=sV,
             sB=sdOt,
             zero_init=True,
-            cta_group=self.cta_group_size,
         )
         # mma_pdo_fn = partial(gemm_w_idx, tiled_mma_dV, tdVtdV, tdVrP, tdVrdO)
         mma_pdo_fn = partial(
@@ -2579,14 +1772,12 @@ class FlashAttentionBackwardSm100:
             sA=None,
             sB=sdO,
             tA_addr=self.tmem_P_offset,
-            cta_group=self.cta_group_size,
         )
-        num_unroll_groups = 2 if const_expr(self.use_2cta_instrs) else 1
-        mma_dsk_fn = partial(gemm_w_idx, tiled_mma_dQ, tdQtdQ, tdQrdS, tdQrK, zero_init=True, num_unroll_groups=num_unroll_groups)
+        mma_dsk_fn = partial(gemm_w_idx, tiled_mma_dQ, tdQtdQ, tdQrdS, tdQrK, zero_init=True)
         # mma_dsk_fn = partial(
         #     gemm_ptx_w_idx, tiled_mma_dQ, tdQtdQ, tdQrdS, tdQrK, sA=sdS, sB=sKt, zero_init=True
         # )
-        if const_expr(self.use_smem_dS_for_mma_dK and not self.use_2cta_instrs):
+        if const_expr(self.use_smem_dS_for_mma_dK):
             mma_dsq_fn = partial(gemm_w_idx, tiled_mma_dK, tdKtdK, tdKrdS, tdKrQ)
         else:
             # Need to explicitly pass in tA_addr for correctness
@@ -2599,24 +1790,12 @@ class FlashAttentionBackwardSm100:
                 sA=None,
                 sB=sQt,
                 tA_addr=self.tmem_dS_offset,
-                cta_group=self.cta_group_size,
             )
 
-        consumer_state_Q = cutlass.pipeline.make_pipeline_state(
-            cutlass.pipeline.PipelineUserType.Consumer, self.Q_stage
-        )
-        consumer_state_Qt = cutlass.pipeline.make_pipeline_state(
-            cutlass.pipeline.PipelineUserType.Consumer, self.Q_stage
-        )
-        consumer_state_Kt = cutlass.pipeline.make_pipeline_state(
-            cutlass.pipeline.PipelineUserType.Consumer, self.single_stage
-        )
         consumer_state_dO = cutlass.pipeline.make_pipeline_state(
             cutlass.pipeline.PipelineUserType.Consumer, self.dO_stage
         )
         producer_phase_acc = Int32(1)  # For S & P, dP, dQ
-        producer_phase_dQ = Int32(1)  # 2-CTA: separate phase for dQ pipeline
-        dS_cluster_phase = Int32(0)
         consumer_state_dS = cutlass.pipeline.make_pipeline_state(
             cutlass.pipeline.PipelineUserType.Consumer, 1
         )
@@ -2633,7 +1812,7 @@ class FlashAttentionBackwardSm100:
         work_tile = tile_scheduler.initial_work_tile_info()
         while work_tile.is_valid_tile:
             n_block, head_idx, batch_idx, _ = work_tile.tile_idx
-            seqlen = SeqlenInfoCls(batch_idx)
+            seqlen = SeqlenInfoCls(batch_idx)  # must be seqlen_k
             m_block_min, m_block_max = block_info.get_m_block_min_max(
                 seqlen, n_block // self.cluster_shape_mnk[0]
             )
@@ -2642,247 +1821,39 @@ class FlashAttentionBackwardSm100:
             if const_expr(self.enable_flashmask):
                 cute.arch.mbarrier_wait(flashmask_loaded_mbar_ptr, flashmask_phase)
 
-                if not const_expr(self.use_2cta_instrs):
-                    # 1CTA: compute num_blocks by subtracting full-mask blocks
-                    num_blocks = 0
-                    loop_start = m_block_min
-                    loop_end = m_block_max
-                    if const_expr(not self.is_causal):
-                        has_uts = const_expr(flashmask_info.UTS_nblock_max is not None)
-                        if has_uts:
-                            loop_end = min(m_block_max, sFM_max_min[4] + 1)
-                            #  ~ UTS
-                            num_blocks = num_blocks + max(0, (loop_end - loop_start))
-                            loop_start = loop_end
-                            if tidx == 0 and self.debug_print:
-                                cute.printf('after uts mma: n_block: %d, %d', n_block, num_blocks)
-                        loop_start = max(loop_start, sFM_max_min[7])
-
-                    # UTE ~ LTS
-                    loop_end = min(m_block_max, sFM_max_min[0] + 1)
-                    num_blocks = num_blocks + max(0, (loop_end - loop_start))
-                    if tidx == 0 and self.debug_print:
-                        cute.printf('after ute ~ lts mma: n_block: %d, %d, m_block_min: %d, m_block_max: %d', n_block, num_blocks, m_block_min, m_block_max)
-
-                    # LTE ~ seqlen_q
-                    has_lte = const_expr(flashmask_info.LTE_nblock_max is not None)
-                    if has_lte:
-                        loop_start = max(sFM_max_min[0] + 1, sFM_max_min[3])
-                        if sFM_max_min[3] == sFM_max_min[0]:
-                            loop_start = sFM_max_min[3] + 1
-                        loop_start = max(m_block_min, loop_start)
-                        loop_end = m_block_max
-                        num_blocks = num_blocks + (loop_end - loop_start)
+                num_blocks = 0
+                loop_start = m_block_min
+                loop_end = m_block_max
+                if const_expr(not self.is_causal):
+                    has_uts = const_expr(flashmask_info.UTS_nblock_max is not None)
+                    if has_uts:
+                        loop_end = min(m_block_max, sFM_max_min[4] + 1)
+                        #  ~ UTS
+                        num_blocks = num_blocks + max(0, (loop_end - loop_start))
                         if tidx == 0 and self.debug_print:
-                            cute.printf('after lts ~ seqlen_q mma: n_block: %d, %d', n_block, num_blocks)
-                # else: 2CTA - keep num_blocks = m_block_max - m_block_min (no skipping)
+                            cute.printf('after uts mma: n_block: %d, %d', n_block, num_blocks)
+                    loop_start = sFM_max_min[7]
+
+                # UTE ~ LTS
+                #loop_end = m_block_max if m_block_max < sFM_max_min[0] + 1 else sFM_max_min[0] + 1
+                loop_end = min(m_block_max, sFM_max_min[0] + 1)
+                num_blocks = num_blocks + max(0, (loop_end - loop_start))
                 if tidx == 0 and self.debug_print:
-                    cute.printf('MMA FM: cta_rank=%d, n_block=%d, num_blocks=%d, m_block_min=%d, m_block_max=%d, 2cta=%d', cute.arch.block_idx_in_cluster(), n_block, num_blocks, m_block_min, m_block_max, const_expr(self.use_2cta_instrs))
+                    cute.printf('after ute ~ lts mma: n_block: %d, %d, m_block_min: %d, m_block_max: %d', n_block, num_blocks, m_block_min, m_block_max)
 
-            if const_expr(self.use_2cta_instrs and self.tile_hdim == 192):
-                # hdim192: flat loop with double pipeline_Q/dO consumption
-                # Only leader CTA executes MMA loop; non-leader CTA's MMA warps are idle
-                if is_leader_cta:
+                # LTE ~ seqlen_q
+                has_lte = const_expr(flashmask_info.LTE_nblock_max is not None)
+                if has_lte:
+                    loop_start = max(sFM_max_min[0] + 1, sFM_max_min[3])
+                    if sFM_max_min[3] == sFM_max_min[0]:
+                        loop_start = sFM_max_min[3] + 1
+                    loop_start = max(m_block_min, loop_start)
+                    loop_end = m_block_max
+                    num_blocks = num_blocks + (loop_end - loop_start)
                     if tidx == 0 and self.debug_print:
-                        cute.printf('MMA hdim192: cta_rank=%d, CTA %d entering loop, num_blocks=%d, is_leader=%d', cute.arch.block_idx_in_cluster(), cute.arch.block_idx()[0], num_blocks, is_leader_cta)
-                    accumulate_dK = False
-                    accumulate_dV = False
+                        cute.printf('after lts ~ seqlen_q mma: n_block: %d, %d', n_block, num_blocks)
 
-                    main_loop_iters = num_blocks
-
-                    for _ in cutlass.range(main_loop_iters, unroll=1):
-                        # 1) S.T = K @ Q.T
-                        if tidx == 0 and self.debug_print:
-                            cute.printf('MMA step1: CTA %d before Q.consumer_wait', cute.arch.block_idx_in_cluster())
-                        pipeline_Q.consumer_wait(consumer_state_Q)
-                        if tidx == 0 and self.debug_print:
-                            cute.printf('MMA step1: CTA %d before dQ.empty.wait phase=%d', cute.arch.block_idx_in_cluster(), producer_phase_acc)
-                        pipeline_dQ.sync_object_empty.wait(
-                            0, producer_phase_acc
-                        )  # dQ tmem overlaps with S
-                        if tidx == 0 and self.debug_print:
-                            cute.printf('MMA step1: CTA %d before mma_qk', cute.arch.block_idx_in_cluster())
-                        mma_qk_fn(B_idx=consumer_state_Q.index)
-                        if tidx == 0 and self.debug_print:
-                            cute.printf('MMA step1: CTA %d after mma_qk, signaling S_P full', cute.arch.block_idx_in_cluster())
-                        pipeline_S_P.sync_object_full.arrive(
-                            0, pipeline_S_P.producer_mask, cta_group
-                        )
-                        pipeline_Q.consumer_release(consumer_state_Q)
-                        consumer_state_Q.advance()
-
-                        producer_phase_acc ^= 1
-
-                        # 2) dP.T = V @ dO.T
-                        if tidx == 0 and self.debug_print:
-                            cute.printf('MMA step2: CTA %d before dO.consumer_wait', cute.arch.block_idx_in_cluster())
-                        pipeline_dO.consumer_wait(consumer_state_dO)
-                        if tidx == 0 and self.debug_print:
-                            cute.printf('MMA step2: CTA %d before S_P.empty.wait phase=%d', cute.arch.block_idx_in_cluster(), producer_phase_acc)
-                        pipeline_S_P.sync_object_empty.wait(
-                            0, producer_phase_acc
-                        )  # dP tmem overlaps with S
-                        if tidx == 0 and self.debug_print:
-                            cute.printf('MMA step2: CTA %d after S_P.empty.wait, before mma_dov', cute.arch.block_idx_in_cluster())
-                        mma_dov_fn(B_idx=consumer_state_dO.index)
-                        if tidx == 0 and self.debug_print:
-                            cute.printf('MMA step2: CTA %d after mma_dov, signaling dP full', cute.arch.block_idx_in_cluster())
-                        pipeline_dP.sync_object_full.arrive(0, pipeline_dP.producer_mask, cta_group)
-                        pipeline_dO.consumer_release(consumer_state_dO)
-                        consumer_state_dO.advance()
-
-                        # 3) dK = dS.T @ Q
-                        pipeline_Q.consumer_wait(consumer_state_Q)
-                        pipeline_dP.sync_object_empty.wait(0, producer_phase_acc)  # dP -> dS
-                        mma_dsq_fn(B_idx=consumer_state_Q.index, zero_init=not accumulate_dK)
-                        pipeline_Q.consumer_release(consumer_state_Q)
-                        consumer_state_Q.advance()
-                        accumulate_dK = True
-
-                        # 4) dV = P.T @ dO
-                        pipeline_dO.consumer_wait(consumer_state_dO)
-                        mma_pdo_fn(B_idx=consumer_state_dO.index, zero_init=not accumulate_dV)
-                        pipeline_dO.consumer_release(consumer_state_dO)
-                        consumer_state_dO.advance()
-                        accumulate_dV = True
-
-                        # 5) dQ = dS @ K
-                        pipeline_dS.consumer_wait(consumer_state_dS)
-                        cute.arch.mbarrier_wait(dS_cluster_leader_mbar_ptr, phase=dS_cluster_phase)
-                        mma_dsk_fn()
-                        pipeline_dQ.sync_object_full.arrive(0, pipeline_dQ.producer_mask, cta_group)
-                        pipeline_dS.consumer_release(consumer_state_dS)
-                        consumer_state_dS.advance()
-                        dS_cluster_phase ^= 1
-
-                    # signal to the epilogue that dV is ready
-                    pipeline_dKV.sync_object_empty.wait(0, producer_phase_dKV)
-                    pipeline_dKV.sync_object_full.arrive(0, pipeline_dKV.producer_mask, cta_group)
-                    # signal to the epilogue that dK is ready
-                    pipeline_dKV.sync_object_empty.wait(1, producer_phase_dKV)
-                    pipeline_dKV.sync_object_full.arrive(1, pipeline_dKV.producer_mask, cta_group)
-                    producer_phase_dKV ^= 1
-
-            elif const_expr(self.use_2cta_instrs):
-                if is_leader_cta and num_blocks > 0:
-                    accumulate_dK = False
-                    # -----------------------------------------------------------
-                    ###### Prologue (2CTA hdim128)
-                    # -----------------------------------------------------------
-                    # 1. S  = Q0 @ K.T
-                    # 2. dP = V @ dOt.T
-                    # 3. dV = P @ dO
-
-                    # 1) S = K @ Q
-                    pipeline_Q.consumer_wait(consumer_state_Q)
-                    pipeline_S_P.sync_object_empty.wait(0, producer_phase_acc)
-                    mma_qk_fn(B_idx=consumer_state_Q.index)
-                    pipeline_S_P.sync_object_full.arrive(0, pipeline_S_P.producer_mask, cta_group)
-                    pipeline_Q.consumer_release(consumer_state_Q)
-                    consumer_state_Q.advance()
-
-                    # 2) dP = V @ dOt.T
-                    pipeline_dO.consumer_wait(consumer_state_dO)
-                    pipeline_dP.sync_object_empty.wait(0, producer_phase_acc)
-                    mma_dov_fn(B_idx=consumer_state_dO.index)
-                    pipeline_dP.sync_object_full.arrive(0, pipeline_dP.producer_mask, cta_group)
-
-                    # 3) dV = P.T @ dO
-                    producer_phase_acc ^= 1
-                    pipeline_S_P.sync_object_empty.wait(0, producer_phase_acc)
-                    mma_pdo_fn(B_idx=consumer_state_dO.index, zero_init=True)
-                    pipeline_dO.consumer_release(consumer_state_dO)
-                    consumer_state_dO.advance()
-
-                    pipeline_Kt.consumer_wait(consumer_state_Kt)
-                    # -----------------------------------------------------------
-                    ###### MAIN LOOP (2CTA hdim128)
-                    # -----------------------------------------------------------
-                    # 1. S.T  = K    @ Q.T
-                    # 2. dK   = dS.T @ Q
-                    # 3. dP.T = V    @ dO.T
-                    # 4. dQ   = dS   @ K
-                    # 5. dV   = P.T  @ dO
-
-                    main_loop_iters = m_block_max - m_block_min - 1
-
-                    for _ in cutlass.range(main_loop_iters, unroll=1):
-                        # (1) S.T = K @ Q.T (next)
-                        pipeline_Q.consumer_wait(consumer_state_Q)
-                        pipeline_dQ.sync_object_empty.wait(0, producer_phase_dQ)
-                        mma_qk_fn(B_idx=consumer_state_Q.index)
-                        pipeline_S_P.sync_object_full.arrive(
-                            0, pipeline_S_P.producer_mask, cta_group
-                        )
-                        pipeline_Q.consumer_release(consumer_state_Q)
-                        consumer_state_Q.advance()
-
-                        # (2) dK += dS.T @ Q (cur)
-                        pipeline_Qt.consumer_wait(consumer_state_Qt)
-                        pipeline_dP.sync_object_empty.wait(0, producer_phase_acc)  # dP -> dS
-                        mma_dsq_fn(B_idx=consumer_state_Qt.index, zero_init=not accumulate_dK)
-                        accumulate_dK = True
-                        pipeline_Qt.consumer_release(consumer_state_Qt)
-                        consumer_state_Qt.advance()
-
-                        # (3) dP.T = V @ dO.T (next)
-                        pipeline_dO.consumer_wait(consumer_state_dO)
-                        mma_dov_fn(B_idx=consumer_state_dO.index)
-                        pipeline_dP.sync_object_full.arrive(0, pipeline_dP.producer_mask, cta_group)
-
-                        # (4) dQ = dS @ K (cur)
-                        pipeline_dS.consumer_wait(consumer_state_dS)
-                        cute.arch.mbarrier_wait(dS_cluster_leader_mbar_ptr, phase=dS_cluster_phase)
-                        mma_dsk_fn()
-                        pipeline_dQ.sync_object_full.arrive(0, pipeline_dQ.producer_mask, cta_group)
-                        pipeline_dS.consumer_release(consumer_state_dS)
-                        consumer_state_dS.advance()
-                        dS_cluster_phase ^= 1
-                        producer_phase_dQ ^= 1
-
-                        # (5) dV += P.T @ dO (next)
-                        producer_phase_acc ^= 1
-                        pipeline_S_P.sync_object_empty.wait(0, producer_phase_acc)  # S -> P
-                        mma_pdo_fn(B_idx=consumer_state_dO.index, zero_init=False)
-                        pipeline_dO.consumer_release(consumer_state_dO)
-                        consumer_state_dO.advance()
-
-                    pipeline_S_P.sync_object_full.arrive(0, pipeline_S_P.producer_mask, cta_group)
-
-                    # signal to the epilogue that dV is ready
-                    pipeline_dKV.sync_object_empty.wait(0, producer_phase_dKV)
-                    pipeline_dKV.sync_object_full.arrive(0, pipeline_dKV.producer_mask, cta_group)
-                    pipeline_dKV.sync_object_empty.wait(1, producer_phase_dKV)
-
-                    # -----------------------------------------------------------
-                    # Tail: Remaining dK and dQ
-                    # -----------------------------------------------------------
-                    # dK += dS.T @ Q
-                    pipeline_Qt.consumer_wait(consumer_state_Qt)
-                    pipeline_dP.sync_object_empty.wait(0, producer_phase_acc)  # dP -> dS
-                    mma_dsq_fn(B_idx=consumer_state_Qt.index, zero_init=not accumulate_dK)
-                    pipeline_Qt.consumer_release(consumer_state_Qt)
-                    consumer_state_Qt.advance()
-                    # signal to the epilogue that dK is ready
-                    pipeline_dKV.sync_object_full.arrive(1, pipeline_dKV.producer_mask, cta_group)
-                    producer_phase_dKV ^= 1
-
-                    # dQ = dS @ K
-                    pipeline_dS.consumer_wait(consumer_state_dS)
-                    cute.arch.mbarrier_wait(dS_cluster_leader_mbar_ptr, phase=dS_cluster_phase)
-                    pipeline_dQ.sync_object_empty.wait(0, producer_phase_dQ)
-                    mma_dsk_fn()
-                    pipeline_dQ.sync_object_full.arrive(0, pipeline_dQ.producer_mask, cta_group)
-                    pipeline_dS.consumer_release(consumer_state_dS)
-                    pipeline_Kt.consumer_release(consumer_state_Kt)
-                    consumer_state_dS.advance()
-                    consumer_state_Kt.advance()
-                    dS_cluster_phase ^= 1
-                    producer_phase_dQ ^= 1
-
-                    producer_phase_acc ^= 1
-
-            elif is_leader_cta and num_blocks > 0:
+            if num_blocks > 0:
                 accumulate_dK = False
                 # -----------------------------------------------------------
                 ###### Prologue
@@ -3085,24 +2056,20 @@ class FlashAttentionBackwardSm100:
         thr_mma_dV: cute.core.ThrMma,
         thr_mma_dK: cute.core.ThrMma,
         tStS: cute.Tensor,
-        tdPtdP: cute.Tensor,
-        tdVtdV: cute.Tensor,
-        tdKtdK: cute.Tensor,
         sLSE: cute.Tensor,
         sdPsum: cute.Tensor,
+        tdVtdV: cute.Tensor,
+        tdKtdK: cute.Tensor,
         mdV: cute.Tensor,
         mdK: cute.Tensor,
         sdS: cute.Tensor,
-        sdS_xchg: cute.Tensor,
+        tdPtdP: cute.Tensor,
         pipeline_LSE: PipelineAsync,
         pipeline_dPsum: PipelineAsync,
         pipeline_S_P: PipelineAsync,
         pipeline_dS: PipelineAsync,
         pipeline_dKV: PipelineAsync,
         pipeline_dP: PipelineAsync,
-        dS_cluster_empty_mbar_ptr: cute.Pointer,
-        dS_cluster_full_mbar_ptr: cute.Pointer,
-        dQaccum_empty_mbar_ptr: Optional[cute.Pointer],
         softmax_scale: cutlass.Float32,
         softmax_scale_log2: cutlass.Float32,
         block_info: BlockInfo,
@@ -3122,7 +2089,6 @@ class FlashAttentionBackwardSm100:
         sStartEndRowIndices: cute.Tensor,
         sFM_max_min: cute.Tensor,
         flashmask_loaded_mbar_ptr: cute.Pointer,
-        is_leader_cta: cutlass.Boolean,
     ):
         sLSE_2D = cute.make_tensor(
             sLSE.iterator,
@@ -3153,7 +2119,7 @@ class FlashAttentionBackwardSm100:
         # 0: [256...384]
         # 1: [128...256]
 
-        tileP_f32_like = self.cta_tiler[1] // 32 * self.v_dtype.width  # (128, 64)
+        tileP_f32_like = self.mma_tiler_kq[0] // 32 * self.v_dtype.width  # (128, 64)
         # tStS has shape ((128, 128), 1, 1), tStP has shape ((128, 64), 1, 1)
         # tP overlap with tS
         # cute.printf(tStS)
@@ -3200,26 +2166,14 @@ class FlashAttentionBackwardSm100:
         )
         thr_copy_r2s = cute.make_tiled_copy_D(copy_atom_r2s, thr_copy_t2r).get_slice(tidx)
         # We assume the swizzle (i.e. layout.inner) stays the same
-        sdS_epi_layout = sm100_utils_basic.make_smem_layout_epi(
+        sdS_layout = sm100_utils_basic.make_smem_layout_epi(
             self.ds_dtype, LayoutEnum.ROW_MAJOR, (self.tile_n, self.tile_m), 1
-        )
-        sdS_layout = cute.slice_(sdS_epi_layout.outer, (None, None, 0))  # ((8,16), (64,2))
+        ).outer  # ((8,16), (64,2), (1, 1))
+        sdS_layout = cute.slice_(sdS_layout, (None, None, 0))  # ((8,16), (64,2))
         # Need to group into 1 mode to be compatible w thr_copy_r2s
         sdS_layout = cute.make_layout((sdS_layout.shape,), stride=(sdS_layout.stride,))
         sdS_epi = cute.make_tensor(sdS.iterator, sdS_layout)
         tRS_sdS = thr_copy_r2s.partition_D(sdS_epi)
-
-        tRS_sdS_xchg = None
-        if const_expr(self.use_2cta_instrs):
-            sdS_xchg_epi = cute.make_tensor(
-                cute.recast_ptr(sdS_xchg.iterator, sdS_epi_layout.inner), sdS_layout
-            )
-            tRS_sdS_xchg = thr_copy_r2s.partition_D(sdS_xchg_epi)
-
-        cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
-        dS_cluster_empty_phase = Int32(1)
-        # 2-CTA: CTA 0 exchanges stage 1 (bottom half), CTA 1 exchanges stage 0 (top half)
-        exchange_stage = cta_rank_in_cluster ^ 1 if const_expr(self.use_2cta_instrs) else Int32(0)
 
         consumer_state_S_P_dP = pipeline.make_pipeline_state(  # Our impl has shortcut for stage==1
             cutlass.pipeline.PipelineUserType.Consumer, 1
@@ -3249,19 +2203,17 @@ class FlashAttentionBackwardSm100:
             m_block_min, m_block_max = block_info.get_m_block_min_max(
                 seqlen, n_block // self.cluster_shape_mnk[0]
             )
-            n_block_for_cluster = n_block // self.cta_group_size
             mask = AttentionMaskCls(seqlen.seqlen_q, seqlen.seqlen_k)
             # TODO: condition mask_seqlen
             mask_fn = partial(
                 mask.apply_mask_sm100_transposed,
                 tScS_t2r=tScS_t2r,
                 t0ScS_t2r=t0ScS_t2r,
-                n_block=n_block_for_cluster,
+                n_block=n_block,
                 mask_seqlen=True,
                 mask_causal=self.is_causal,
                 mask_local=self.is_local,
                 sStartEndRowIndices=sStartEndRowIndices,
-                per_cta_tile_n=self.tile_n,
             )
 
             # prefetch_LSE = not self.is_causal
@@ -3288,279 +2240,219 @@ class FlashAttentionBackwardSm100:
                 pipeline_dS=pipeline_dS,
                 softmax_scale_log2=softmax_scale_log2,
                 mask_fn=mask_fn,
-                sdS_xchg=sdS_xchg,
-                tRS_sdS_xchg=tRS_sdS_xchg,
-                exchange_stage=exchange_stage,
-                dS_cluster_empty_mbar_ptr=dS_cluster_empty_mbar_ptr,
-                dS_cluster_full_mbar_ptr=dS_cluster_full_mbar_ptr,
-                dQaccum_empty_mbar_ptr=dQaccum_empty_mbar_ptr,
-                sdS_epi_layout=sdS_epi_layout,
-                cta_rank_in_cluster=cta_rank_in_cluster,
-                tidx=tidx,
-                sdS=sdS,
             )
 
-            if const_expr(True):  # Both CTAs must execute compute body for pipeline sync in 2-CTA mode
-                if tidx == 0 and self.debug_print:
-                    cute.printf('COMPUTE: cta_rank=%d, CTA %d entering compute body, is_leader=%d, n_block=%d, m_block_min=%d, m_block_max=%d, total=%d', cute.arch.block_idx_in_cluster(), cute.arch.block_idx()[0], is_leader_cta, n_block, m_block_min, m_block_max, m_block_max - m_block_min)
-                zero_block = m_block_max <= m_block_min
-                if const_expr(self.enable_flashmask):
-                    if tidx == 0 and self.debug_print:
-                        cute.printf('COMPUTE: CTA %d before flashmask_loaded_mbar_wait phase=%d', cute.arch.block_idx_in_cluster(), flashmask_phase)
-                    cute.arch.mbarrier_wait(flashmask_loaded_mbar_ptr, flashmask_phase)
-                    if tidx == 0 and self.debug_print:
-                        cute.printf('COMPUTE: CTA %d after flashmask_loaded_mbar_wait', cute.arch.block_idx_in_cluster())
-                    if const_expr(self.use_2cta_instrs):
-                        # 2CTA: process ALL blocks without skipping for pipeline sync.
-                        # Both CTAs have different flashmask boundaries but share pipelines,
-                        # so they must iterate the same number of blocks.
-                        compute_iter_idx = cute.Int32(0)
-                        for m_block in cutlass.range(m_block_min, m_block_max, unroll=1):
-                            zero_block = False
-                            if tidx == 0 and self.debug_print:
-                                cute.printf('COMPUTE 2CTA: cta_rank=%d, n_block=%d, m_block=%d of [%d,%d)', cute.arch.block_idx_in_cluster(), n_block, m_block, m_block_min, m_block_max)
-                            consumer_state_LSE, consumer_state_S_P_dP, consumer_state_dPsum, producer_state_dS, dS_cluster_empty_phase = compute_step(
-                                m_block=m_block,
-                                consumer_state_LSE=consumer_state_LSE,
-                                consumer_state_S_P_dP=consumer_state_S_P_dP,
-                                consumer_state_dPsum=consumer_state_dPsum,
-                                producer_state_dS=producer_state_dS,
-                                dS_cluster_empty_phase=dS_cluster_empty_phase,
-                                partially_masked=True,
-                                iter_idx=compute_iter_idx,
-                            )
-                            compute_iter_idx = compute_iter_idx + 1
-                            if tidx == 0 and self.debug_print:
-                                cute.printf('n_block: %d, after compute_step 2CTA all: %d', n_block, m_block)
-                    else:
-                        # 1CTA: iterate flashmask segments, skipping full-mask blocks
-                        loop_start = m_block_min
-                        loop_end = m_block_max
-                        zero_block = True
-                        # 0: 0 ~ UTS_min, no mask
-                        # 1: UTS_min ~ UTS_max, partially mask
-                        # 2: UTE_min ~ UTE_max, partially mask
-                        # 3: UTE_max ~ LTS_min, no mask
-                        # 4: LTS_min ~ LTS_max, partially mask
-                        # 5: LTE_min ~ LTE_max, partially mask
-                        # 6: LTE_max ~ max_seq_k, no mask
-                        if const_expr(not self.is_causal):
-                            has_uts = const_expr(flashmask_info.UTS_nblock_max is not None)
-                            if has_uts:
-                                # 0 ~ UTS
-                                loop_end = sFM_max_min[5] # UTS_min
-                                for m_block in cutlass.range(loop_start, loop_end, unroll=1):
-                                    zero_block = False
-                                    if tidx == 0 and self.debug_print:
-                                        cute.printf('n_block: %d, before compute_step 0 ~ UTS_min: %d', n_block, m_block)
-                                    consumer_state_LSE, consumer_state_S_P_dP, consumer_state_dPsum, producer_state_dS, dS_cluster_empty_phase = compute_step(
-                                        m_block=m_block,
-                                        consumer_state_LSE=consumer_state_LSE,
-                                        consumer_state_S_P_dP=consumer_state_S_P_dP,
-                                        consumer_state_dPsum=consumer_state_dPsum,
-                                        producer_state_dS=producer_state_dS,
-                                        dS_cluster_empty_phase=dS_cluster_empty_phase,
-                                        partially_masked=False,
-                                    )
-                                    if tidx == 0 and self.debug_print:
-                                        cute.printf('n_block: %d, after compute_step 0 ~ UTS_min: %d', n_block, m_block)
-
-                                loop_start = sFM_max_min[5] # UTS_min
-                                loop_end = sFM_max_min[4] + 1 # UTS_max
-                                for m_block in cutlass.range(loop_start, loop_end, unroll=1):
-                                    zero_block = False
-                                    if tidx == 0 and self.debug_print:
-                                        cute.printf('n_block: %d, before compute_step UTS_min ~ UTS_max: %d', n_block, m_block)
-                                    consumer_state_LSE, consumer_state_S_P_dP, consumer_state_dPsum, producer_state_dS, dS_cluster_empty_phase = compute_step(
-                                        m_block=m_block,
-                                        consumer_state_LSE=consumer_state_LSE,
-                                        consumer_state_S_P_dP=consumer_state_S_P_dP,
-                                        consumer_state_dPsum=consumer_state_dPsum,
-                                        producer_state_dS=producer_state_dS,
-                                        dS_cluster_empty_phase=dS_cluster_empty_phase,
-                                        partially_masked=True,
-                                    )
-                                    if tidx == 0 and self.debug_print:
-                                        cute.printf('n_block: %d, after compute_step UTS_min ~ UTS_max: %d', n_block, m_block)
-
-                            loop_start = max(loop_start, sFM_max_min[7]) # UTE_min
-                            loop_end = min(sFM_max_min[6] + 1, m_block_max) # UTE_max
-                            for m_block in cutlass.range(loop_start, loop_end, unroll=1):
-                                zero_block = False
-                                if tidx == 0 and self.debug_print:
-                                    cute.printf('n_block: %d, before compute_step UTE_min ~ UTE_max: %d', n_block, m_block)
-                                consumer_state_LSE, consumer_state_S_P_dP, consumer_state_dPsum, producer_state_dS, dS_cluster_empty_phase = compute_step(
-                                    m_block=m_block,
-                                    consumer_state_LSE=consumer_state_LSE,
-                                    consumer_state_S_P_dP=consumer_state_S_P_dP,
-                                    consumer_state_dPsum=consumer_state_dPsum,
-                                    producer_state_dS=producer_state_dS,
-                                    dS_cluster_empty_phase=dS_cluster_empty_phase,
-                                    partially_masked=True,
-                                )
-                                if tidx == 0 and self.debug_print:
-                                    cute.printf('n_block: %d, after compute_step UTE_min ~ UTE_max: %d', n_block, m_block)
-                            loop_start = max(loop_start, loop_end)
-
-                        # UTE ~ LTS
-                        loop_end = min(m_block_max, sFM_max_min[1])
+            zero_block = m_block_max <= m_block_min
+            if const_expr(self.enable_flashmask):
+                cute.arch.mbarrier_wait(flashmask_loaded_mbar_ptr, flashmask_phase)
+                loop_start = m_block_min
+                loop_end = m_block_max
+                zero_block = True
+                # 0: 0 ~ UTS_min, no mask
+                # 1: UTS_min ~ UTS_max, partially mask
+                # 2: UTE_min ~ UTE_max, partially mask
+                # 3: UTE_max ~ LTS_min, no mask
+                # 4: LTS_min ~ LTS_max, partially mask
+                # 5: LTE_min ~ LTE_max, partially mask
+                # 6: LTE_max ~ max_seq_k, no mask
+                if const_expr(not self.is_causal):
+                    has_uts = const_expr(flashmask_info.UTS_nblock_max is not None)
+                    if has_uts:
+                        # 0 ~ UTS
+                        loop_end = sFM_max_min[5] # UTS_min
                         for m_block in cutlass.range(loop_start, loop_end, unroll=1):
                             zero_block = False
                             if tidx == 0 and self.debug_print:
-                                cute.printf('n_block: %d, before compute_step UTE_max ~ LTS_min: %d', n_block, m_block)
-                            consumer_state_LSE, consumer_state_S_P_dP, consumer_state_dPsum, producer_state_dS, dS_cluster_empty_phase = compute_step(
+                                cute.printf('n_block: %d, before compute_step 0 ~ UTS_min: %d', n_block, m_block)
+                            consumer_state_LSE, consumer_state_S_P_dP, consumer_state_dPsum, producer_state_dS = compute_step(
                                 m_block=m_block,
                                 consumer_state_LSE=consumer_state_LSE,
                                 consumer_state_S_P_dP=consumer_state_S_P_dP,
                                 consumer_state_dPsum=consumer_state_dPsum,
                                 producer_state_dS=producer_state_dS,
-                                dS_cluster_empty_phase=dS_cluster_empty_phase,
                                 partially_masked=False,
                             )
                             if tidx == 0 and self.debug_print:
-                                cute.printf('n_block: %d, after compute_step UTE_max ~ LTS_min: %d', n_block, m_block)
+                                cute.printf('n_block: %d, after compute_step 0 ~ UTS_min: %d', n_block, m_block)
 
-                        loop_start = max(loop_start, loop_end)
-                        loop_end = min(m_block_max, sFM_max_min[0] + 1)
+                        loop_start = sFM_max_min[5] # UTS_min
+                        loop_end = sFM_max_min[4] + 1 # UTS_max
                         for m_block in cutlass.range(loop_start, loop_end, unroll=1):
                             zero_block = False
                             if tidx == 0 and self.debug_print:
-                                cute.printf('n_block: %d, before compute_step LTS_min ~ LTS_max: %d', n_block, m_block)
-                            consumer_state_LSE, consumer_state_S_P_dP, consumer_state_dPsum, producer_state_dS, dS_cluster_empty_phase = compute_step(
+                                cute.printf('n_block: %d, before compute_step UTS_min ~ UTS_max: %d', n_block, m_block)
+                            consumer_state_LSE, consumer_state_S_P_dP, consumer_state_dPsum, producer_state_dS = compute_step(
                                 m_block=m_block,
                                 consumer_state_LSE=consumer_state_LSE,
                                 consumer_state_S_P_dP=consumer_state_S_P_dP,
                                 consumer_state_dPsum=consumer_state_dPsum,
                                 producer_state_dS=producer_state_dS,
-                                dS_cluster_empty_phase=dS_cluster_empty_phase,
                                 partially_masked=True,
                             )
                             if tidx == 0 and self.debug_print:
-                                cute.printf('n_block: %d, after compute_step LTS_min ~ LTS_max: %d', n_block, m_block)
+                                cute.printf('n_block: %d, after compute_step UTS_min ~ UTS_max: %d', n_block, m_block)
 
-                        # LTE ~ seqlen_q
-                        has_lte = const_expr(flashmask_info.LTE_nblock_max is not None)
-                        if has_lte:
-                            loop_start = max(sFM_max_min[0] + 1, sFM_max_min[3])
-                            if sFM_max_min[3] == sFM_max_min[0]:
-                                loop_start = sFM_max_min[3] + 1
-                            loop_start = max(loop_start, m_block_min)
-                            loop_end = min(m_block_max, sFM_max_min[2] + 1)
-                            #loop_end = m_block_max
-                            for m_block in cutlass.range(loop_start, loop_end, unroll=1):
-                                zero_block = False
-                                if tidx == 0 and self.debug_print:
-                                    cute.printf('n_block: %d, before compute_step LTE_min ~ LTE_max: %d', n_block, m_block)
-                                consumer_state_LSE, consumer_state_S_P_dP, consumer_state_dPsum, producer_state_dS, dS_cluster_empty_phase = compute_step(
-                                    m_block=m_block,
-                                    consumer_state_LSE=consumer_state_LSE,
-                                    consumer_state_S_P_dP=consumer_state_S_P_dP,
-                                    consumer_state_dPsum=consumer_state_dPsum,
-                                    producer_state_dS=producer_state_dS,
-                                    dS_cluster_empty_phase=dS_cluster_empty_phase,
-                                    partially_masked=True,
-                                )
-                                if tidx == 0 and self.debug_print:
-                                    cute.printf('n_block: %d, after compute_step LTE_min ~ LTE_max: %d', n_block, m_block)
-
-                            loop_start = max(loop_start, loop_end)
-                            loop_end = m_block_max
-                            for m_block in cutlass.range(loop_start, loop_end, unroll=1):
-                                zero_block = False
-                                if tidx == 0 and self.debug_print:
-                                    cute.printf('n_block: %d, before compute_step LTE_max ~ seqlen_q: %d', n_block, m_block)
-                                consumer_state_LSE, consumer_state_S_P_dP, consumer_state_dPsum, producer_state_dS, dS_cluster_empty_phase = compute_step(
-                                    m_block=m_block,
-                                    consumer_state_LSE=consumer_state_LSE,
-                                    consumer_state_S_P_dP=consumer_state_S_P_dP,
-                                    consumer_state_dPsum=consumer_state_dPsum,
-                                    producer_state_dS=producer_state_dS,
-                                    dS_cluster_empty_phase=dS_cluster_empty_phase,
-                                    partially_masked=False,
-                                )
-                                if tidx == 0 and self.debug_print:
-                                    cute.printf('n_block: %d, after compute_step LTE_max ~ seqlen_q: %d', n_block, m_block)
-                else:
-                    # Mainloop
-                    compute_iter_idx = cute.Int32(0)
-                    for m_block in cutlass.range(m_block_min, m_block_max, unroll=1):
-                        consumer_state_LSE, consumer_state_S_P_dP, consumer_state_dPsum, producer_state_dS, dS_cluster_empty_phase = compute_step(
+                    loop_start = max(loop_start, sFM_max_min[7]) # UTE_min
+                    loop_end = min(sFM_max_min[6] + 1, m_block_max) # UTE_max
+                    for m_block in cutlass.range(loop_start, loop_end, unroll=1):
+                        zero_block = False
+                        if tidx == 0 and self.debug_print:
+                            cute.printf('n_block: %d, before compute_step UTE_min ~ UTE_max: %d', n_block, m_block)
+                        consumer_state_LSE, consumer_state_S_P_dP, consumer_state_dPsum, producer_state_dS = compute_step(
                             m_block=m_block,
                             consumer_state_LSE=consumer_state_LSE,
                             consumer_state_S_P_dP=consumer_state_S_P_dP,
                             consumer_state_dPsum=consumer_state_dPsum,
                             producer_state_dS=producer_state_dS,
-                            dS_cluster_empty_phase=dS_cluster_empty_phase,
-                            iter_idx=compute_iter_idx,
+                            partially_masked=True,
                         )
-                        compute_iter_idx = compute_iter_idx + 1
+                        if tidx == 0 and self.debug_print:
+                            cute.printf('n_block: %d, after compute_step UTE_min ~ UTE_max: %d', n_block, m_block)
+                    loop_start = max(loop_start, loop_end)
 
-                # Final signal for dS smem store completion (deferred for 2CTA hdim128)
-                if const_expr(self.use_2cta_instrs and self.tile_hdim == 128):
-                    with cute.arch.elect_one():
-                        pipeline_dS.producer_commit(producer_state_dS)
-                    producer_state_dS.advance()
+                # UTE ~ LTS
+                loop_end = min(m_block_max, sFM_max_min[1])
+                for m_block in cutlass.range(loop_start, loop_end, unroll=1):
+                    zero_block = False
+                    if tidx == 0 and self.debug_print:
+                        cute.printf('n_block: %d, before compute_step UTE_max ~ LTS_min: %d', n_block, m_block)
+                    consumer_state_LSE, consumer_state_S_P_dP, consumer_state_dPsum, producer_state_dS = compute_step(
+                        m_block=m_block,
+                        consumer_state_LSE=consumer_state_LSE,
+                        consumer_state_S_P_dP=consumer_state_S_P_dP,
+                        consumer_state_dPsum=consumer_state_dPsum,
+                        producer_state_dS=producer_state_dS,
+                        partially_masked=False,
+                    )
+                    if tidx == 0 and self.debug_print:
+                        cute.printf('n_block: %d, after compute_step UTE_max ~ LTS_min: %d', n_block, m_block)
 
-                if const_expr(self.use_2cta_instrs) or not zero_block:
-                    if const_expr(not self.use_tma_store):
-                        consumer_state_dKV = self.epilogue_dKV(
-                            dp_idx,
-                            warp_idx,
-                            batch_idx,
-                            head_idx,
-                            n_block,
-                            thr_mma_dV,
-                            thr_mma_dK,
-                            tdVtdV,
-                            tdKtdK,
-                            mdV,
-                            mdK,
-                            pipeline_dKV,
-                            consumer_state_dKV,
-                            softmax_scale,
+                loop_start = max(loop_start, loop_end)
+                loop_end = min(m_block_max, sFM_max_min[0] + 1)
+                for m_block in cutlass.range(loop_start, loop_end, unroll=1):
+                    zero_block = False
+                    if tidx == 0 and self.debug_print:
+                        cute.printf('n_block: %d, before compute_step LTS_min ~ LTS_max: %d', n_block, m_block)
+                    consumer_state_LSE, consumer_state_S_P_dP, consumer_state_dPsum, producer_state_dS = compute_step(
+                        m_block=m_block,
+                        consumer_state_LSE=consumer_state_LSE,
+                        consumer_state_S_P_dP=consumer_state_S_P_dP,
+                        consumer_state_dPsum=consumer_state_dPsum,
+                        producer_state_dS=producer_state_dS,
+                        partially_masked=True,
+                    )
+                    if tidx == 0 and self.debug_print:
+                        cute.printf('n_block: %d, after compute_step LTS_min ~ LTS_max: %d', n_block, m_block)
+
+                # LTE ~ seqlen_q
+                has_lte = const_expr(flashmask_info.LTE_nblock_max is not None)
+                if has_lte:
+                    loop_start = max(sFM_max_min[0] + 1, sFM_max_min[3])
+                    if sFM_max_min[3] == sFM_max_min[0]:
+                        loop_start = sFM_max_min[3] + 1
+                    loop_start = max(loop_start, m_block_min)
+                    loop_end = min(m_block_max, sFM_max_min[2] + 1)
+                    #loop_end = m_block_max
+                    for m_block in cutlass.range(loop_start, loop_end, unroll=1):
+                        zero_block = False
+                        if tidx == 0 and self.debug_print:
+                            cute.printf('n_block: %d, before compute_step LTE_min ~ LTE_max: %d', n_block, m_block)
+                        consumer_state_LSE, consumer_state_S_P_dP, consumer_state_dPsum, producer_state_dS = compute_step(
+                            m_block=m_block,
+                            consumer_state_LSE=consumer_state_LSE,
+                            consumer_state_S_P_dP=consumer_state_S_P_dP,
+                            consumer_state_dPsum=consumer_state_dPsum,
+                            producer_state_dS=producer_state_dS,
+                            partially_masked=True,
                         )
-                    else:
-                        thr_copy_r2s_dKV = tiled_copy_r2s_dKV.get_slice(dp_idx)
-                        #### STORE dV
-                        consumer_state_dKV = self.epilogue_dK_or_dV_tma(
-                            dp_idx,
-                            batch_idx,
-                            head_idx,
-                            n_block,
-                            thr_mma_dV,
-                            tdVtdV,
-                            mdV_tma_tensor,
-                            sdV,
-                            tma_atom_dV,
-                            thr_copy_r2s_dKV,
-                            pipeline_dKV,
-                            consumer_state_dKV,
-                            None,  # Don't scale
-                            int(NamedBarrierBwdSm100.EpilogueWG1),  # barrier_id
-                            mdV_semaphore,
-                            "V",
+                        if tidx == 0 and self.debug_print:
+                            cute.printf('n_block: %d, after compute_step LTE_min ~ LTE_max: %d', n_block, m_block)
+
+                    loop_start = max(loop_start, loop_end)
+                    loop_end = m_block_max
+                    for m_block in cutlass.range(loop_start, loop_end, unroll=1):
+                        zero_block = False
+                        if tidx == 0 and self.debug_print:
+                            cute.printf('n_block: %d, before compute_step LTE_max ~ seqlen_q: %d', n_block, m_block)
+                        consumer_state_LSE, consumer_state_S_P_dP, consumer_state_dPsum, producer_state_dS = compute_step(
+                            m_block=m_block,
+                            consumer_state_LSE=consumer_state_LSE,
+                            consumer_state_S_P_dP=consumer_state_S_P_dP,
+                            consumer_state_dPsum=consumer_state_dPsum,
+                            producer_state_dS=producer_state_dS,
+                            partially_masked=False,
                         )
-                        #### STORE dK
-                        consumer_state_dKV = self.epilogue_dK_or_dV_tma(
-                            dp_idx,
-                            batch_idx,
-                            head_idx,
-                            n_block,
-                            thr_mma_dK,
-                            tdKtdK,
-                            mdK_tma_tensor,
-                            sdK,
-                            tma_atom_dK,
-                            thr_copy_r2s_dKV,
-                            pipeline_dKV,
-                            consumer_state_dKV,
-                            softmax_scale if const_expr(not self.dKV_postprocess) else None,
-                            int(NamedBarrierBwdSm100.EpilogueWG1),  # barrier_id
-                            mdK_semaphore,
-                            "K",
-                        )
-                if const_expr(self.enable_flashmask):
-                    flashmask_phase ^= 1
+                        if tidx == 0 and self.debug_print:
+                            cute.printf('n_block: %d, after compute_step LTE_max ~ seqlen_q: %d', n_block, m_block)
+            else:
+                # Mainloop
+                for m_block in cutlass.range(m_block_min, m_block_max, unroll=1):
+                    consumer_state_LSE, consumer_state_S_P_dP, consumer_state_dPsum, producer_state_dS = compute_step(
+                        m_block=m_block,
+                        consumer_state_LSE=consumer_state_LSE,
+                        consumer_state_S_P_dP=consumer_state_S_P_dP,
+                        consumer_state_dPsum=consumer_state_dPsum,
+                        producer_state_dS=producer_state_dS
+                    )
+
+            if not zero_block:
+                if const_expr(not self.use_tma_store):
+                    consumer_state_dKV = self.epilogue_dKV(
+                        dp_idx,
+                        warp_idx,
+                        batch_idx,
+                        head_idx,
+                        n_block,
+                        thr_mma_dV,
+                        thr_mma_dK,
+                        tdVtdV,
+                        tdKtdK,
+                        mdV,
+                        mdK,
+                        pipeline_dKV,
+                        consumer_state_dKV,
+                        softmax_scale,
+                    )
+                else:
+                    thr_copy_r2s_dKV = tiled_copy_r2s_dKV.get_slice(dp_idx)
+                    #### STORE dV
+                    consumer_state_dKV = self.epilogue_dK_or_dV_tma(
+                        dp_idx,
+                        batch_idx,
+                        head_idx,
+                        n_block,
+                        thr_mma_dV,
+                        tdVtdV,
+                        mdV_tma_tensor,
+                        sdV,
+                        tma_atom_dV,
+                        thr_copy_r2s_dKV,
+                        pipeline_dKV,
+                        consumer_state_dKV,
+                        None,  # Don't scale
+                        int(NamedBarrierBwdSm100.EpilogueWG1),  # barrier_id
+                        mdV_semaphore,
+                    )
+                    #### STORE dK
+                    consumer_state_dKV = self.epilogue_dK_or_dV_tma(
+                        dp_idx,
+                        batch_idx,
+                        head_idx,
+                        n_block,
+                        thr_mma_dK,
+                        tdKtdK,
+                        mdK_tma_tensor,
+                        sdK,
+                        tma_atom_dK,
+                        thr_copy_r2s_dKV,
+                        pipeline_dKV,
+                        consumer_state_dKV,
+                        softmax_scale if const_expr(self.qhead_per_kvhead == 1) else None,
+                        int(NamedBarrierBwdSm100.EpilogueWG1),  # barrier_id
+                        mdK_semaphore,
+                    )
+            if const_expr(self.enable_flashmask):
+                flashmask_phase ^= 1
 
             if tidx == 0 and self.debug_print:
                 cute.printf('n_block: %d, EEEEEEEEEEEEEEEEEEEE after compute_loop EEEEEEEEEEEEEEEEEEEE', n_block)
@@ -3592,58 +2484,22 @@ class FlashAttentionBackwardSm100:
         consumer_state_LSE: cutlass.pipeline.PipelineState,
         consumer_state_S_P_dP: cutlass.pipeline.PipelineState,
         consumer_state_dPsum: cutlass.pipeline.PipelineState,
-        producer_state_dS: cutlass.pipeline.PipelineState,
+        producer_state_dS: cutlass.pipeline.PipelineState, 
         mask_fn: Callable,
         partially_masked: bool = False,
-        sdS_xchg: cute.Tensor = None,
-        tRS_sdS_xchg = None,
-        exchange_stage: cute.Int32 = Int32(0),
-        dS_cluster_empty_mbar_ptr: cute.Pointer = None,
-        dS_cluster_full_mbar_ptr: cute.Pointer = None,
-        dQaccum_empty_mbar_ptr: Optional[cute.Pointer] = None,
-        sdS_epi_layout = None,
-        dS_cluster_empty_phase: cute.Int32 = Int32(1),
-        cta_rank_in_cluster: cute.Int32 = Int32(0),
-        tidx: cute.Int32 = Int32(0),
-        sdS: cute.Tensor = None,
-        iter_idx: cute.Int32 = Int32(0),
     ):
         # Prefetch 1 stage of LSE
-        if tidx == 0 and self.debug_print:
-            cute.printf('compute_step: CTA %d m_block=%d before LSE.consumer_wait', cute.arch.block_idx_in_cluster(), m_block)
         pipeline_LSE.consumer_wait(consumer_state_LSE)
-        if tidx == 0 and self.debug_print:
-            cute.printf('compute_step: CTA %d m_block=%d after LSE.consumer_wait', cute.arch.block_idx_in_cluster(), m_block)
         tSrLSE_s2r = cute.make_fragment(tScS_t2r[None, 0, 0, 0].shape, Float32)
         if const_expr(prefetch_LSE and not self.shuffle_LSE):
             cute.autovec_copy(tSsLSE[None, 0, 0, 0, consumer_state_LSE.index], tSrLSE_s2r)
     
-        if tidx == 0 and self.debug_print:
-            cute.printf('compute_step: CTA %d m_block=%d before S_P.consumer_wait', cute.arch.block_idx_in_cluster(), m_block)
         pipeline_S_P.consumer_wait(consumer_state_S_P_dP)
-        if tidx == 0 and self.debug_print:
-            cute.printf('compute_step: CTA %d m_block=%d after S_P.consumer_wait', cute.arch.block_idx_in_cluster(), m_block)
+        # pipeline_S_P.sync_object_full.wait(0, consumer_phase_S_P_dP)
         #### TMEM->RMEM (Load S from TMEM)
         tSrS_t2r = cute.make_fragment(tScS_t2r.shape, Float32)
         cute.copy(thr_copy_t2r, tStS_t2r, tSrS_t2r)
-
-        if const_expr(self.tile_hdim == 192):
-            cute.arch.fence_view_async_tmem_load()
-            if tidx == 0 and self.debug_print:
-                cute.printf('compute_step: CTA %d m_block=%d before S_P.consumer_release', cute.arch.block_idx_in_cluster(), m_block)
-            with cute.arch.elect_one():
-                pipeline_S_P.consumer_release(consumer_state_S_P_dP)
-            if tidx == 0 and self.debug_print:
-                cute.printf('compute_step: CTA %d m_block=%d after S_P.consumer_release', cute.arch.block_idx_in_cluster(), m_block)
-        elif const_expr(self.use_2cta_instrs and self.tile_hdim <= 128):
-            # Signal S tmem load completion using pipeline_dS when 2cta hdim 128
-            # dQ is overlapped with S
-            if iter_idx > 0:
-                cute.arch.fence_view_async_tmem_load()
-                with cute.arch.elect_one():
-                    pipeline_dS.producer_commit(producer_state_dS)
-                producer_state_dS.advance()
-
+    
         #### APPLY MASK
         mask_fn(tSrS_t2r, m_block=m_block, partially_masked=partially_masked)
     
@@ -3694,34 +2550,23 @@ class FlashAttentionBackwardSm100:
         cute.arch.fence_view_async_tmem_store()
         self.compute_sync_barrier.arrive_and_wait()
     
-        if const_expr(not self.tile_hdim == 192):
-            # Signal tmem store P completion with pipeline_S_P
-            with cute.arch.elect_one():
-                pipeline_S_P.consumer_release(consumer_state_S_P_dP)
+        with cute.arch.elect_one():
+            pipeline_S_P.consumer_release(consumer_state_S_P_dP)
+            # pipeline_S_P.sync_object_empty.arrive(0, pipeline_S_P.consumer_mask)
         pipeline_LSE.consumer_release(consumer_state_LSE)
+        # consumer_state_S_P_dP.advance()
         consumer_state_LSE.advance()
     
         # ---------------------------------------------
         # dS.T = P.T * (dP.T - D)
         # ---------------------------------------------
-        if tidx == 0 and self.debug_print:
-            cute.printf('compute_step: CTA %d m_block=%d before dPsum.consumer_wait', cute.arch.block_idx_in_cluster(), m_block)
         pipeline_dPsum.consumer_wait(consumer_state_dPsum)
-        if tidx == 0 and self.debug_print:
-            cute.printf('compute_step: CTA %d m_block=%d after dPsum.consumer_wait', cute.arch.block_idx_in_cluster(), m_block)
-
-        if tidx == 0 and self.debug_print:
-            cute.printf('compute_step: CTA %d m_block=%d before dP.consumer_wait', cute.arch.block_idx_in_cluster(), m_block)
+    
         pipeline_dP.consumer_wait(consumer_state_S_P_dP)
-        if tidx == 0 and self.debug_print:
-            cute.printf('compute_step: CTA %d m_block=%d after dP.consumer_wait', cute.arch.block_idx_in_cluster(), m_block)
         # pipeline_dP.sync_object_full.wait(0, consumer_phase_S_P_dP)
-        ### Now delayed to after loop
-        # consumer_state_S_P_dP.advance()
-        # if const_expr(self.use_2cta_instrs):
-        #     cute.arch.mbarrier_wait(dS_cluster_empty_mbar_ptr, phase=dS_cluster_empty_phase)
-        #     dS_cluster_empty_phase ^= 1
-
+        consumer_state_S_P_dP.advance()
+        # consumer_phase_S_P_dP ^= 1
+    
         ##### dS.T = P.T * (dP.T - Psum)
         for stage in cutlass.range_constexpr(num_stages):
             tdPrdP_t2r = cute.make_fragment(tScS_t2r[None, 0, None, None].shape, Float32)
@@ -3754,88 +2599,29 @@ class FlashAttentionBackwardSm100:
             tdPrdS_cvt = cute.make_fragment_like(tdPrdP_cur, self.ds_dtype)
             utils.cvt_f16(tdPrdP_cur, tdPrdS_cvt)
             if const_expr(stage == 0):
-                if tidx == 0 and self.debug_print:
-                    cute.printf('compute_step: CTA %d m_block=%d before dS.producer_acquire', cute.arch.block_idx_in_cluster(), m_block)
                 pipeline_dS.producer_acquire(producer_state_dS)
-                if tidx == 0 and self.debug_print:
-                    cute.printf('compute_step: CTA %d m_block=%d after dS.producer_acquire', cute.arch.block_idx_in_cluster(), m_block)
-                if const_expr(self.use_2cta_instrs):
-                    tdPrdS_xchg = cute.make_fragment_like(tdPrdS_cvt, self.ds_dtype)
-
-            # RMEM->TMEM: always write to TMEM for MMA
-            if const_expr(not self.use_smem_dS_for_mma_dK or self.use_2cta_instrs):
+            cute.autovec_copy(tdPrdS_cvt, tRS_sdS[None, stage])
+            if const_expr(not self.use_smem_dS_for_mma_dK):
                 tdPrdS_r2t_f32 = cute.recast_tensor(tdPrdS_cvt, Float32)
                 cute.copy(thr_copy_r2t, tdPrdS_r2t_f32, tdPtdS_r2t[None, stage, 0, 0])
-
-            # RMEM->SMEM: For 2-CTA, keep exchange stage in registers, write non-exchange to sdS
-            if const_expr(self.use_2cta_instrs):
-                if exchange_stage == stage:
-                    cute.autovec_copy(tdPrdS_cvt, tdPrdS_xchg)
-                else:
-                    cute.autovec_copy(tdPrdS_cvt, tRS_sdS[None, stage])
-            else:
-                cute.autovec_copy(tdPrdS_cvt, tRS_sdS[None, stage])
-
-
-
+    
         if const_expr(not self.use_smem_dS_for_mma_dK):
             cute.arch.fence_view_async_tmem_store()
-
-        if const_expr(self.use_2cta_instrs):
-            # use pipeline_dP to signal tmem store of dS
-            with cute.arch.elect_one():
-                pipeline_dP.consumer_release(consumer_state_S_P_dP)
-        consumer_state_S_P_dP.advance()
-
-        # After the loop: copy exchange registers to sdS_xchg buffer
-        if const_expr(self.use_2cta_instrs):
-            if const_expr(self.tile_hdim == 192):
-                if tidx == 0 and self.debug_print:
-                    cute.printf('compute_step: CTA %d m_block=%d before dQaccum_empty.mbarrier_wait phase=%d', cute.arch.block_idx_in_cluster(), m_block, producer_state_dS.phase)
-                cute.arch.mbarrier_wait(
-                    dQaccum_empty_mbar_ptr, phase=producer_state_dS.phase
-                )
-                if tidx == 0 and self.debug_print:
-                    cute.printf('compute_step: CTA %d m_block=%d after dQaccum_empty.mbarrier_wait', cute.arch.block_idx_in_cluster(), m_block)
-            cute.autovec_copy(tdPrdS_xchg, tRS_sdS_xchg[None, 0])
-
-        cute.arch.fence_view_async_shared()
+        cute.arch.fence_proxy(
+            cute.arch.ProxyKind.async_shared, space=cute.arch.SharedSpace.shared_cta
+        )
         self.compute_sync_barrier.arrive_and_wait()
+    
+        # with cute.arch.elect_one():
+        # The mma warp no longer waits for dP (it waits for dS), so we don't have to arrive
+        # pipeline_dP.sync_object_empty.arrive(0, pipeline_dP.consumer_mask)
         pipeline_dPsum.consumer_release(consumer_state_dPsum)
         consumer_state_dPsum.advance()
-        # when 2cta hdim 128, pipeline_dS also signals S tmem load completion so is deferred
-        if const_expr(not (self.use_2cta_instrs and self.tile_hdim == 128)):
-            with cute.arch.elect_one():
-                pipeline_dS.producer_commit(producer_state_dS)
-            producer_state_dS.advance()
+        with cute.arch.elect_one():
+            pipeline_dS.producer_commit(producer_state_dS)
+        producer_state_dS.advance()
 
-        # 2-CTA: DSMEM copy from sdS_xchg to peer's sdS buffer
-        if const_expr(self.use_2cta_instrs):
-            stage_copy_bytes = const_expr(self.tma_copy_bytes["dS"] // 2)
-            stage_copy_elems = const_expr(stage_copy_bytes // (self.ds_dtype.width // 8))
-            if tidx == 0:
-                peer_cta_rank_in_cluster = cta_rank_in_cluster ^ 1
-                smem_src_ptr = sdS_xchg.iterator
-                # Destination is peer's sdS at our CTA's offset (exchange_stage position)
-                smem_dst_ptr = sdS.iterator + cta_rank_in_cluster * stage_copy_elems
-                cute.arch.mbarrier_arrive_and_expect_tx(
-                    dS_cluster_full_mbar_ptr,
-                    stage_copy_bytes,
-                    peer_cta_rank_in_cluster=peer_cta_rank_in_cluster,
-                )
-                copy_utils.cpasync_bulk_s2cluster(
-                    smem_src_ptr,
-                    smem_dst_ptr,
-                    dS_cluster_full_mbar_ptr,
-                    stage_copy_bytes,
-                    peer_cta_rank_in_cluster=peer_cta_rank_in_cluster,
-                )
-
-
-        if tidx == 0 and self.debug_print:
-            cute.printf('compute_step: CTA %d m_block=%d end of compute_step', cute.arch.block_idx_in_cluster(), m_block)
-
-        return consumer_state_LSE, consumer_state_S_P_dP, consumer_state_dPsum, producer_state_dS, dS_cluster_empty_phase
+        return consumer_state_LSE, consumer_state_S_P_dP, consumer_state_dPsum, producer_state_dS
 
     @cute.jit
     def dQacc_reduce(
@@ -3845,7 +2631,6 @@ class FlashAttentionBackwardSm100:
         thr_mma_dQ: cute.core.ThrMma,
         tdQtdQ: cute.Tensor,
         pipeline_dQ: PipelineAsync,
-        dQaccum_empty_mbar_ptr: Optional[cute.Pointer],
         block_info: BlockInfo,
         SeqlenInfoCls: Callable,
         TileSchedulerCls: Callable,
@@ -3853,29 +2638,21 @@ class FlashAttentionBackwardSm100:
         flashmask_info: FlashMaskInfo,
         sFM_max_min: cute.Tensor,
         flashmask_loaded_mbar_ptr: cute.Pointer,
-        is_leader_cta: cutlass.Boolean,
     ):
         num_reduce_threads = cute.arch.WARP_SIZE * len(self.reduce_warp_ids)
         tidx = cute.arch.thread_idx()[0] % num_reduce_threads
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx() % len(self.reduce_warp_ids))
         is_tma_warp = warp_idx == 0
-        cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
         # TMEM -> RMEM
         tmem_load_atom = cute.make_copy_atom(
-            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(self.dQ_reduce_ncol_t2r)), Float32
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(self.dQ_reduce_ncol)), Float32
         )
         thr_copy_t2r = tcgen05.make_tmem_copy(tmem_load_atom, tdQtdQ).get_slice(tidx)
         tdQtdQ_t2r = thr_copy_t2r.partition_S(tdQtdQ)
         tdQcdQ = thr_mma_dQ.partition_C(cute.make_identity_tensor(self.mma_tiler_dsk[:2]))
         tdQrdQ_t2r_shape = thr_copy_t2r.partition_D(tdQcdQ).shape
-        expected_reduce_stages_t2r = self.dQaccum_reduce_stage_t2r // self.cta_group_size
-        assert cute.size(tdQrdQ_t2r_shape, mode=[1]) == expected_reduce_stages_t2r, (
-            "dQaccum t2r reduce stage mismatch"
-        )
-        expected_reduce_stages = self.dQaccum_reduce_stage // self.cta_group_size
-        # 2-CTA: CTA 0 -> (M/2, D) (stage 0, 1) & CTA 1 -> (M/2, D) (stage 2, 3)
-        stage_offset = (
-            expected_reduce_stages * cta_rank_in_cluster if const_expr(self.use_2cta_instrs) else Int32(0)
+        assert cute.size(tdQrdQ_t2r_shape, mode=[1]) == self.dQaccum_reduce_stage, (
+            "dQaccum reduce stage mismatch"
         )
 
         thr_copy_dQaccum_r2s = copy_utils.tiled_copy_1d(
@@ -3897,10 +2674,9 @@ class FlashAttentionBackwardSm100:
         )
         while work_tile.is_valid_tile:
             n_block, head_idx, batch_idx, _ = work_tile.tile_idx
-            n_block_cta_group = n_block // self.cta_group_size  # for 2cta
             seqlen = SeqlenInfoCls(batch_idx)
             m_block_min, m_block_max = block_info.get_m_block_min_max(
-                seqlen, n_block_cta_group
+                seqlen, n_block // self.cluster_shape_mnk[0]
             )
             mdQaccum_cur = mdQaccum[None, head_idx, batch_idx]
             gdQaccum_ = cute.local_tile(mdQaccum_cur, (self.tile_m * self.tile_hdim,), (None,))
@@ -3914,18 +2690,13 @@ class FlashAttentionBackwardSm100:
             else:
                 mdQ_semaphore_cur = None
 
-            delay_semaphore_release = not self.tile_hdim == 192
+            delay_semaphore_release = self.is_causal
             n_block_global_max = cute.ceil_div(seqlen.seqlen_k, self.tile_n)
-
-            if tidx == 0 and self.debug_print:
-                cute.printf('[dQacc_reduce] cta_rank=%d, n_block=%d, n_block_cta_group=%d, m_block_min=%d, m_block_max=%d, total_blocks=%d, stage_offset=%d, expected_stages=%d',
-                            cta_rank_in_cluster, n_block, n_block_cta_group, m_block_min, m_block_max, m_block_max - m_block_min, stage_offset, expected_reduce_stages)
 
             dQacc_reduce_step = partial(
                 self.dQacc_reduce_step,
                 m_block_min=m_block_min,
                 n_block=n_block,
-                n_block_cta_group=n_block_cta_group,
                 n_block_global_max=n_block_global_max,
                 tidx=tidx,
                 tdQrdQ_t2r_shape=tdQrdQ_t2r_shape,
@@ -3943,88 +2714,85 @@ class FlashAttentionBackwardSm100:
                 read_flag=read_flag,
                 is_tma_warp=is_tma_warp,
                 mdQ_semaphore_cur=mdQ_semaphore_cur,
-                stage_offset=stage_offset,
-                dQaccum_empty_mbar_ptr=dQaccum_empty_mbar_ptr,
             )
 
             if const_expr(self.enable_flashmask):
+                # 0: 0 ~ UTS_min, no mask
+                # 1: UTS_min ~ UTS_max, partially mask
+                # 2: UTS_max ~ UTE_min, full mask
+                # 3: UTE_min ~ UTE_max, partially mask
+                # 4: UTE_max ~ LTS_min, no mask
+                # 5: LTS_min ~ LTS_max, partially mask
+                # 6: LTS_max ~ LTE_min, full mask
+                # 7: LTE_min ~ LTE_max, partially mask
+                # 8: LTE_max ~ max_seq_k, no mask
+
+                # sFM_max_min[0], [1] -> LTS_max, LTS_min
+                # sFM_max_min[2], [3] -> LTE_max, LTE_min
+                # sFM_max_min[4], [5] -> UTS_max, UTS_min
+                # sFM_max_min[6], [7] -> UTE_max, UTE_min
                 cute.arch.mbarrier_wait(flashmask_loaded_mbar_ptr, flashmask_phase)
-                if const_expr(self.use_2cta_instrs):
-                    # 2CTA: process ALL blocks without skipping for pipeline sync.
-                    # Both CTAs have different flashmask boundaries but share pipelines.
-                    for m_block in cutlass.range(m_block_min, m_block_max, unroll=1):
+                loop_start = m_block_min
+                loop_end = m_block_max
+                for m_block in cutlass.range(m_block_min, m_block_max, unroll=1):
+                    full_mask = False
+                    if const_expr(not self.is_causal):
+                        UTS_max = -1
+                        if const_expr(flashmask_info.UTS_nblock_max is not None):
+                            UTS_max = sFM_max_min[4]
+                        UTE_min = sFM_max_min[7]
+                        if m_block > UTS_max and m_block < UTE_min:
+                            full_mask = True
+
+                    LTS_max = sFM_max_min[0]
+                    LTE_min = m_block_max
+                    if const_expr(flashmask_info.LTE_nblock_max is not None):
+                        LTE_min = sFM_max_min[3]
+
+                    if m_block > LTS_max and m_block < LTE_min:
+                        full_mask = True
+
+                    if not full_mask:
                         if tidx == 0 and self.debug_print:
-                            cute.printf('REDUCE 2CTA: cta_rank=%d, n_block=%d, m_block=%d of [%d,%d), stage_offset=%d', cta_rank_in_cluster, n_block, m_block, m_block_min, m_block_max, stage_offset)
+                            cute.printf('n_block: %d, m_block: %d, before reduce_step', n_block, m_block)
                         dQ_consumer_state, dQ_tma_store_producer_state = dQacc_reduce_step(
                             m_block=m_block,
                             dQ_consumer_state=dQ_consumer_state,
                             dQ_tma_store_producer_state=dQ_tma_store_producer_state,
                         )
                         if tidx == 0 and self.debug_print:
-                            cute.printf('n_block: %d, m_block: %d, after reduce_step 2CTA', n_block, m_block)
-                else:
-                    # 1CTA: skip full-mask blocks
-                    loop_start = m_block_min
-                    loop_end = m_block_max
-                    for m_block in cutlass.range(m_block_min, m_block_max, unroll=1):
-                        full_mask = False
-                        if const_expr(not self.is_causal):
-                            UTS_max = -1
-                            if const_expr(flashmask_info.UTS_nblock_max is not None):
-                                UTS_max = sFM_max_min[4]
-                            UTE_min = sFM_max_min[7]
-                            if m_block > UTS_max and m_block < UTE_min:
-                                full_mask = True
+                            cute.printf('n_block: %d, m_block: %d, after reduce_step', n_block, m_block)
 
-                        LTS_max = sFM_max_min[0]
-                        LTE_min = m_block_max
-                        if const_expr(flashmask_info.LTE_nblock_max is not None):
-                            LTE_min = sFM_max_min[3]
-
-                        if m_block > LTS_max and m_block < LTE_min:
-                            full_mask = True
-
-                        if not full_mask:
+                    if const_expr(self.deterministic):
+                        if full_mask:
                             if tidx == 0 and self.debug_print:
-                                cute.printf('n_block: %d, m_block: %d, before reduce_step', n_block, m_block)
-                            dQ_consumer_state, dQ_tma_store_producer_state = dQacc_reduce_step(
-                                m_block=m_block,
-                                dQ_consumer_state=dQ_consumer_state,
-                                dQ_tma_store_producer_state=dQ_tma_store_producer_state,
-                            )
-                            if tidx == 0 and self.debug_print:
-                                cute.printf('n_block: %d, m_block: %d, after reduce_step', n_block, m_block)
+                                cute.printf('n_block: %d, m_block: %d, before reduce_step SKIPPPPPPP', n_block, m_block)
 
-                        if const_expr(self.deterministic):
-                            if full_mask:
-                                if tidx == 0 and self.debug_print:
-                                    cute.printf('n_block: %d, m_block: %d, before reduce_step SKIPPPPPPP', n_block, m_block)
-
-                                if const_expr(self.spt):
-                                    n_block_max_for_m_block = min(
-                                        n_block_global_max,
-                                        cute.ceil_div(
-                                            (m_block + 1) * self.tile_m + seqlen.seqlen_k - seqlen.seqlen_q,
-                                            self.tile_n,
-                                        ),
-                                    )
-                                    lock_value = n_block_max_for_m_block - 1 - n_block_cta_group
-                                else:
-                                    lock_value = n_block_cta_group
-                                barrier.wait_eq(
-                                    mdQ_semaphore_cur[(m_block, None)].iterator, tidx, cta_rank_in_cluster, lock_value
+                            if const_expr(self.spt):
+                                n_block_max_for_m_block = min(
+                                    n_block_global_max,
+                                    cute.ceil_div(
+                                        (m_block + 1) * self.tile_m + seqlen.seqlen_k - seqlen.seqlen_q,
+                                        self.tile_n,
+                                    ),
                                 )
+                                lock_value = n_block_max_for_m_block - 1 - n_block
+                            else:
+                                lock_value = n_block
+                            barrier.wait_eq(
+                                mdQ_semaphore_cur[(m_block, None)].iterator, tidx, 0, lock_value
+                            )
 
-                                if const_expr(delay_semaphore_release):
-                                    if m_block > m_block_min:
-                                        barrier.arrive_inc(
-                                            mdQ_semaphore_cur[(m_block - 1, None)].iterator, tidx, cta_rank_in_cluster, 1
-                                        )
-                                else:
-                                    barrier.arrive_inc(mdQ_semaphore_cur[m_block, None].iterator, tidx, cta_rank_in_cluster, 1)
+                            if const_expr(delay_semaphore_release):
+                                if m_block > m_block_min:
+                                    barrier.arrive_inc(
+                                        mdQ_semaphore_cur[(m_block - 1, None)].iterator, tidx, 0, 1
+                                    )
+                            else:
+                                barrier.arrive_inc(mdQ_semaphore_cur[m_block, None].iterator, tidx, 0, 1)
 
-                                if tidx == 0 and self.debug_print:
-                                    cute.printf('n_block: %d, m_block: %d, after reduce_step SKIPPPPPPP', n_block, m_block)
+                            if tidx == 0 and self.debug_print:
+                                cute.printf('n_block: %d, m_block: %d, after reduce_step SKIPPPPPPP', n_block, m_block)
 
             else:
                 for m_block in cutlass.range(m_block_min, m_block_max, unroll=1):
@@ -4039,7 +2807,7 @@ class FlashAttentionBackwardSm100:
             self.reduce_sync_barrier.arrive_and_wait()
             # final semaphore release
             if const_expr(self.deterministic and delay_semaphore_release):
-                barrier.arrive_inc(mdQ_semaphore_cur[(m_block_max - 1, None)].iterator, tidx, cta_rank_in_cluster, 1)
+                barrier.arrive_inc(mdQ_semaphore_cur[(m_block_max - 1, None)].iterator, tidx, 0, 1)
 
             if const_expr(self.enable_flashmask):
                 flashmask_phase ^= 1
@@ -4055,7 +2823,6 @@ class FlashAttentionBackwardSm100:
         m_block: cute.Int32,
         m_block_min: cute.Int32,
         n_block: cute.Int32,
-        n_block_cta_group: cute.Int32,
         n_block_global_max: cute.Int32,
         tidx: cute.Int32,
         tdQrdQ_t2r_shape: cute.Shape,
@@ -4073,12 +2840,9 @@ class FlashAttentionBackwardSm100:
         read_flag: bool,
         is_tma_warp: bool,
         mdQ_semaphore_cur: Optional[cute.Tensor],
-        stage_offset: cute.Int32,
-        dQaccum_empty_mbar_ptr: Optional[cute.Pointer],
     ):
         num_reduce_threads = cute.arch.WARP_SIZE * len(self.reduce_warp_ids)
         tidx = cute.arch.thread_idx()[0] % num_reduce_threads
-        cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
         if tidx == 0 and self.debug_print:
             cute.printf('n_block: %d, m_block:%d, reduce_step before pipeline_dQ.consumer_wait', n_block, m_block)
         pipeline_dQ.consumer_wait(dQ_consumer_state)
@@ -4094,24 +2858,20 @@ class FlashAttentionBackwardSm100:
             cute.printf('n_block: %d, m_block:%d, reduce_step after pipeline_dQ.consumer_wait', n_block, m_block)
     
         gdQaccum_cur = gdQaccum[None, None, m_block]
-
-        tdQrdQ_shape = (
-            self.dQ_reduce_ncol,
-            self.tile_hdim // self.cta_group_size // self.dQ_reduce_ncol,
-        )
-        tdQrdQ = cute.make_tensor(tdQrdQ_t2r.iterator, tdQrdQ_shape)
-
-        for stage in cutlass.range_constexpr(cute.size(tdQrdQ, mode=[1])):  # 4
+    
+        for stage in cutlass.range_constexpr(cute.size(tdQrdQ_t2r, mode=[1])):  # 4
             if tidx == 0 and self.debug_print:
-                cute.printf('REDUCE_STEP: cta_rank=%d, n_block=%d, m_block=%d, stage=%d, stage+offset=%d', cta_rank_in_cluster, n_block, m_block, stage, stage + stage_offset)
+                cute.printf('n_block: %d, m_block: %d, stage: %d, reduce_step before dQ_tma_store_producer_state.advance', n_block, m_block, stage)
             smem_idx = dQ_tma_store_producer_state.index
             tdQsdQ_r2s = tdQsdQ[None, None, smem_idx]
             tdQrdQ_r2s = cute.make_tensor(
-                tdQrdQ[None, stage].iterator, tdQsdQ_r2s.shape
+                tdQrdQ_t2r[None, stage, None, None].iterator, tdQsdQ_r2s.shape
             )
             cute.copy(thr_copy_dQaccum_r2s, tdQrdQ_r2s, tdQsdQ_r2s)
             # Fence and barrier to make sure shared memory store is visible to TMA store
-            cute.arch.fence_view_async_shared()
+            cute.arch.fence_proxy(
+                cute.arch.ProxyKind.async_shared, space=cute.arch.SharedSpace.shared_cta
+            )
             # semaphore acquire
             if const_expr(self.deterministic and stage == 0):
                 if const_expr(self.spt):
@@ -4122,13 +2882,13 @@ class FlashAttentionBackwardSm100:
                             self.tile_n,
                         ),
                     )
-                    lock_value = n_block_max_for_m_block - 1 - n_block_cta_group
+                    lock_value = n_block_max_for_m_block - 1 - n_block
                 else:
-                    lock_value = n_block_cta_group
+                    lock_value = n_block
                 if tidx == 0 and self.debug_print:
                     cute.printf('n_block: %d, m_block: %d, stage: %d, lock_value: %d, reduce_step before barrier.wait_eq', n_block, m_block, stage, lock_value)
                 barrier.wait_eq(
-                    mdQ_semaphore_cur[(m_block, None)].iterator, tidx, cta_rank_in_cluster, lock_value
+                    mdQ_semaphore_cur[(m_block, None)].iterator, tidx, 0, lock_value
                 )
                 if tidx == 0 and self.debug_print:
                     cute.printf('n_block: %d, m_block: %d, stage: %d, lock_value: %d, reduce_step after barrier.wait_eq', n_block, m_block, stage, lock_value)
@@ -4138,7 +2898,7 @@ class FlashAttentionBackwardSm100:
                 with cute.arch.elect_one():
                     copy_utils.cpasync_reduce_bulk_add_f32(
                         sdQaccum[None, smem_idx].iterator,
-                        gdQaccum_cur[None, stage + stage_offset].iterator,
+                        gdQaccum_cur[None, stage].iterator,
                         self.tma_copy_bytes["dQ"] // 1,
                     )
                 cute.arch.cp_async_bulk_commit_group()
@@ -4164,27 +2924,20 @@ class FlashAttentionBackwardSm100:
                     if tidx == 0 and self.debug_print:
                         cute.printf('n_block: %d, m_block: %d, stage: %d, lock_value: %d, reduce_step before barrier.arrive_inc in stage', n_block, m_block, stage, lock_value)
                     barrier.arrive_inc(
-                        mdQ_semaphore_cur[(m_block - 1, None)].iterator, tidx, cta_rank_in_cluster, 1
+                        mdQ_semaphore_cur[(m_block - 1, None)].iterator, tidx, 0, 1
                     )
                     if tidx == 0 and self.debug_print:
                         cute.printf('n_block: %d, m_block: %d, stage: %d, lock_value: %d, reduce_step after barrier.arrive_inc in stage', n_block, m_block, stage, lock_value)
     
-        if const_expr(self.tile_hdim == 192):
-            if const_expr(self.sdQaccum_stage > 1):
-                if is_tma_warp:
-                    cute.arch.cp_async_bulk_wait_group(0, read=read_flag)
-                self.reduce_sync_barrier.arrive_and_wait()
-            with cute.arch.elect_one():
-                cute.arch.mbarrier_arrive(dQaccum_empty_mbar_ptr)
-
         # semaphore release
         # NOTE: arrive_inc calls red_release which issues membar
         if const_expr(self.deterministic and not delay_semaphore_release):
-            if const_expr(self.sdQaccum_stage > 1 and not self.tile_hdim == 192):
-                if is_tma_warp:
-                    cute.arch.cp_async_bulk_wait_group(0, read=read_flag)
-                self.reduce_sync_barrier.arrive_and_wait()
-            barrier.arrive_inc(mdQ_semaphore_cur[m_block, None].iterator, tidx, cta_rank_in_cluster, 1)
+            if tidx == 0 and self.debug_print:
+                cute.printf('n_block: %d, m_block: %d, reduce_step before barrier.arrive_inc', n_block, m_block)
+            if is_tma_warp:
+                cute.arch.cp_async_bulk_wait_group(0, read=read_flag)
+            self.reduce_sync_barrier.arrive_and_wait()
+            barrier.arrive_inc(mdQ_semaphore_cur[m_block, None].iterator, tidx, 0, 1)
             if tidx == 0 and self.debug_print:
                 cute.printf('n_block: %d, m_block: %d, reduce_step after barrier.arrive_inc', n_block, m_block)
 
@@ -4258,8 +3011,8 @@ class FlashAttentionBackwardSm100:
             dV_vec = tdVrdV_t2r[(None, i, 0, 0)].load()
             tdVrdV_r2s[(None, i, 0, 0)].store(dV_vec.to(self.dv_dtype))
 
-        gdV = cute.local_tile(mdV_cur, (self.mma_tiler_pdo[0], self.tile_hdimv), (None, 0))
-        gdV_tile = gdV[None, None, n_block // self.cta_group_size]
+        gdV = cute.local_tile(mdV_cur, (self.tile_m, self.tile_hdimv), (None, 0))
+        gdV_tile = gdV[None, None, n_block]
 
         tdVgdV = thr_mma_dV.partition_C(gdV_tile)
         tdVgdV_r2g_p = thr_tmem_ld_dV.partition_D(tdVgdV)
@@ -4311,8 +3064,8 @@ class FlashAttentionBackwardSm100:
             dK_vec = tdKrdK_t2r[(None, i, 0, 0)].load() * softmax_scale
             tdKrdK_r2s[(None, i, 0, 0)].store(dK_vec.to(self.dk_dtype))
 
-        gdK = cute.local_tile(mdK_cur, (self.mma_tiler_dsq[0], self.tile_hdim), (None, 0))
-        gdK_tile = gdK[None, None, n_block // self.cta_group_size]
+        gdK = cute.local_tile(mdK_cur, (self.tile_n, self.tile_hdimv), (None, 0))
+        gdK_tile = gdK[None, None, n_block]
 
         tdKgdK = thr_mma_dK.partition_C(gdK_tile)
         tdKgdK_r2g_p = thr_tmem_ld_dK.partition_D(tdKgdK)
@@ -4344,23 +3097,15 @@ class FlashAttentionBackwardSm100:
         scale: Optional[Float32],
         barrier_id: Int32,
         mdKV_semaphore: Optional[cute.Tensor],
-        K_or_V: cutlass.Constexpr[str],
     ) -> cutlass.pipeline.PipelineState:
-        assert K_or_V in ("K", "V")
-        tile_hdim = self.tile_hdim if const_expr(K_or_V == "K") else self.tile_hdimv
-        dtype = self.dk_dtype if const_expr(K_or_V == "K") else self.dv_dtype
-        epi_tile = self.sdK_epi_tile if const_expr(K_or_V == "K") else self.sdV_epi_tile
-        flat_epi_tile = (
-            self.sdK_flat_epi_tile if const_expr(K_or_V == "K") else self.sdV_flat_epi_tile
-        )
+        # assumes mma_tiler_pdo = mma_tiler_dsq = (tile_n, head_dim)
+        # head_dim = head_dim_v, dk_dtype = dv_dtype
         num_compute_threads = cute.arch.WARP_SIZE * len(self.compute_warp_ids)
         wg_idx = (cute.arch.thread_idx()[0] % num_compute_threads) // 128
         num_wg = num_compute_threads // 128
         leader_warp = (cute.arch.make_warp_uniform(cute.arch.warp_idx()) % 4) == 0
 
-        cta_group_tile_n = const_expr(self.tile_n * self.cta_group_size)
-
-        if const_expr(not self.dKV_postprocess):
+        if const_expr(self.qhead_per_kvhead == 1):
             sdKV = sdKV[None, None, wg_idx]  # (tile_n, 64) for bf16
         else:
             sdKV = sdKV[None, wg_idx]  # (tile_n * 32) for fp32
@@ -4369,32 +3114,32 @@ class FlashAttentionBackwardSm100:
         tdKVsdKV_r2s = thr_copy_r2s_dKV.partition_D(sdKV)
 
         head_idx_kv = head_idx // self.qhead_per_kvhead
-        if const_expr(not self.dKV_postprocess):
+        if const_expr(self.qhead_per_kvhead == 1):
             mdKV_cur = mdKV[None, None, head_idx_kv, batch_idx]  # (seqlen, hdim)
             gdKV_p = cute.local_tile(
-                mdKV_cur, (self.tile_n, tile_hdim), (n_block, 0)
+                mdKV_cur, (self.tile_n, self.tile_hdim), (n_block, 0)
             )  # (tile_n, hdim)
             gdKV = self.split_wg(gdKV_p, wg_idx, num_wg)  # (tile_n, hdim / 2)
             gdKV_epi = cute.local_tile(
-                gdKV, epi_tile, (0, None)
+                gdKV, self.sdKV_epi_tile, (0, None)
             )  # (tile_n, 64, epi_stage = (hdim / 2) / 64)
         else:
             mdKV_cur = mdKV[None, head_idx_kv, batch_idx]  # (seqlen * hdim)
             gdKV_p = cute.local_tile(
-                mdKV_cur, (self.tile_n * tile_hdim,), (n_block,)
+                mdKV_cur, (self.tile_n * self.tile_hdim,), (n_block,)
             )  # (tile_n * hdim)
-            gdKV = cute.logical_divide(gdKV_p, (self.tile_n * tile_hdim // num_wg,))[
+            gdKV = cute.logical_divide(gdKV_p, (self.tile_n * self.tile_hdim // num_wg,))[
                 ((None, wg_idx),)
             ]  # (tile_n * hdim / 2)
             gdKV_epi = cute.flat_divide(
-                gdKV, (flat_epi_tile,)
+                gdKV, (self.sdKV_flat_epi_tile,)
             )  # (tile_n * hdim / 2 / epi_stage, epi_stage)
 
-        deterministic_KV = self.deterministic and self.dKV_postprocess
+        deterministic_KV = self.deterministic and self.qhead_per_kvhead > 1
         if const_expr(deterministic_KV):
             mdKV_semaphore_cur = mdKV_semaphore[n_block, None, head_idx_kv, batch_idx]
 
-        if const_expr(not self.dKV_postprocess):
+        if const_expr(self.qhead_per_kvhead == 1):
             tdKVsdKV, tdKVgdKV = cpasync.tma_partition(
                 tma_atom_dKV,
                 0,  # no multicast
@@ -4405,12 +3150,9 @@ class FlashAttentionBackwardSm100:
             assert len(tdKVsdKV.shape) == 1, "Wrong rank for SMEM fragment tdKVsdKV"
             assert len(tdKVgdKV.shape) == 2, "Wrong rank for GMEM fragment tdKVgdKV"
             num_epi_stages = cute.size(tdKVgdKV.shape[1])
-            if const_expr(K_or_V == "K"):
-                assert num_epi_stages == self.num_epi_stages, f"Epi stage calculation is wrong (K). num_epi_stages:{num_epi_stages} != self.num_epi_stages: {self.num_epi_stages}"
-            else:
-                assert num_epi_stages == self.num_epi_stages_v, f"Epi stage calculation is wrong (V). num_epi_stages:{num_epi_stages} != self.num_epi_stages_v: {self.num_epi_stages_v}"
+            assert num_epi_stages == self.num_epi_stages, f"Epi stage calculation is wrong. num_epi_stages:{num_epi_stages} != self.num_epi_stages: {self.num_epi_stages}"
         else:
-            num_epi_stages = self.num_epi_stages if const_expr(K_or_V == "K") else self.num_epi_stages_v
+            num_epi_stages = self.num_epi_stages
 
         tmem_load_atom = cute.make_copy_atom(
             tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32)), Float32
@@ -4435,7 +3177,7 @@ class FlashAttentionBackwardSm100:
             if const_expr(num_epi_stages > 1):
                 tdKVtdKV_t2r = tdKVtdKV_t2r[None, epi_stage]
 
-            cdKV = cute.make_identity_tensor((cta_group_tile_n, tile_hdim))
+            cdKV = cute.make_identity_tensor((self.tile_n, self.tile_hdim))
             tdKVcdKV = thr_mma.partition_C(cdKV)
             tdKVcdKV_t2r_p = thr_copy_t2r.partition_D(tdKVcdKV)
             tdKVcdKV_t2r = self.split_wg(tdKVcdKV_t2r_p, wg_idx, num_wg)[None, None, 0, 0]
@@ -4458,18 +3200,20 @@ class FlashAttentionBackwardSm100:
                     tdKVrdKV_t2r[2 * i], tdKVrdKV_t2r[2 * i + 1] = utils.mul_packed_f32x2(
                         (tdKVrdKV_t2r[2 * i], tdKVrdKV_t2r[2 * i + 1]), (scale, scale)
                     )
-            tdKVrdKV = cute.make_fragment(tdKVrdKV_t2r.shape, dtype)  # (32 columns)
-            tdKVrdKV.store(tdKVrdKV_t2r.load().to(dtype))
+            tdKVrdKV = cute.make_fragment(tdKVrdKV_t2r.shape, self.dv_dtype)  # (32 columns)
+            tdKVrdKV.store(tdKVrdKV_t2r.load().to(self.dv_dtype))
 
             # RMEM -> SMEM -- copy, fence and barrier
             tdKVrdKV_r2s = cute.make_tensor(tdKVrdKV.iterator, tdKVsdKV_r2s.shape)
             cute.copy(thr_copy_r2s_dKV, tdKVrdKV_r2s, tdKVsdKV_r2s)
-            cute.arch.fence_view_async_shared()
+            cute.arch.fence_proxy(
+                cute.arch.ProxyKind.async_shared, space=cute.arch.SharedSpace.shared_cta
+            )
             cute.arch.barrier(barrier_id=barrier_id + wg_idx, number_of_threads=128)
 
             # SMEM -> GMEM
             if leader_warp:
-                if const_expr(not self.dKV_postprocess):
+                if const_expr(self.qhead_per_kvhead == 1):
                     cute.copy(tma_atom_dKV, tdKVsdKV, tdKVgdKV[None, epi_stage])
                 else:
                     with cute.arch.elect_one():
@@ -4486,7 +3230,9 @@ class FlashAttentionBackwardSm100:
                 )
 
             # Barrier since all warps need to wait for SMEM to be freed
-            cute.arch.fence_view_async_shared()
+            cute.arch.fence_proxy(
+                cute.arch.ProxyKind.async_shared, space=cute.arch.SharedSpace.shared_cta
+            )
             cute.arch.barrier(
                 barrier_id=barrier_id + wg_idx, number_of_threads=128 + cute.arch.WARP_SIZE
             )

--- a/flashmask/flash_mask/cute/flash_fwd_sm100.py
+++ b/flashmask/flash_mask/cute/flash_fwd_sm100.py
@@ -233,13 +233,7 @@ class FlashAttentionForwardSm100:
         - Configures pipeline stages for softmax, correction, and epilogue operations
         """
 
-        if self.head_dim_padded == 192 and self.head_dim_v_padded == 128:
-            self.kv_stage = 2 if self.enable_flashmask else 3
-        elif self.q_dtype.width == 8 or self.q_stage == 1:
-            self.kv_stage = 4
-        else:
-            self.kv_stage = 3
-
+        self.kv_stage = 4 if self.q_dtype.width == 8 else 3
         self.acc_stage = 1
         self.epi_stage = 2
         self.generate_block_stage = 2

--- a/flashmask/flash_mask/cute/interface.py
+++ b/flashmask/flash_mask/cute/interface.py
@@ -641,8 +641,6 @@ def _flash_attn_bwd(
         cute_flashmask_info = to_cute_flashmask_info(flashmask_info)
         num_flashmask_tensors = 2 * flashmask_info.startend_row_indices.shape[-1]
 
-    num_head, head_dim = q.shape[-2:]
-
     if compute_capability == 9:
         m_block_size = 80 if not causal else 64
         n_block_size = 128
@@ -663,16 +661,13 @@ def _flash_attn_bwd(
         dKV_swapAB = False
         AtomLayoutMdQ = 1
         AtomLayoutNdKV = 1
-
-        need_large_cluster = (head_dim > 128) or (head_dim == 128 and flashmask_info is None)
-        cluster_size = 2 if need_large_cluster else 1
-        use_2cta_instrs = cluster_size == 2
-
+        # TODO: support cluster size 2
+        cluster_size = 1
     q, k, v, out, dout, lse, cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k = [
         maybe_contiguous(t)
         for t in (q, k, v, out, dout, lse, cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k)
     ]
-
+    num_head, head_dim = q.shape[-2:]
     if cu_seqlens_q is None:
         batch_size, seqlen_q = q.shape[:2]
         total_q = batch_size * seqlen_q
@@ -829,7 +824,7 @@ def _flash_attn_bwd(
     ]
     if deterministic:
         dQ_semaphore = paddle.zeros(
-            shape=[batch_size, num_head, seqlen_q_rounded // m_block_size, cluster_size], dtype=paddle.int32
+            shape=[batch_size, num_head, seqlen_q_rounded // m_block_size, 1], dtype=paddle.int32
         )
     else:
         dQ_semaphore = None
@@ -863,11 +858,10 @@ def _flash_attn_bwd(
     current_stream = cuda.CUstream(paddle.device.current_stream().stream_base.cuda_stream)
 
     # Preprocess kernel: compute (o * dout).sum(dim=-1), lse * log2_e, and zero out dq_accum.
-    compile_key_pre = (compute_capability, dtype, head_dim, head_dim_v, head_dim_rounded, m_block_size, num_threads)
+    compile_key_pre = (compute_capability, dtype, head_dim_v, head_dim_rounded, m_block_size, num_threads)
     if compile_key_pre not in _flash_attn_bwd.compile_cache_pre:
         fa_bwd_pre = FlashAttentionBackwardPreprocess(
             dtype,
-            head_dim,
             head_dim_v,
             m_block_size,
             num_threads=num_threads,
@@ -992,7 +986,7 @@ def _flash_attn_bwd(
                 # tile_m=m_block_size,
                 # tile_n=n_block_size,
                 cluster_size=cluster_size,
-                use_2cta_instrs=use_2cta_instrs,
+                # cluster_size=1,
                 deterministic=deterministic,
             )
         # TODO: check @can_implement
@@ -1043,11 +1037,10 @@ def _flash_attn_bwd(
     num_threads = 256 if compute_capability == 9 else 128
     arch = compute_capability * 10
     # Postprocess kernel: convert dq_accum from float32 to dq in bf16/fp16
-    compile_key_post = (dtype, head_dim, arch, m_block_size, num_threads, AtomLayoutMdQ, dQ_swapAB, use_2cta_instrs)
+    compile_key_post = (dtype, head_dim, arch, m_block_size, num_threads, AtomLayoutMdQ, dQ_swapAB)
     if compile_key_post not in _flash_attn_bwd.compile_cache_post:
         fa_bwd_post = FlashAttentionBackwardPostprocess(
-            dtype, head_dim, arch, m_block_size, num_threads, AtomLayoutMdQ, dQ_swapAB,
-            use_2cta_instrs=use_2cta_instrs,
+            dtype, head_dim, arch, m_block_size, num_threads, AtomLayoutMdQ, dQ_swapAB
         )
         # TODO: check @can_implement
         _flash_attn_bwd.compile_cache_post[compile_key_post] = cute.compile(
@@ -1073,8 +1066,7 @@ def _flash_attn_bwd(
         compile_key_post = (dtype, head_dim, arch, n_block_size, num_threads, AtomLayoutNdKV, dKV_swapAB)
         if compile_key_post not in _flash_attn_bwd.compile_cache_post:
             fa_bwd_post = FlashAttentionBackwardPostprocess(
-                dtype, head_dim, arch, n_block_size, num_threads, AtomLayoutNdKV, dKV_swapAB,
-                cluster_size=cluster_size,
+                dtype, head_dim, arch, n_block_size, num_threads, AtomLayoutNdKV, dKV_swapAB
             )
             # TODO: check @can_implement
             _flash_attn_bwd.compile_cache_post[compile_key_post] = cute.compile(
@@ -1105,8 +1097,7 @@ def _flash_attn_bwd(
         )
         if compile_key_post not in _flash_attn_bwd.compile_cache_post:
             fa_bwd_post = FlashAttentionBackwardPostprocess(
-                dtype, head_dim_v, arch, n_block_size, num_threads, AtomLayoutNdKV, dKV_swapAB,
-                cluster_size=cluster_size,
+                dtype, head_dim_v, arch, n_block_size, num_threads, AtomLayoutNdKV, dKV_swapAB
             )
             # TODO: check @can_implement
             _flash_attn_bwd.compile_cache_post[compile_key_post] = cute.compile(
@@ -1705,11 +1696,7 @@ def flashmask_attention(
 ):
     if (
         paddle.base.framework.get_flags(["FLAGS_flash_attn_version"])["FLAGS_flash_attn_version"] == 4
-        and (
-            (query.shape[-1] <= 128 and key.shape[-1] <= 128 and value.shape[-1] <= 128)
-            or
-            (query.shape[-1] == 192 and key.shape[-1] == 192 and value.shape[-1] == 128)
-        )
+        and query.shape[-1] <= 128 and key.shape[-1] <= 128 and value.shape[-1] <= 128
         and (startend_row_indices is None or startend_row_indices.shape[-1] != 4)
     ):
         assert dropout == 0.0, (
@@ -1845,11 +1832,7 @@ def flash_attention(
 ):
     if (
         paddle.base.framework.get_flags(["FLAGS_flash_attn_version"])["FLAGS_flash_attn_version"] == 4
-        and (
-            (query.shape[-1] <= 128 and key.shape[-1] <= 128 and value.shape[-1] <= 128)
-            or
-            (query.shape[-1] == 192 and key.shape[-1] == 192 and value.shape[-1] == 128)
-        )
+        and query.shape[-1] <= 128 and key.shape[-1] <= 128 and value.shape[-1] <= 128
     ):
         assert dropout == 0.0, (
             "flash attention 4 does not support dropout"

--- a/flashmask/flash_mask/cute/mask.py
+++ b/flashmask/flash_mask/cute/mask.py
@@ -256,10 +256,10 @@ class AttentionMask:
                             )
                         if const_expr(self.window_size_right is not None):
                             col_limit_right = row_idx + local_row_offset_right
+                            if const_expr(mask_seqlen):
+                                col_limit_right = cutlass.min(col_limit_right, seqlenk_col_limit)
                         else:
                             col_limit_right = self.tile_n
-                        if const_expr(mask_seqlen):
-                            col_limit_right = cutlass.min(col_limit_right, seqlenk_col_limit)
                         col_limit_left = (
                             row_idx + local_row_offset_left
                             if const_expr(self.window_size_left is not None)
@@ -442,10 +442,10 @@ class AttentionMask:
                 )
                 if const_expr(self.window_size_right is not None):
                     col_limit_right = row_idx + local_row_offset_right
+                    if const_expr(mask_seqlen):
+                        col_limit_right = cutlass.min(col_limit_right, seqlenk_col_limit)
                 else:
                     col_limit_right = self.tile_n
-                if const_expr(mask_seqlen):
-                    col_limit_right = cutlass.min(col_limit_right, seqlenk_col_limit)
                 col_limit_left = (
                     row_idx + local_row_offset_left
                     if const_expr(self.window_size_left is not None)
@@ -512,7 +512,6 @@ class AttentionMask:
         mask_local: cutlass.Constexpr,
         sStartEndRowIndices: cute.Tensor,
         partially_masked: bool,
-        per_cta_tile_n: cutlass.Constexpr[int] = 0,
     ) -> None:
         """
         Backward pass: mask S = K @ Q.T where n_block tiles seqlen_k and m_block tiles seqlen_q.
@@ -520,26 +519,20 @@ class AttentionMask:
         assert not (mask_causal and mask_local), "mask_causal and mask_local cannot be both True"
         ROW = 0 if const_expr(not self.swap_AB) else 1
         COL = 1 if const_expr(not self.swap_AB) else 0
-        # assert t0ScS_t2r[0][COL] == 0, "col0 == 0" # tmp comment for 2-cta bwd
         thr_col_offset = tScS_t2r[0][COL]
         seqlenk_col_limit = self.seqlen_k - n_block * self.tile_n - thr_col_offset
         #cute.printf('seqlenk_col_limit: %d, thr_col_offset: %d, t0ScS_t2r[0][COL]: %d, %d', seqlenk_col_limit, thr_col_offset, t0ScS_t2r[0][COL], t0ScS_t2r[32][COL])
         #cute.print_tensor(t0ScS_t2r)
         if const_expr(not mask_causal and not mask_local):
             if const_expr(mask_seqlen):
-                if seqlenk_col_limit <= 0:
+                if t0ScS_t2r[0][COL] >= seqlenk_col_limit:
                     for i in cutlass.range(cute.size(acc_S.shape), unroll_full=True):
                         acc_S[i] = -cutlass.Float32.inf
             # FlashMask
             if partially_masked:
-                # In 2CTA mode, COL coordinates span cta_group_size * tile_n (e.g. 256),
-                # but sStartEndRowIndices has per-CTA tile_n entries (e.g. 128).
-                # Convert global COL to per-CTA local coordinate.
-                _fm_tile_n = per_cta_tile_n if const_expr(per_cta_tile_n > 0) else self.tile_n
                 for i in cutlass.range(cute.size(acc_S.shape), unroll_full=True):
-                    col_local = tScS_t2r[i][COL] % _fm_tile_n
-                    lts = sStartEndRowIndices[col_local, 0] - m_block * self.tile_m 
-                    ute = sStartEndRowIndices[col_local, 1] - m_block * self.tile_m
+                    lts = sStartEndRowIndices[tScS_t2r[i][COL], 0] - m_block * self.tile_m 
+                    ute = sStartEndRowIndices[tScS_t2r[i][COL], 1] - m_block * self.tile_m
                     acc_S[i] = (
                         -cutlass.Float32.inf if tScS_t2r[i][ROW] >= lts else acc_S[i]
                     )
@@ -549,17 +542,19 @@ class AttentionMask:
 
         else:  # Causal or local
             thr_row_offset = tScS_t2r[0][ROW]
-            seqlenq_row_limit = self.seqlen_q - m_block * self.tile_m - thr_row_offset
-            causal_offset = seqlenq_row_limit - seqlenk_col_limit
+            causal_row_offset = (
+                seqlenk_col_limit - self.seqlen_q + m_block * self.tile_m + thr_row_offset
+            )
             if const_expr(mask_causal):
+                col0 = t0ScS_t2r[0][COL]
+                row_limit_top = col0 - causal_row_offset
                 # tidx = cute.arch.thread_idx()[0] % 256
                 # if tidx < 32:
-                #     cute.printf("tidx = {}, {} {}, {} {}", tidx, tScS_t2r[0][0], tScS_t2r[0][1], tScS_t2r[1][0], tScS_t2r[1][1])
-                row_limit_top = causal_offset
+                #     cute.printf("tidx = {}, {} {}, {} {}, col0 = {}", tidx, tScS_t2r[0][0], tScS_t2r[0][1], tScS_t2r[1][0], tScS_t2r[1][1], col0)
                 if const_expr(mask_seqlen):
                     # If col is beyond the column limit, we want to mask out the entire
                     # column, by setting row limit to be self.tile_m.
-                    if seqlenk_col_limit <= 0:
+                    if t0ScS_t2r[0][COL] >= seqlenk_col_limit:
                         row_limit_top = self.tile_m
 
                 r2p = True
@@ -574,14 +569,9 @@ class AttentionMask:
 
                 if partially_masked:
                     # FlashMask
-                    # In 2CTA mode, COL coordinates span cta_group_size * tile_n (e.g. 256),
-                    # but sStartEndRowIndices has per-CTA tile_n entries (e.g. 128).
-                    # Convert global COL to per-CTA local coordinate.
-                    _fm_tile_n = per_cta_tile_n if const_expr(per_cta_tile_n > 0) else self.tile_n
                     for i in cutlass.range(cute.size(acc_S.shape), unroll_full=True):
-                        col_local = tScS_t2r[i][COL] % _fm_tile_n
-                        lts = sStartEndRowIndices[col_local, 0] - m_block * self.tile_m 
-                        lte = sStartEndRowIndices[col_local, 1] - m_block * self.tile_m
+                        lts = sStartEndRowIndices[tScS_t2r[i][COL], 0] - m_block * self.tile_m 
+                        lte = sStartEndRowIndices[tScS_t2r[i][COL], 1] - m_block * self.tile_m
                         acc_S[i] = (
                             -cutlass.Float32.inf if tScS_t2r[i][ROW] >= lts and tScS_t2r[i][ROW] < lte else acc_S[i]
                         )

--- a/flashmask/flash_mask/cute/pipeline.py
+++ b/flashmask/flash_mask/cute/pipeline.py
@@ -1,38 +1,49 @@
 # Copyright (c) 2025, Tri Dao.
 
+# import math
 from typing import Optional
 from dataclasses import dataclass
 
+import cutlass
 import cutlass.cute as cute
 from cutlass import Boolean, Int32, const_expr
-from cutlass.cutlass_dsl import if_generate, dsl_user_op
-from cutlass.pipeline import PipelineState
-from cutlass.pipeline import PipelineUserType
-from cutlass.pipeline import NamedBarrier as NamedBarrierOg
-from cutlass.pipeline import PipelineAsync as PipelineAsyncOg
-from cutlass.pipeline import PipelineCpAsync as PipelineCpAsyncOg
+from cutlass.cutlass_dsl import if_generate
+from cutlass.pipeline import PipelineAsync, PipelineState, Agent, CooperativeGroup
+from cutlass.pipeline import PipelineUserType, PipelineOp
 from cutlass.pipeline import PipelineTmaAsync as PipelineTmaAsyncOg
 from cutlass.pipeline import PipelineTmaUmma as PipelineTmaUmmaOg
-from cutlass.pipeline import PipelineUmmaAsync as PipelineUmmaAsyncOg
-from cutlass.pipeline import PipelineAsyncUmma as PipelineAsyncUmmaOg
 
 
-def _override_create(parent_cls, child_cls):
-    """Create a static factory that constructs parent_cls then re-classes to child_cls."""
+# We deviate from cute-dsl implementation to use cute.arch.cluster_arrive_relaxed
+def pipeline_init_wait(cta_layout_vmnk: Optional[cute.Layout] = None):
+    """
+    Fences the mbarrier init and syncs the threadblock or cluster
+    """
+    cute.arch.mbarrier_init_fence()
 
-    @staticmethod
-    def create(*args, **kwargs):
-        obj = parent_cls.create(*args, **kwargs)
-        # Can't assign to __class__ directly since the dataclass is frozen
-        object.__setattr__(obj, "__class__", child_cls)
-        return obj
-
-    return create
+    if cta_layout_vmnk is None or cute.size(cta_layout_vmnk) == 1:
+        # If not using clusters, sync the threadblock
+        _sync(Agent.ThreadBlock)
+    else:
+        # If using clusters, sync the cluster
+        _sync(Agent.ThreadBlockCluster)
 
 
-def _make_state(index: Int32, phase: Int32) -> PipelineState:
-    """Construct a PipelineState from index and phase (count/stages unused by callers)."""
-    return PipelineState(stages=0, count=Int32(0), index=index, phase=phase)
+def _sync(group: Agent):
+    """
+    Syncs all threads within an agent.
+    """
+    if group is Agent.Thread:
+        raise NotImplementedError("Error: Not supported.")
+    elif group is Agent.ThreadBlock:
+        cute.arch.sync_threads()
+    elif group is Agent.ThreadBlockCluster:
+        cute.arch.cluster_arrive_relaxed()
+        cute.arch.cluster_wait()
+    else:
+        assert False, (
+            "Error: No explicit sync instruction exists. Please use barriers (named / mbarrier) instead."
+        )
 
 
 class PipelineStateSimple:
@@ -43,6 +54,9 @@ class PipelineStateSimple:
     """
 
     def __init__(self, stages: int, phase_index: Int32):
+        # assert stages < 2**16
+        # self._log_stages = int(math.log2(stages))
+        # assert 1 << self._log_stages == stages, "Number of stages must be a power of 2."
         self._stages = stages
         self._phase_index = phase_index
 
@@ -51,10 +65,13 @@ class PipelineStateSimple:
 
     @property
     def stages(self) -> int:
+        # return 1 << self._log_stages
         return self._stages
 
     @property
     def index(self) -> Int32:
+        # return self._phase_index & 0xFFFF
+        # return self._phase_index & ((1 << self._log_stages) - 1)
         if const_expr(self._stages == 1):
             return Int32(0)
         else:
@@ -62,8 +79,11 @@ class PipelineStateSimple:
 
     @property
     def phase(self) -> Int32:
+        # return self._phase_index >> 16
         # PTX docs say that the phase parity needs to be 0 or 1, so by right we need to
         # take modulo 2. But in practice just passing the phase in without modulo works fine.
+        # return (self._phase_index >> self._log_stages) % 2
+        # return self._phase_index >> self._log_stages
         if const_expr(self._stages == 1):
             return self._phase_index
         else:
@@ -74,6 +94,21 @@ class PipelineStateSimple:
             self._phase_index ^= 1
         else:
             self._phase_index += 1
+
+        # def then_body(phase_index):
+        #     # XOR the phase bit and set the index to 0
+        #     return (phase_index & 0xFFFF0000) ^ (1 << 16)
+
+        # def else_body(phase_index):
+        #     return phase_index
+
+        # self._phase_index = if_generate(
+        #     (self._phase_index & 0xFFFF) == self.stages,
+        #     then_body,
+        #     else_body,
+        #     [self._phase_index],
+        #     [Int32],
+        # )
 
     def __extract_mlir_values__(self):
         phase_index = self._phase_index
@@ -88,6 +123,7 @@ def make_pipeline_state(type: PipelineUserType, stages: int):
     Creates a pipeline state. Producers are assumed to start with an empty buffer and have a flipped phase bit of 1.
     """
     if type is PipelineUserType.Producer:
+        # return PipelineStateSimple(stages, Int32(1 << 16))
         return PipelineStateSimple(stages, Int32(stages))
     elif type is PipelineUserType.Consumer:
         return PipelineStateSimple(stages, Int32(0))
@@ -95,308 +131,237 @@ def make_pipeline_state(type: PipelineUserType, stages: int):
         assert False, "Error: invalid PipelineUserType specified for make_pipeline_state."
 
 
-# ── Shared helpers ───────────────────────────────────────────────────────────
-
-
-def _call_with_elect_one(parent_method, self, state, elect_one, syncwarp, loc, ip):
-    """Optionally wrap a parent pipeline method call in sync_warp + elect_one."""
-    if const_expr(elect_one):
-        if const_expr(syncwarp):
-            cute.arch.sync_warp()
-        with cute.arch.elect_one():
-            parent_method(self, state, loc=loc, ip=ip)
-    else:
-        parent_method(self, state, loc=loc, ip=ip)
-
-
-# ── Mixin: _w_index / _w_index_phase variants that delegate to parent ───────
-# Each parent class has PipelineState-based methods (producer_acquire, producer_commit,
-# consumer_wait, consumer_release). The _w_index_phase variants just construct a
-# PipelineState from (index, phase) and delegate.
-
-
-class _PipelineIndexPhaseMixin:
-    """Mixin providing _w_index_phase / _w_index methods that delegate to PipelineState-based parents."""
-
-    @dsl_user_op
-    def producer_acquire_w_index_phase(
-        self,
-        index: Int32,
-        phase: Int32,
-        try_acquire_token: Optional[Boolean] = None,
-        *,
-        loc=None,
-        ip=None,
-    ):
-        state = _make_state(index, phase)
-        # Call the parent's producer_acquire (which takes PipelineState)
-        self.producer_acquire(state, try_acquire_token, loc=loc, ip=ip)
-
-    @dsl_user_op
-    def producer_commit_w_index(self, index: Int32, *, loc=None, ip=None):
-        state = _make_state(index, Int32(0))
-        self.producer_commit(state, loc=loc, ip=ip)
-
-    @dsl_user_op
-    def consumer_wait_w_index_phase(
-        self,
-        index: Int32,
-        phase: Int32,
-        try_wait_token: Optional[Boolean] = None,
-        *,
-        loc=None,
-        ip=None,
-    ):
-        state = _make_state(index, phase)
-        self.consumer_wait(state, try_wait_token, loc=loc, ip=ip)
-
-    @dsl_user_op
-    def consumer_release_w_index(self, index: Int32, *, loc=None, ip=None):
-        state = _make_state(index, Int32(0))
-        self.consumer_release(state, loc=loc, ip=ip)
-
-
-# ── NamedBarrier ─────────────────────────────────────────────────────────────
-
-
 @dataclass(frozen=True)
-class NamedBarrier(NamedBarrierOg):
-    create = _override_create(NamedBarrierOg, None)  # patched below
-
-    @dsl_user_op
-    def arrive_w_index(self, index: Int32, *, loc=None, ip=None) -> None:
-        """
-        The aligned flavor of arrive is used when all threads in the CTA will execute the
-        same instruction. See PTX documentation.
-        """
-        cute.arch.barrier_arrive(
-            barrier_id=self.barrier_id + index,
-            number_of_threads=self.num_threads,
-            loc=loc,
-            ip=ip,
-        )
-
-    @dsl_user_op
-    def arrive_and_wait_w_index(self, index: Int32, *, loc=None, ip=None) -> None:
-        cute.arch.barrier(
-            barrier_id=self.barrier_id + index,
-            number_of_threads=self.num_threads,
-            loc=loc,
-            ip=ip,
-        )
-
-
-NamedBarrier.create = _override_create(NamedBarrierOg, NamedBarrier)
-
-
-# ── PipelineAsync ────────────────────────────────────────────────────────────
-
-
-@dataclass(frozen=True)
-class PipelineAsync(_PipelineIndexPhaseMixin, PipelineAsyncOg):
+class PipelineTmaAsync(PipelineTmaAsyncOg):
     """
-    PipelineAsync with optional elect_one for producer_commit and consumer_release.
+    If size(ClusterShape) == 1, PipelineTmaAsync has all threads
+    signaling the barrier during consumer_release. This causes a perf regression in FA3
+    forward pass (especially hdim 128 causal). We instead implement a version of
+    PipelineTmaAsync where only 1 out of 128 threads signals the barrier.
 
-    When elect_one_*=True (set at create time), only one elected thread per warp
-    signals the barrier arrive. This is useful when the mask count is set to 1 per warp.
-
-    Args (to create):
-        elect_one_commit: If True, only elected thread signals producer_commit.
-        syncwarp_before_commit: If True (default), issue syncwarp before elect_one.
-        elect_one_release: If True, only elected thread signals consumer_release.
-        syncwarp_before_release: If True (default), issue syncwarp before elect_one.
-            Set syncwarp to False when threads are already converged (e.g. after wgmma wait_group).
+    Assumptions:
+    (1) num_consumers % NumThreadsPerWarpGroup == 0
+    (2) all 128 threads in the warp group are sync'ed right before calling consumer_release
     """
-
-    _elect_one_commit: bool = False
-    _syncwarp_before_commit: bool = True
-    _elect_one_release: bool = False
-    _syncwarp_before_release: bool = True
 
     @staticmethod
     def create(
-        *args,
-        elect_one_commit: bool = False,
-        syncwarp_before_commit: bool = True,
-        elect_one_release: bool = False,
-        syncwarp_before_release: bool = True,
-        **kwargs,
+        *,
+        num_stages: int,
+        producer_group: CooperativeGroup,
+        consumer_group: CooperativeGroup,
+        tx_count: int,
+        barrier_storage: cute.Pointer = None,
+        cta_layout_vmnk: Optional[cute.Layout] = None,
+        tidx: Optional[Int32] = None,
+        mcast_mode_mn: tuple[int, int] = (1, 1),
+        init_wait: cutlass.Constexpr[bool] = True,
     ):
-        obj = PipelineAsyncOg.create(*args, **kwargs)
-        object.__setattr__(obj, "__class__", PipelineAsync)
-        object.__setattr__(obj, "_elect_one_commit", elect_one_commit)
-        object.__setattr__(obj, "_syncwarp_before_commit", syncwarp_before_commit)
-        object.__setattr__(obj, "_elect_one_release", elect_one_release)
-        object.__setattr__(obj, "_syncwarp_before_release", syncwarp_before_release)
-        return obj
+        """
+        This helper function computes any necessary attributes and returns an instance of PipelineTmaAsync.
+        :param barrier_storage: Pointer to the smem address for this pipeline's mbarriers
+        :type barrier_storage: cute.Pointer
+        :param num_stages: Number of buffer stages for this pipeline
+        :type num_stages: Int32
+        :param producer_group: `CooperativeGroup` for the producer agent
+        :type producer_group: CooperativeGroup
+        :param consumer_group: `CooperativeGroup` for the consumer agent
+        :type consumer_group: CooperativeGroup
+        :param tx_count: Number of bytes expected to be written to the transaction barrier for one stage
+        :type tx_count: int
+        :param cta_layout_vmnk: Layout of the cluster shape
+        :type cta_layout_vmnk: cute.Layout | None
+        :param tidx: thread index to consumer async threads
+        :type tidx: Int32 | None
+        :param mcast_mode_mn: Tuple of two integers, specifying whether mcast is enabled for the m and n modes. At least one of the two integers must be 1.
+        :type mcast_mode_mn: tuple[int, int]
+        """
+        if not isinstance(barrier_storage, cute.Pointer):
+            raise ValueError(
+                f"Expected barrier_storage to be a cute.Pointer, but got {type(barrier_storage)}"
+            )
 
-    @dsl_user_op
-    def producer_commit(self, state: PipelineState, *, loc=None, ip=None):
-        _call_with_elect_one(
-            PipelineAsyncOg.producer_commit,
-            self,
-            state,
-            self._elect_one_commit,
-            self._syncwarp_before_commit,
-            loc,
-            ip,
+        producer_type = PipelineOp.TmaLoad
+        consumer_type = PipelineOp.AsyncThread
+
+        producer = (producer_type, producer_group)
+        consumer = (consumer_type, consumer_group)
+
+        sync_object_full = PipelineAsync._make_sync_object(
+            barrier_storage.align(min_align=8), num_stages, producer, tx_count
+        )
+        sync_object_empty = PipelineAsync._make_sync_object(
+            barrier_storage.align(min_align=8) + num_stages, num_stages, consumer
+        )
+        if tidx is None:
+            tidx, _, _ = cute.arch.thread_idx()
+        if cta_layout_vmnk is None:
+            cta_layout_vmnk = cute.make_layout((1, 1, 1, 1))
+        if const_expr(cta_layout_vmnk is None or cute.size(cta_layout_vmnk) == 1):
+            dst_rank = None
+            is_signalling_thread = tidx % 128 == 0
+        else:
+            (
+                dst_rank,
+                is_signalling_thread,
+            ) = PipelineTmaAsync.init_empty_barrier_arrive_signal(
+                cta_layout_vmnk, tidx, mcast_mode_mn
+            )
+
+        producer_mask = None
+
+        if const_expr(init_wait):
+            pipeline_init_wait()
+
+        return PipelineTmaAsync(
+            sync_object_full,
+            sync_object_empty,
+            num_stages,
+            producer_mask,
+            dst_rank,
+            is_signalling_thread,
         )
 
-    @dsl_user_op
-    def consumer_release(self, state: PipelineState, *, loc=None, ip=None):
-        _call_with_elect_one(
-            PipelineAsyncOg.consumer_release,
-            self,
-            state,
-            self._elect_one_release,
-            self._syncwarp_before_release,
-            loc,
-            ip,
-        )
-
-    # _w_index variants inherited from _PipelineIndexPhaseMixin, which delegate
-    # to producer_commit / consumer_release above.
-
-
-# ── PipelineCpAsync ──────────────────────────────────────────────────────────
-
-
-@dataclass(frozen=True)
-class PipelineCpAsync(_PipelineIndexPhaseMixin, PipelineCpAsyncOg):
-    _elect_one_release: bool = False
-    _syncwarp_before_release: bool = True
-
-    @staticmethod
-    def create(
-        *args,
-        elect_one_release: bool = False,
-        syncwarp_before_release: bool = True,
-        **kwargs,
-    ):
-        obj = PipelineCpAsyncOg.create(*args, **kwargs)
-        object.__setattr__(obj, "__class__", PipelineCpAsync)
-        object.__setattr__(obj, "_elect_one_release", elect_one_release)
-        object.__setattr__(obj, "_syncwarp_before_release", syncwarp_before_release)
-        return obj
-
-    @dsl_user_op
-    def consumer_release(self, state: PipelineState, *, loc=None, ip=None):
-        _call_with_elect_one(
-            PipelineCpAsyncOg.consumer_release,
-            self,
-            state,
-            self._elect_one_release,
-            self._syncwarp_before_release,
-            loc,
-            ip,
-        )
-
-    # _w_index variants inherited from _PipelineIndexPhaseMixin.
-
-
-# ── PipelineTmaAsync ────────────────────────────────────────────────────────
-
-
-@dataclass(frozen=True)
-class PipelineTmaAsync(_PipelineIndexPhaseMixin, PipelineTmaAsyncOg):
-    """Override producer_acquire to take in extra_tx_count parameter."""
-
-    @dsl_user_op
     def producer_acquire(
         self,
         state: PipelineState,
         try_acquire_token: Optional[Boolean] = None,
         extra_tx_count: int = 0,
-        *,
-        loc=None,
-        ip=None,
+        **kwargs,
     ):
         """
         TMA producer commit conditionally waits on buffer empty and sets the transaction barrier for leader threadblocks.
         """
         if_generate(
             try_acquire_token is None or try_acquire_token == 0,
-            lambda: self.sync_object_empty.wait(state.index, state.phase, loc=loc, ip=ip),
-            loc=loc,
-            ip=ip,
+            lambda: self.sync_object_empty.wait(state.index, state.phase),
         )
         if const_expr(extra_tx_count == 0):
-            self.sync_object_full.arrive(state.index, self.producer_mask, loc=loc, ip=ip)
+            self.sync_object_full.arrive(state.index, self.producer_mask)
         else:
             tx_count = self.sync_object_full.tx_count + extra_tx_count
-            self.sync_object_full.arrive_and_expect_tx(state.index, tx_count, loc=loc, ip=ip)
+            self.sync_object_full.arrive_and_expect_tx(state.index, tx_count)
 
-
-PipelineTmaAsync.create = _override_create(PipelineTmaAsyncOg, PipelineTmaAsync)
-
-
-# ── PipelineTmaUmma ─────────────────────────────────────────────────────────
+    def consumer_release(self, state: PipelineState, **kwargs):
+        """
+        TMA consumer release conditionally signals the empty buffer to the producer.
+        """
+        # Only 1 thread per warp group signals the empty buffer.
+        if self.consumer_mask is None:  # No cluster, 1 thread per warp group to signal
+            if_generate(
+                cute.arch.thread_idx()[0] % 128 == 0,
+                lambda: self.sync_object_empty.arrive(state.index, self.consumer_mask),
+            )
+        else:
+            if_generate(
+                self.is_signalling_thread,
+                lambda: self.sync_object_empty.arrive(state.index, self.consumer_mask),
+            )
 
 
 @dataclass(frozen=True)
-class PipelineTmaUmma(_PipelineIndexPhaseMixin, PipelineTmaUmmaOg):
-    """Override producer_acquire to take in extra_tx_count parameter."""
+class PipelineTmaUmma(PipelineTmaUmmaOg):
+    @staticmethod
+    def create(
+        *,
+        num_stages: int,
+        producer_group: CooperativeGroup,
+        consumer_group: CooperativeGroup,
+        tx_count: int,
+        barrier_storage: cute.Pointer = None,
+        cta_layout_vmnk: Optional[cute.Layout] = None,
+        mcast_mode_mn: tuple[int, int] = (1, 1),
+        init_wait: cutlass.Constexpr[bool] = True,
+    ):
+        """
+        This helper function computes any necessary attributes and returns an instance of PipelineTmaUmma.
+        :param barrier_storage: Pointer to the smem address for this pipeline's mbarriers
+        :type barrier_storage: cute.Pointer
+        :param num_stages: Number of buffer stages for this pipeline
+        :type num_stages: Int32
+        :param producer_group: `CooperativeGroup` for the producer agent
+        :type producer_group: CooperativeGroup
+        :param consumer_group: `CooperativeGroup` for the consumer agent
+        :type consumer_group: CooperativeGroup
+        :param tx_count: Number of bytes expected to be written to the transaction barrier for one stage
+        :type tx_count: int
+        :param cta_layout_vmnk: Layout of the cluster shape
+        :type cta_layout_vmnk: cute.Layout | None
+        :param mcast_mode_mn: Tuple of two integers, specifying whether mcast is enabled for the m and n modes. At least one of the two integers must be 1.
+        :type mcast_mode_mn: tuple[int, int]
+        """
+        if not isinstance(barrier_storage, cute.Pointer):
+            raise ValueError(
+                f"Expected barrier_storage to be a cute.Pointer, but got {type(barrier_storage)}"
+            )
 
-    @dsl_user_op
+        producer_type = PipelineOp.TmaLoad
+        consumer_type = PipelineOp.TCGen05Mma
+
+        producer = (producer_type, producer_group)
+        consumer = (consumer_type, consumer_group)
+
+        sync_object_full = PipelineTmaUmmaOg._make_sync_object(
+            barrier_storage.align(min_align=8), num_stages, producer, tx_count
+        )
+        sync_object_empty = PipelineTmaUmmaOg._make_sync_object(
+            barrier_storage.align(min_align=8) + num_stages, num_stages, consumer
+        )
+
+        if cta_layout_vmnk is None or cute.size(cta_layout_vmnk) == 1:
+            # No mcast mask if not using clusters
+            producer_mask = None
+            # All threadblocks are leaders if not using clusters
+            is_leader_cta = True
+        else:
+            producer_mask = PipelineTmaUmma._compute_mcast_arrival_mask(
+                cta_layout_vmnk, mcast_mode_mn
+            )
+            is_leader_cta = PipelineTmaUmma._compute_is_leader_cta(cta_layout_vmnk)
+
+        cta_group = (
+            cute.nvgpu.tcgen05.CtaGroup.ONE
+            if cta_layout_vmnk is None or cute.size(cta_layout_vmnk, mode=[0]) == 1
+            else cute.nvgpu.tcgen05.CtaGroup.TWO
+        )
+
+        consumer_mask = producer_mask
+
+        if const_expr(init_wait):
+            pipeline_init_wait(cta_layout_vmnk)
+
+        return PipelineTmaUmma(
+            sync_object_full,
+            sync_object_empty,
+            num_stages,
+            producer_mask,
+            consumer_mask,
+            is_leader_cta,
+            cta_group,
+        )
+
     def producer_acquire(
         self,
         state: PipelineState,
         try_acquire_token: Optional[Boolean] = None,
         extra_tx_count: int = 0,
-        *,
-        loc=None,
-        ip=None,
+        **kwargs,
     ):
         """
         TMA producer commit conditionally waits on buffer empty and sets the transaction barrier for leader threadblocks.
         """
         if_generate(
             try_acquire_token is None or try_acquire_token == 0,
-            lambda: self.sync_object_empty.wait(state.index, state.phase, loc=loc, ip=ip),
-            loc=loc,
-            ip=ip,
+            lambda: self.sync_object_empty.wait(state.index, state.phase),
         )
         if const_expr(extra_tx_count == 0):
             if_generate(
                 self.is_leader_cta,
-                lambda: self.sync_object_full.arrive(
-                    state.index, self.producer_mask, loc=loc, ip=ip
-                ),
-                loc=loc,
-                ip=ip,
+                lambda: self.sync_object_full.arrive(state.index, self.producer_mask),
             )
         else:
             tx_count = self.sync_object_full.tx_count + extra_tx_count
             if_generate(
                 self.is_leader_cta,
-                lambda: self.sync_object_full.arrive_and_expect_tx(
-                    state.index, tx_count, loc=loc, ip=ip
-                ),
-                loc=loc,
-                ip=ip,
+                lambda: self.sync_object_full.arrive_and_expect_tx(state.index, tx_count),
             )
-
-
-PipelineTmaUmma.create = _override_create(PipelineTmaUmmaOg, PipelineTmaUmma)
-
-
-# ── PipelineUmmaAsync ───────────────────────────────────────────────────────
-
-
-@dataclass(frozen=True)
-class PipelineUmmaAsync(_PipelineIndexPhaseMixin, PipelineUmmaAsyncOg):
-    pass
-
-
-PipelineUmmaAsync.create = _override_create(PipelineUmmaAsyncOg, PipelineUmmaAsync)
-
-
-# ── PipelineAsyncUmma ───────────────────────────────────────────────────────
-
-
-@dataclass(frozen=True)
-class PipelineAsyncUmma(_PipelineIndexPhaseMixin, PipelineAsyncUmmaOg):
-    pass
-
-
-PipelineAsyncUmma.create = _override_create(PipelineAsyncUmmaOg, PipelineAsyncUmma)


### PR DESCRIPTION
This reverts commit 781035e201b52258ac3d1e948372ce02aa46bb98. (PR https://github.com/PaddlePaddle/flash-attention/pull/125)

commit 781035e201b52258ac3d1e948372ce02aa46bb98 cause hang of `test_bwd_md5sum.py::test_flashmask_bwd_md5[causal-gen_startend_row_indices1-1-8192-33792-2-1-1_0-128-128-4-dtype0]`

FlashMask v4's support of `d/dv: 192, 128` will be not available after this revert.