### PR TITLE
[optim] support skip_empty_tile

### DIFF
--- a/csrc/flashmask_v2/flash_bwd_kernel_sm90.h
+++ b/csrc/flashmask_v2/flash_bwd_kernel_sm90.h
@@ -214,6 +214,7 @@ public:
         CollectiveEpilogue epilogue;
         __shared__ __align__(16) int32_t flashmask_smem_[8];
         __shared__ __align__(128) int32_t flashmask_index_smem_[kBlockN * 4];
+        __shared__ __align__(128) int32_t empty_tile[1];
         constexpr int max_seqlen_k = 1024 * 128;
         static constexpr bool Is_blockmask = CollectiveMainloop_::Is_blockmask;
         int32_t* blockmask_smem_ = nullptr;
@@ -255,13 +256,19 @@ public:
                  work_tile_info.is_valid(params.scheduler);
                  work_tile_info = scheduler.template get_next_work</*IsProducerWarp=*/true>(params.scheduler, work_tile_info)
             ) {
+                scheduler.producer_notify();
                 auto block_coord_ = work_tile_info.get_block_coord(params.scheduler);
                 auto [n_block, bidh, bidb] = block_coord_;
                 cute::tuple<int32_t, int32_t, int32_t> block_coord = {n_block, bidh, bidb};
-                mainloop.load_n_block_info(flashmask_smem_, flashmask_index_smem_, blockmask_smem_, block_coord, params.mainloop);
-                scheduler.producer_notify();
+                mainloop.load_n_block_info(flashmask_smem_, flashmask_index_smem_, blockmask_smem_, empty_tile, block_coord, params.mainloop);
+                if (empty_tile[0]) {
+                    if (warp_idx_in_warpgroup == 1) {
+                        mainloop.store_dq_empty_tile(params.mainloop, block_coord);
+                    }
+                    scheduler.prefetch_next_work(params.scheduler, work_tile_info);
+                    continue;
+                }
                 if (warp_idx_in_warpgroup == 0) {  // Load K, V, and do TMA on Q and dO
-                    
                     // auto block_coord_ = work_tile_info.get_block_coord(params.scheduler);
                     // auto [n_block, bidh, bidb] = block_coord_;
                     // cute::tuple<int32_t, int32_t, int32_t> block_coord = {n_block, bidh, bidb};
@@ -307,6 +314,12 @@ public:
                 auto block_coord_ = work_tile_info.get_block_coord(params.scheduler);
                 auto [n_block, bidh, bidb] = block_coord_;
                 cute::tuple<int32_t, int32_t, int32_t> block_coord = {n_block, bidh, bidb};
+                cutlass::arch::NamedBarrier::sync(CollectiveMainloop::NumMmaThreads + cutlass::NumThreadsPerWarp * 4, static_cast<uint32_t>(BwdNamedBarriers::FlashmaskProducer) /*id*/);
+                if (empty_tile[0]) {
+                    scheduler.consumer_notify();
+                    epilogue.store_zero(params.epilogue, threadIdx.x - NumCopyThreads, block_coord);
+                    continue;
+                }
                 
                 bool tile_valid = mainloop.mma(
                     params.mainloop, pipeline_q, pipeline_do, smem_pipe_read, smem_pipe_read_do,

--- a/csrc/flashmask_v2/mainloop_bwd_sm90_tma_gmma_ws.hpp
+++ b/csrc/flashmask_v2/mainloop_bwd_sm90_tma_gmma_ws.hpp
@@ -513,7 +513,8 @@ struct CollectiveMainloopBwdSm90 {
 
 
     CUTLASS_DEVICE
-    void load_n_block_info( int32_t *  fm_mem, int32_t * flashmask_index_smem_, int32_t* blockmask_smem_, cute::tuple<int32_t, int32_t, int32_t> block_coord, Params const& params){
+    void load_n_block_info( int32_t *  fm_mem, int32_t * flashmask_index_smem_, int32_t* blockmask_smem_, int32_t* empty_tile, cute::tuple<int32_t, int32_t, int32_t> block_coord, Params const& params){
+
         auto [n_block, bidh, bidb] = block_coord;
         int const seqlen_k = get<0>(params.shape_K);
         int const seqlen_q = get<0>(params.shape_Q);
@@ -550,6 +551,15 @@ struct CollectiveMainloopBwdSm90 {
                 fm_mem[6] = (params.ut_end_nblockmax[bh_offset_block + n_block] - 1) / kBlockM;
                 fm_mem[7] = params.ut_end_nblockmin[bh_offset_block + n_block] / kBlockM;
             }
+
+            if constexpr (!Is_causal and !Has_ut_start) {
+                *empty_tile = params.ut_end_nblockmin[bh_offset_block + n_block] >= params.lt_start_nblockmin[bh_offset_block + n_block] &&
+                              params.lt_start_nblockmax[bh_offset_block + n_block] == params.lt_start_nblockmin[bh_offset_block + n_block] &&
+                              params.ut_end_nblockmax[bh_offset_block + n_block] == params.ut_end_nblockmin[bh_offset_block + n_block];
+            } else {
+                *empty_tile = false;
+            }
+
             // if(bidb ==1 and bidh == 0) printf("params.ut_end_nblockmax: %d, params.ut_end_nblockmin: %d ,n_block: %d\n", fm_mem[6], fm_mem[7], n_block);
             // printf("bidh: %d, bidb: %d, n_block: %d\n", bidh, bidb, n_block);
             // printf("params.h_flashmask: %d, params.h_h_flashmask_ratio: %d,get<0>(params.shape_Q): %d", params.h_flashmask, params.h_h_flashmask_ratio, get<0>(params.shape_Q));
@@ -591,7 +601,7 @@ struct CollectiveMainloopBwdSm90 {
         }
         // if(thread_idx < kBlockN) if(bidb ==1 and bidh == 0) printf("threadidx: %d,bidb: %d,bidh: %d,n_block: %d, row_offset: %d, ut_end_flashmask_index_smem_%d: %d\n", thread_idx,bidb,bidh,n_block,thread_idx + row_offset-seqlen,thread_idx,flashmask_index_smem_[thread_idx + 3 * kBlockN]);
             // if(bidb ==0 and (bidh == 0 or bidh == 2) and n_block * kBlockN + i < seqlen and params.ut_end_ptr != nullptr) printf("threadidx: %d,bidb: %d,bidh: %d,n_block: %d, row_offset: %d, ut_end_flashmask_index_smem_%d: %d, params.ut_end_ptr_val: %d, params.ut_end_ptr_ptr: %p\n", thread_idx,bidb,bidh,n_block,row_offset,i,flashmask_index_smem_[i + 3 * kBlockN],params.ut_end_ptr[i + row_offset],params.ut_end_ptr + i + row_offset);
-        cutlass::arch::NamedBarrier::sync(cutlass::NumThreadsPerWarp * 4, static_cast<uint32_t>(BwdNamedBarriers::FlashmaskProducer) /*id*/);
+        cutlass::arch::NamedBarrier::sync(NumMmaThreads + cutlass::NumThreadsPerWarp * 4, static_cast<uint32_t>(BwdNamedBarriers::FlashmaskProducer) /*id*/);
     }
 
     template <typename SharedStorage>
@@ -988,6 +998,30 @@ struct CollectiveMainloopBwdSm90 {
                 /* Do Nothing, just wait */
 				Barrier::arrive_inc(lock_ptr, threadIdx.x % cutlass::NumThreadsPerWarp, m_block * num_batch * num_head);
             }
+        }
+    }
+
+    CUTLASS_DEVICE void
+    store_dq_empty_tile(Params const& params, cute::tuple<int32_t, int32_t, int32_t> block_coord) {
+        if constexpr (!Deterministic || !dQacc_use_TMA) { return; }
+
+        auto [n_block, bidh, bidb] = block_coord;
+        SeqlenInfo_t seqlen_info{
+            bidb, get<0>(params.shape_Q), size<0>(params.shape_K),
+            params.cu_seqlens_q, params.cu_seqlens_k, params.seqused_q, params.seqused_k
+        };
+
+        int const num_batch = params.num_batch;
+        int const num_head = get<2>(params.shape_Q);
+        int *lock_ptr = params.dq_semaphore + bidb * num_head + bidh;
+        using Barrier = cutlass::GenericBarrier<cutlass::detail::SyncwarpSync>;
+        static constexpr int kBlockM = get<0>(TileShape_MNK{});
+
+        int const m_block_global_max = cute::ceil_div(seqlen_info.seqlen_q, kBlockM);
+        for (int m_block = 0; m_block < m_block_global_max; m_block++) {
+            Barrier::wait_eq(lock_ptr, threadIdx.x % cutlass::NumThreadsPerWarp, m_block * num_batch * num_head, n_block);
+            /* Do Nothing, just wait */
+            Barrier::arrive_inc(lock_ptr, threadIdx.x % cutlass::NumThreadsPerWarp, m_block * num_batch * num_head);
         }
     }
 


### PR DESCRIPTION
### 性能优化 
@umiswing 增加了empty_tile时跳过Producer/Consumer 的计算/存储逻辑。
### Deterministic适配empty_tile的优化。
- 新增 store_dq_empty_tile 函数，什么都不做，只是更新信号量，避免hang。 