### PR TITLE
Exclude flash_mask.cp_balance when BUILD_CPB is off

### DIFF
--- a/flashmask/setup.py
+++ b/flashmask/setup.py
@@ -136,6 +136,11 @@ if not BUILD_FLA:
         'flash_mask.linear_attn',
         'flash_mask.linear_attn.*',
     ]
+if not BUILD_CPB:
+    exclude_packages += [
+        "flash_mask.cp_balance",
+        "flash_mask.cp_balance.*",
+    ]
 
 packages = find_packages(exclude=exclude_packages)
 


### PR DESCRIPTION
FLASHMASK_BUILD 不带 cpb 时，确保 site-packages 下无 cp_balance 目录