### PR TITLE
Bump nvidia-cutlass-dsl upper bound to 4.4.2

### DIFF
--- a/flashmask/setup.py
+++ b/flashmask/setup.py
@@ -141,7 +141,7 @@ if BUILD_FLA:
 if BUILD_FA4:
     install_requires += [
         'nvidia-cutlass==4.2.0.0',
-        'nvidia-cutlass-dsl==4.4.1',
+        'nvidia-cutlass-dsl>=4.4.1,<=4.4.2',
         "apache-tvm-ffi >= 0.1.5, < 0.2.0",
     ]
 


### PR DESCRIPTION
Bump nvidia-cutlass-dsl upper bound to 4.4.2
